### PR TITLE
fix(ui): align sidebar header icons to w-5 h-5 to match nav icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.4] — 2026-03-24
+
+### Fixed
+- **Sidebar header icon size.** Gear (settings) and cloud (sync) icons were 16px (`w-4 h-4`) while all sidebar nav icons are 20px (`w-5 h-5`). All four icon states (gear, spinning ring, cloud+check, cloud at rest) are now consistently `w-5 h-5`.
+
+---
+
 ## [0.7.3] — 2026-03-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1090,4 +1090,4 @@ npm run lint:fix           # Fix auto-fixable issues
 
 ---
 
-*Last Updated: March 2026 — v0.7.3*
+*Last Updated: March 2026 — v0.7.4*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moodbloom",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A calm, secure mood tracking and journaling app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moodbloom"
-version = "0.7.3"
+version = "0.7.4"
 description = "A calm, secure mood tracking and journaling app"
 authors = ["MoodBloom"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MoodBloom",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "com.moodbloom.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -85,7 +85,7 @@ export function Sidebar({ currentView, onNavigate, onOpenSync, onNavigateToJourn
               : 'text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
           }`}
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z" />
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
@@ -109,13 +109,13 @@ export function Sidebar({ currentView, onNavigate, onOpenSync, onNavigateToJourn
         >
             {savingState === 'saving' ? (
             /* Spinning ring while saving */
-            <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+            <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
             </svg>
           ) : savingState === 'saved' ? (
             /* Cloud + checkmark — pops in when saved */
-            <svg className="w-4 h-4 animate-cloud-saved" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <svg className="w-5 h-5 animate-cloud-saved" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               {/* Cloud body */}
               <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z" />
               {/* Checkmark inside cloud */}
@@ -123,7 +123,7 @@ export function Sidebar({ currentView, onNavigate, onOpenSync, onNavigateToJourn
             </svg>
           ) : (
             /* Cloud icon at rest */
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z" />
             </svg>
           )}


### PR DESCRIPTION
## Summary
- Gear (settings) and cloud (sync) icons in the sidebar header were 16px (`w-4 h-4`) while all nav icons below are 20px (`w-5 h-5`) via the `SidebarItem` wrapper span — a 4px visual incongruency
- All four icon states bumped to `w-5 h-5`: gear, spinning ring (saving), cloud+checkmark (saved), cloud at rest

## Test Coverage
No new code paths — pure CSS class changes. All 450 existing tests pass.

## Pre-Landing Review
No issues found. (Eng Review CLEAR — commit 9fd03fc)

## Design Review
Design Review (lite): No issues found. Change IS the design fix.

## Eval Results
No prompt-related files changed — evals skipped.

## Greptile Review
No Greptile comments.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] All Vitest tests pass (450 tests, 23 files)
- [ ] Visual verification: sidebar header icons visually match nav icon size

🤖 Generated with [Claude Code](https://claude.com/claude-code)