### PR TITLE
perf: tiered Insights loading, WAL mode, PBKDF2 session key cache (v0.7.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.10] — 2026-03-28
+
+### Added
+- **SQLite WAL mode + cache pragmas.** `PRAGMA journal_mode = WAL`, `cache_size = -8000` (8 MB), and `synchronous = NORMAL` applied at startup. WAL mode enables concurrent reads during writes; 8 MB page cache reduces repeated I/O on analytics queries.
+- **`get_full_analytics_bundle` command.** Replaces five parallel `invoke()` calls from the Insights page with a single Rust command that acquires the DB mutex once and returns all analytics data (overall stats, streaks, mood distribution, day-of-week stats, 30-day trend) in one round trip.
+- **`get_insights_metadata` command.** New lightweight command that reads entry counts, weekly totals, and top tags from plaintext columns — no decryption required. Used by Tier A loading in the Insights page to show stats immediately before the decrypt phase completes.
+- **`mood_daily_stats` cache table.** SQLite trigger-maintained cache of `(date, average_mood, entry_count)`. Calendar view now reads from this index rather than running a full table scan with `strftime()` grouping. Includes automatic backfill for historical data on first access.
+- **`idx_entries_book_id` index.** Runtime migration adds an index on `journal_entries(book_id)` to accelerate timeline filtering by journal.
+- **WAL checkpoint before export.** `PRAGMA wal_checkpoint(FULL)` is called before `export_data` to flush pending WAL frames into the main DB file so the export captures a complete snapshot.
+
+### Changed
+- **Insights page tiered loading.** Tier A (metadata, no decrypt) renders the stats grid immediately. Tier B (30-day decrypt) fills in mood and streak cards with a skeleton placeholder until ready. Gratitude streak uses a `localStorage` cache keyed on entry count + last entry date to skip `getAllEntries()` on repeat visits when nothing has changed.
+- **`useInsights` dep array tightened.** Hook now subscribes only to `settings.ai` rather than the full `settings` object, preventing non-AI settings changes (theme, privacy mode, etc.) from triggering a full Insights reload.
+- **`aggregateMetadataBoth` replaces two `aggregateMetadata` calls.** Single convenience wrapper returns both `localMeta` and `aiMeta` in one call, replacing the previous pattern of calling `aggregateMetadata` twice per load.
+
+### Fixed
+- **Streak cache invalidation on delete-and-re-add.** The gratitude streak cache is now keyed on both total entry count and last entry date, preventing stale streak display when a user deletes N entries and adds N new ones in the same session (previously the count-only key would incorrectly hit the old cache).
+- **Insights stats grid on IPC error.** `isMetadataReady` is now set to `true` in the error path so the stats grid renders with zero values rather than staying hidden indefinitely when `get_insights_metadata` fails.
+
+---
+
 ## [0.7.9] — 2026-03-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moodhaven-journal",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A calm, secure mood tracking and journaling app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "moodhaven-journal"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "moodhaven-journal"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moodhaven-journal"
-version = "0.7.9"
+version = "0.7.10"
 description = "A calm, secure mood tracking and journaling app"
 authors = ["Moodbloom"]
 license = "MIT"

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -2,7 +2,10 @@
 //!
 //! Commands for calendar view and analytics dashboard features.
 
-use crate::db::{self, CalendarDayData, Database, DayOfWeekStats, MoodDistribution, StreakStats};
+use crate::db::{
+    self, CalendarDayData, Database, DayOfWeekStats, FullAnalyticsBundle, InsightsMetadata,
+    MoodDistribution, StreakStats,
+};
 use tauri::State;
 
 /// Get mood distribution (count per mood level 1-5)
@@ -36,4 +39,19 @@ pub fn get_monthly_mood_data(
     }
 
     db::get_monthly_mood_data(&db, year, month)
+}
+
+/// Get all analytics data in a single DB session (replaces 5 parallel IPC calls)
+#[tauri::command]
+pub fn get_full_analytics_bundle(
+    db: State<Database>,
+    trend_days: i64,
+) -> Result<FullAnalyticsBundle, String> {
+    db::get_full_analytics_bundle(&db, trend_days)
+}
+
+/// Get lightweight insights metadata (no decryption required)
+#[tauri::command]
+pub fn get_insights_metadata(db: State<Database>) -> Result<InsightsMetadata, String> {
+    db::get_insights_metadata(&db)
 }

--- a/src-tauri/src/commands/data_management.rs
+++ b/src-tauri/src/commands/data_management.rs
@@ -140,6 +140,12 @@ pub async fn factory_reset(app: AppHandle) -> Result<bool, String> {
 pub async fn export_data(app: AppHandle, _password: String) -> Result<String, String> {
     let db = app.state::<Database>();
 
+    // Flush any pending WAL frames before reading, so the export is consistent
+    {
+        let conn = db.conn.lock().map_err(|e| e.to_string())?;
+        let _ = conn.execute_batch("PRAGMA wal_checkpoint(FULL)");
+    }
+
     // Get all journal entries
     let entries = db::get_all_entries(&db, None)?;
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -95,6 +95,25 @@ pub struct DayOfWeekStats {
     pub entry_count: i32,
 }
 
+/// Bundled analytics response — all analytics data in one DB session
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FullAnalyticsBundle {
+    pub average_mood: f64,
+    pub total_entries: i32,
+    pub streak_stats: StreakStats,
+    pub mood_distribution: Vec<MoodDistribution>,
+    pub day_of_week_stats: Vec<DayOfWeekStats>,
+    pub trend_data: Vec<DailyStats>,
+}
+
+/// Insights metadata — lightweight all-time stats that don't require decryption
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsightsMetadata {
+    pub entries_this_week: i32,
+    pub total_entries: i32,
+    pub top_tags: Vec<String>,
+}
+
 /// Calendar day data for monthly view
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CalendarDayData {
@@ -189,6 +208,14 @@ impl Database {
         // Enable foreign keys
         conn.execute("PRAGMA foreign_keys = ON", [])
             .map_err(|e| format!("Failed to enable foreign keys: {}", e))?;
+
+        // Performance pragmas (safe on every startup)
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA cache_size = -8000;
+             PRAGMA synchronous = NORMAL;",
+        )
+        .map_err(|e| format!("Failed to set performance pragmas: {}", e))?;
 
         // Run migrations
         conn.execute_batch(include_str!("schema.sql"))
@@ -448,6 +475,12 @@ impl Database {
             );",
         )
         .map_err(|e| format!("Failed to create peer_sync_state table: {}", e))?;
+
+        // Runtime migration: index for book_id filtering on timeline view
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_entries_book_id ON journal_entries(book_id)",
+            [],
+        );
 
         Ok(Self {
             conn: Mutex::new(conn),
@@ -1023,6 +1056,237 @@ pub fn get_day_of_week_stats(db: &Database) -> Result<Vec<DayOfWeekStats>, Strin
     Ok(stats)
 }
 
+/// Get all analytics data in a single DB session (one mutex acquisition)
+pub fn get_full_analytics_bundle(
+    db: &Database,
+    trend_days: i64,
+) -> Result<FullAnalyticsBundle, String> {
+    let conn = db.conn.lock().map_err(|e| e.to_string())?;
+
+    // Overall stats
+    let (average_mood, total_entries) = conn
+        .query_row(
+            "SELECT COALESCE(AVG(mood), 0), COUNT(*) FROM journal_entries",
+            [],
+            |row| Ok((row.get::<_, f64>(0)?, row.get::<_, i32>(1)?)),
+        )
+        .map_err(|e| format!("Overall stats query failed: {}", e))?;
+
+    // Streak stats
+    let mut date_stmt = conn
+        .prepare(
+            "SELECT DISTINCT date(created_at) as entry_date
+             FROM journal_entries
+             ORDER BY entry_date DESC",
+        )
+        .map_err(|e| format!("Streak prepare failed: {}", e))?;
+
+    let dates: Vec<String> = date_stmt
+        .query_map([], |row| row.get(0))
+        .map_err(|e| format!("Streak query failed: {}", e))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let streak_stats = compute_streak_stats(dates);
+
+    // Mood distribution
+    let mut dist_stmt = conn
+        .prepare(
+            "SELECT mood, COUNT(*) as count FROM journal_entries GROUP BY mood ORDER BY mood",
+        )
+        .map_err(|e| format!("Distribution prepare failed: {}", e))?;
+
+    let mood_distribution = dist_stmt
+        .query_map([], |row| {
+            Ok(MoodDistribution {
+                mood: row.get(0)?,
+                count: row.get(1)?,
+            })
+        })
+        .map_err(|e| format!("Distribution query failed: {}", e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Distribution row parsing failed: {}", e))?;
+
+    // Day of week stats
+    let day_names = [
+        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+    ];
+    let mut dow_stmt = conn
+        .prepare(
+            "SELECT CAST(strftime('%w', created_at) AS INTEGER) as dow,
+                    AVG(mood) as avg_mood, COUNT(*) as count
+             FROM journal_entries GROUP BY dow ORDER BY dow",
+        )
+        .map_err(|e| format!("DOW prepare failed: {}", e))?;
+
+    let day_of_week_stats = dow_stmt
+        .query_map([], |row| {
+            let dow: i32 = row.get(0)?;
+            Ok(DayOfWeekStats {
+                day_of_week: dow,
+                day_name: day_names.get(dow as usize).unwrap_or(&"Unknown").to_string(),
+                average_mood: row.get(1)?,
+                entry_count: row.get(2)?,
+            })
+        })
+        .map_err(|e| format!("DOW query failed: {}", e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("DOW row parsing failed: {}", e))?;
+
+    // Trend data
+    let mut trend_stmt = conn
+        .prepare(
+            "SELECT date(created_at) as date, AVG(mood) as avg_mood, COUNT(*) as count
+             FROM journal_entries
+             WHERE date(created_at) >= date('now', ?1)
+             GROUP BY date(created_at)
+             ORDER BY date",
+        )
+        .map_err(|e| format!("Trend prepare failed: {}", e))?;
+
+    let trend_offset = format!("-{} days", trend_days);
+    let trend_data = trend_stmt
+        .query_map(params![trend_offset], |row| {
+            Ok(DailyStats {
+                date: row.get(0)?,
+                average_mood: row.get(1)?,
+                entry_count: row.get(2)?,
+            })
+        })
+        .map_err(|e| format!("Trend query failed: {}", e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Trend row parsing failed: {}", e))?;
+
+    Ok(FullAnalyticsBundle {
+        average_mood,
+        total_entries,
+        streak_stats,
+        mood_distribution,
+        day_of_week_stats,
+        trend_data,
+    })
+}
+
+/// Get lightweight insights metadata (no decryption required)
+pub fn get_insights_metadata(db: &Database) -> Result<InsightsMetadata, String> {
+    let conn = db.conn.lock().map_err(|e| e.to_string())?;
+
+    // Total entries
+    let total_entries: i32 = conn
+        .query_row("SELECT COUNT(*) FROM journal_entries", [], |row| row.get(0))
+        .unwrap_or(0);
+
+    // Entries since the start of the current week (Sunday-based)
+    let entries_this_week: i32 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM journal_entries
+             WHERE date(created_at) >= date('now', 'weekday 0', '-7 days')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    // Top 5 tags all-time by usage count
+    let mut tag_stmt = conn
+        .prepare(
+            "SELECT t.name
+             FROM entry_tags et
+             JOIN tags t ON t.id = et.tag_id
+             GROUP BY t.id
+             ORDER BY COUNT(*) DESC
+             LIMIT 5",
+        )
+        .map_err(|e| format!("Tag prepare failed: {}", e))?;
+
+    let top_tags = tag_stmt
+        .query_map([], |row| row.get(0))
+        .map_err(|e| format!("Tag query failed: {}", e))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(InsightsMetadata {
+        entries_this_week,
+        total_entries,
+        top_tags,
+    })
+}
+
+/// Compute streak stats from a list of unique entry dates (descending ISO order)
+/// Uses the same algorithm as get_streak_stats to ensure consistent results.
+fn compute_streak_stats(dates: Vec<String>) -> StreakStats {
+    if dates.is_empty() {
+        return StreakStats {
+            current_streak: 0,
+            longest_streak: 0,
+            last_entry_date: None,
+        };
+    }
+
+    let last_entry_date = dates.first().cloned();
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+
+    let mut current_streak = 0i32;
+    let mut check_date = chrono::Local::now().date_naive();
+
+    if let Some(ref last_date) = last_entry_date {
+        if last_date != &today {
+            let yesterday = (chrono::Local::now() - chrono::Duration::days(1))
+                .format("%Y-%m-%d")
+                .to_string();
+            if last_date != &yesterday {
+                current_streak = 0;
+            } else {
+                check_date -= chrono::Duration::days(1);
+            }
+        }
+    }
+
+    if current_streak == 0
+        && (last_entry_date.as_ref() == Some(&today)
+            || last_entry_date.as_ref()
+                == Some(
+                    &(chrono::Local::now() - chrono::Duration::days(1))
+                        .format("%Y-%m-%d")
+                        .to_string(),
+                ))
+    {
+        for date_str in &dates {
+            let expected = check_date.format("%Y-%m-%d").to_string();
+            if date_str == &expected {
+                current_streak += 1;
+                check_date -= chrono::Duration::days(1);
+            } else {
+                break;
+            }
+        }
+    }
+
+    let mut longest_streak = 0i32;
+    let mut temp_streak = 1i32;
+
+    for i in 0..dates.len().saturating_sub(1) {
+        let current = chrono::NaiveDate::parse_from_str(&dates[i], "%Y-%m-%d");
+        let next = chrono::NaiveDate::parse_from_str(&dates[i + 1], "%Y-%m-%d");
+        if let (Ok(c), Ok(n)) = (current, next) {
+            if (c - n).num_days() == 1 {
+                temp_streak += 1;
+            } else {
+                longest_streak = longest_streak.max(temp_streak);
+                temp_streak = 1;
+            }
+        }
+    }
+    longest_streak = longest_streak.max(temp_streak);
+    current_streak = current_streak.min(longest_streak);
+    longest_streak = longest_streak.max(current_streak);
+
+    StreakStats {
+        current_streak,
+        longest_streak,
+        last_entry_date,
+    }
+}
+
 /// Get mood data for a specific month (for calendar view)
 pub fn get_monthly_mood_data(
     db: &Database,
@@ -1031,25 +1295,23 @@ pub fn get_monthly_mood_data(
 ) -> Result<Vec<CalendarDayData>, String> {
     let conn = db.conn.lock().map_err(|e| e.to_string())?;
 
+    // Build date range strings for the month
+    let days_in_month = days_in_month(year, month);
+    let start = format!("{:04}-{:02}-01", year, month);
+    let end = format!("{:04}-{:02}-{:02}", year, month, days_in_month);
+
+    // Primary path: query the pre-computed mood_daily_stats cache (index scan on PK)
     let mut stmt = conn
         .prepare(
-            "SELECT
-                date(created_at) as date,
-                AVG(mood) as avg_mood,
-                COUNT(*) as count
-             FROM journal_entries
-             WHERE strftime('%Y', created_at) = ?1
-               AND strftime('%m', created_at) = ?2
-             GROUP BY date(created_at)
+            "SELECT date, average_mood, entry_count
+             FROM mood_daily_stats
+             WHERE date >= ?1 AND date <= ?2
              ORDER BY date",
         )
         .map_err(|e| format!("Prepare failed: {}", e))?;
 
-    let year_str = format!("{:04}", year);
-    let month_str = format!("{:02}", month);
-
     let data = stmt
-        .query_map(params![year_str, month_str], |row| {
+        .query_map(params![start, end], |row| {
             Ok(CalendarDayData {
                 date: row.get(0)?,
                 average_mood: row.get(1)?,
@@ -1060,7 +1322,75 @@ pub fn get_monthly_mood_data(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Row parsing failed: {}", e))?;
 
-    Ok(data)
+    if !data.is_empty() {
+        return Ok(data);
+    }
+
+    // Fallback: check if entries exist for this month (pre-migration data)
+    let entry_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM journal_entries
+             WHERE date(created_at) >= ?1 AND date(created_at) <= ?2",
+            params![start, end],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if entry_count == 0 {
+        return Ok(vec![]);
+    }
+
+    // Fallback query: full table scan (pre-migration path)
+    let year_str = format!("{:04}", year);
+    let month_str = format!("{:02}", month);
+    let mut fallback_stmt = conn
+        .prepare(
+            "SELECT date(created_at) as date, AVG(mood) as avg_mood, COUNT(*) as count
+             FROM journal_entries
+             WHERE strftime('%Y', created_at) = ?1
+               AND strftime('%m', created_at) = ?2
+             GROUP BY date(created_at)
+             ORDER BY date",
+        )
+        .map_err(|e| format!("Fallback prepare failed: {}", e))?;
+
+    let fallback_data = fallback_stmt
+        .query_map(params![year_str, month_str], |row| {
+            Ok(CalendarDayData {
+                date: row.get(0)?,
+                average_mood: row.get(1)?,
+                entry_count: row.get(2)?,
+            })
+        })
+        .map_err(|e| format!("Fallback query failed: {}", e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Fallback row parsing failed: {}", e))?;
+
+    // Backfill mood_daily_stats for this month so future calls use the cache
+    for row in &fallback_data {
+        let _ = conn.execute(
+            "INSERT OR REPLACE INTO mood_daily_stats (date, average_mood, entry_count)
+             VALUES (?1, ?2, ?3)",
+            params![row.date, row.average_mood, row.entry_count],
+        );
+    }
+
+    Ok(fallback_data)
+}
+
+fn days_in_month(year: i32, month: i32) -> i32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 30,
+    }
 }
 
 // ============================================================================

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -112,6 +112,7 @@ pub struct InsightsMetadata {
     pub entries_this_week: i32,
     pub total_entries: i32,
     pub top_tags: Vec<String>,
+    pub last_entry_date: Option<String>,
 }
 
 /// Calendar day data for monthly view
@@ -1204,10 +1205,20 @@ pub fn get_insights_metadata(db: &Database) -> Result<InsightsMetadata, String> 
         .filter_map(|r| r.ok())
         .collect();
 
+    // Most recent entry date for streak cache invalidation
+    let last_entry_date: Option<String> = conn
+        .query_row(
+            "SELECT date(created_at) FROM journal_entries ORDER BY created_at DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+
     Ok(InsightsMetadata {
         entries_this_week,
         total_entries,
         top_tags,
+        last_entry_date,
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -183,6 +183,8 @@ pub fn run() {
             commands::get_streak_stats,
             commands::get_day_of_week_stats,
             commands::get_monthly_mood_data,
+            commands::get_full_analytics_bundle,
+            commands::get_insights_metadata,
             // Settings
             commands::get_setting,
             commands::set_setting,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MoodHaven",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "identifier": "com.moodhaven.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/hooks/useInsights.test.ts
+++ b/src/hooks/useInsights.test.ts
@@ -59,7 +59,7 @@ const mockCreateAIServiceConfig = vi.mocked(createAIServiceConfig);
 
 // ── Defaults ─────────────────────────────────────────────────────────────────
 
-const defaultMeta = { entries_this_week: 3, total_entries: 10, top_tags: ['work', 'health'] };
+const defaultMeta = { entries_this_week: 3, total_entries: 10, top_tags: ['work', 'health'], last_entry_date: '2024-06-15' };
 const defaultLocalMeta = { totalEntries: 8, averageMood: 3.5, topEmotions: [], entryFrequency: 'daily' as const, preferredTime: 'morning' as const, moodTrend: 'stable' as const, recentMoodAverage: 3.5, dominantEmotions: [] };
 const defaultAiMeta = { ...defaultLocalMeta, totalEntries: 5 };
 
@@ -91,7 +91,7 @@ describe('useInsights', () => {
     it('sets hasData=false and isMetadataReady=true when total_entries=0', async () => {
       // Regression: ISSUE-QA-009 — empty DB must set hasData=false, not stall
       // Found by /qa (coverage audit) on 2026-03-27
-      mockGetInsightsMetadata.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [] });
+      mockGetInsightsMetadata.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [], last_entry_date: null });
 
       const { result } = renderHook(() => useInsights());
 
@@ -117,7 +117,7 @@ describe('useInsights', () => {
       // Regression: ISSUE-QA-011 — cache hit must prevent full getAllEntries decrypt
       // Found by /qa (coverage audit) on 2026-03-27
       localStorage.setItem('mb_gratitude_streak_cache', JSON.stringify({
-        streak: 7, longestStreak: 21, entryCount: 10,
+        streak: 7, longestStreak: 21, entryCount: 10, lastEntryDate: '2024-06-15',
       }));
 
       const { result } = renderHook(() => useInsights());

--- a/src/hooks/useInsights.test.ts
+++ b/src/hooks/useInsights.test.ts
@@ -1,0 +1,196 @@
+/**
+ * useInsights tests
+ *
+ * Coverage targets (from /qa report, ISSUE-QA coverage audit):
+ * - Tier A metadata loaded without decrypt
+ * - localStorage streak cache hit (entry count unchanged)
+ * - localStorage streak cache miss (stale — triggers full getAllEntries)
+ * - AI disabled → no generateInsights call
+ * - hasData=false when total_entries=0
+ * - [settingsAi] dep isolation
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useInsights } from './useInsights';
+import { useSettingsStore } from '../stores/settingsStore';
+import { createDefaultSettings } from '../types/settings';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../lib/journalService', () => ({
+  getAllEntries: vi.fn(),
+  getEntriesByDateRange: vi.fn(),
+}));
+
+vi.mock('../lib/metadataExtractor', () => ({
+  aggregateMetadataBoth: vi.fn(),
+  calculateGratitudeStreak: vi.fn(),
+}));
+
+vi.mock('../lib/aiService', () => ({
+  generateInsights: vi.fn(),
+  generateWeeklyReflection: vi.fn(),
+  detectRecurringPatterns: vi.fn(),
+  createAIServiceConfig: vi.fn(),
+}));
+
+vi.mock('../lib/analyticsService', () => ({
+  getInsightsMetadata: vi.fn(),
+}));
+
+vi.mock('../lib/dateUtils', () => ({
+  getDaysAgo: vi.fn(() => new Date('2024-05-15')),
+}));
+
+import { getAllEntries, getEntriesByDateRange } from '../lib/journalService';
+import { aggregateMetadataBoth, calculateGratitudeStreak } from '../lib/metadataExtractor';
+import { generateInsights, generateWeeklyReflection, detectRecurringPatterns, createAIServiceConfig } from '../lib/aiService';
+import { getInsightsMetadata } from '../lib/analyticsService';
+
+const mockGetInsightsMetadata = vi.mocked(getInsightsMetadata);
+const mockGetEntriesByDateRange = vi.mocked(getEntriesByDateRange);
+const mockGetAllEntries = vi.mocked(getAllEntries);
+const mockAggregateMetadataBoth = vi.mocked(aggregateMetadataBoth);
+const mockCalculateGratitudeStreak = vi.mocked(calculateGratitudeStreak);
+const mockGenerateInsights = vi.mocked(generateInsights);
+const mockGenerateWeeklyReflection = vi.mocked(generateWeeklyReflection);
+const mockDetectRecurringPatterns = vi.mocked(detectRecurringPatterns);
+const mockCreateAIServiceConfig = vi.mocked(createAIServiceConfig);
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+const defaultMeta = { entries_this_week: 3, total_entries: 10, top_tags: ['work', 'health'] };
+const defaultLocalMeta = { totalEntries: 8, averageMood: 3.5, topEmotions: [], entryFrequency: 'daily' as const, preferredTime: 'morning' as const, moodTrend: 'stable' as const, recentMoodAverage: 3.5, dominantEmotions: [] };
+const defaultAiMeta = { ...defaultLocalMeta, totalEntries: 5 };
+
+function setupDefaultMocks() {
+  mockGetInsightsMetadata.mockResolvedValue(defaultMeta);
+  mockGetEntriesByDateRange.mockResolvedValue([]);
+  mockGetAllEntries.mockResolvedValue([]);
+  mockAggregateMetadataBoth.mockReturnValue({ localMeta: defaultLocalMeta, aiMeta: defaultAiMeta });
+  mockDetectRecurringPatterns.mockReturnValue([]);
+  mockCalculateGratitudeStreak.mockReturnValue({ currentStreak: 5, longestStreak: 14 });
+  mockCreateAIServiceConfig.mockReturnValue({ provider: 'none' } as ReturnType<typeof createAIServiceConfig>);
+  mockGenerateInsights.mockResolvedValue({ success: false });
+  mockGenerateWeeklyReflection.mockResolvedValue({ success: false });
+}
+
+// ── Store reset ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  useSettingsStore.setState({ settings: createDefaultSettings() });
+  setupDefaultMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useInsights', () => {
+  describe('Tier A — metadata load', () => {
+    it('sets hasData=false and isMetadataReady=true when total_entries=0', async () => {
+      // Regression: ISSUE-QA-009 — empty DB must set hasData=false, not stall
+      // Found by /qa (coverage audit) on 2026-03-27
+      mockGetInsightsMetadata.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [] });
+
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => expect(result.current.isMetadataReady).toBe(true));
+      expect(result.current.hasData).toBe(false);
+      // Should NOT call getEntriesByDateRange when there's nothing
+      expect(mockGetEntriesByDateRange).not.toHaveBeenCalled();
+    });
+
+    it('sets entriesThisWeek and topTags from Tier A metadata', async () => {
+      // Regression: ISSUE-QA-010 — Tier A fields must populate before decrypt completes
+      // Found by /qa (coverage audit) on 2026-03-27
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => expect(result.current.isMetadataReady).toBe(true));
+      expect(result.current.entriesThisWeek).toBe(3);
+      expect(result.current.topTags).toEqual(['work', 'health']);
+    });
+  });
+
+  describe('localStorage streak cache', () => {
+    it('uses cached streak when entry count matches', async () => {
+      // Regression: ISSUE-QA-011 — cache hit must prevent full getAllEntries decrypt
+      // Found by /qa (coverage audit) on 2026-03-27
+      localStorage.setItem('mb_gratitude_streak_cache', JSON.stringify({
+        streak: 7, longestStreak: 21, entryCount: 10,
+      }));
+
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => expect(result.current.isMetadataReady).toBe(true));
+      // Should use cache, not recompute
+      expect(mockGetAllEntries).not.toHaveBeenCalled();
+      expect(result.current.gratitudeStreak).toBe(7);
+      expect(result.current.gratitudeLongestStreak).toBe(21);
+    });
+
+    it('recomputes streak and updates cache when entry count differs (stale cache)', async () => {
+      // Regression: ISSUE-QA-012 — stale cache must trigger fresh decrypt + cache update
+      // Found by /qa (coverage audit) on 2026-03-27
+      localStorage.setItem('mb_gratitude_streak_cache', JSON.stringify({
+        streak: 3, longestStreak: 5, entryCount: 7, // total_entries is 10 → stale
+      }));
+
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => !result.current.isLoading);
+      expect(mockGetAllEntries).toHaveBeenCalledTimes(1);
+      expect(result.current.gratitudeStreak).toBe(5); // from calculateGratitudeStreak mock
+      // Cache should be updated
+      const updated = JSON.parse(localStorage.getItem('mb_gratitude_streak_cache') ?? '{}');
+      expect(updated.entryCount).toBe(10);
+    });
+  });
+
+  describe('AI features', () => {
+    it('does not call generateInsights when AI is disabled', async () => {
+      // Regression: ISSUE-QA-013 — disabled AI must not trigger LLM calls
+      // Found by /qa (coverage audit) on 2026-03-27
+      useSettingsStore.setState({
+        settings: { ...createDefaultSettings(), ai: { ...createDefaultSettings().ai, enabled: false } },
+      });
+      mockGetEntriesByDateRange.mockResolvedValue([{ id: '1' } as Parameters<typeof mockGetEntriesByDateRange>[0] extends never ? never : Awaited<ReturnType<typeof mockGetEntriesByDateRange>>[number]]);
+
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => !result.current.isLoading);
+      expect(mockGenerateInsights).not.toHaveBeenCalled();
+      expect(mockGenerateWeeklyReflection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('return values', () => {
+    it('exposes refresh function that re-runs load', async () => {
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => expect(result.current.isMetadataReady).toBe(true));
+      expect(mockGetInsightsMetadata).toHaveBeenCalledTimes(1);
+
+      await act(async () => { await result.current.refresh(); });
+      expect(mockGetInsightsMetadata).toHaveBeenCalledTimes(2);
+    });
+
+    it('dismissInsight removes the insight by id', async () => {
+      mockGetInsightsMetadata.mockResolvedValue(defaultMeta);
+      useSettingsStore.setState({
+        settings: {
+          ...createDefaultSettings(),
+          ai: { ...createDefaultSettings().ai, enabled: true, features: { ...createDefaultSettings().ai.features, wellnessInsights: true } },
+        },
+      });
+      mockGetEntriesByDateRange.mockResolvedValue([{ id: '1' } as Awaited<ReturnType<typeof mockGetEntriesByDateRange>>[number]]);
+      mockGenerateInsights.mockResolvedValue({ success: true, data: [{ id: 'i1', type: 'pattern', title: 'test', message: 'msg', priority: 'low' }] });
+
+      const { result } = renderHook(() => useInsights());
+
+      await waitFor(() => result.current.insights.length > 0);
+      act(() => result.current.dismissInsight('i1'));
+      expect(result.current.insights).toHaveLength(0);
+    });
+  });
+});

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -7,12 +7,18 @@
  * - Local patterns always use entries with privacyMode < 2 (Open + Mindful)
  * - LLM calls only use entries with privacyMode === 0 (Open)
  * - The actual journal text never leaves the device
+ *
+ * Performance:
+ * - get_insights_metadata provides entriesThisWeek / topTags / totalEntries immediately (no decrypt)
+ * - aggregateMetadata uses only the last 30 days of entries (not all-time)
+ * - Gratitude streak uses a localStorage cache keyed by entry count to avoid cold-session decrypt
+ * - settings.ai scoped dependency prevents non-AI settings changes from triggering reload
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { getAllEntries } from '../lib/journalService';
+import { getAllEntries, getEntriesByDateRange } from '../lib/journalService';
 import {
-  aggregateMetadata,
+  aggregateMetadataBoth,
   calculateGratitudeStreak,
 } from '../lib/metadataExtractor';
 import {
@@ -21,8 +27,38 @@ import {
   detectRecurringPatterns,
   createAIServiceConfig,
 } from '../lib/aiService';
+import { getInsightsMetadata } from '../lib/analyticsService';
 import { useSettingsStore } from '../stores/settingsStore';
+import { getDaysAgo } from '../lib/dateUtils';
 import type { AggregatedMetadata, WellnessInsight, RecurringPattern, WeeklyReflection } from '../types/ai';
+
+const STREAK_CACHE_KEY = 'mb_gratitude_streak_cache';
+
+interface StreakCache {
+  streak: number;
+  longestStreak: number;
+  entryCount: number;
+}
+
+function loadStreakCache(): StreakCache | null {
+  try {
+    const raw = localStorage.getItem(STREAK_CACHE_KEY);
+    return raw ? (JSON.parse(raw) as StreakCache) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveStreakCache(streak: number, longestStreak: number, entryCount: number): void {
+  try {
+    localStorage.setItem(
+      STREAK_CACHE_KEY,
+      JSON.stringify({ streak, longestStreak, entryCount })
+    );
+  } catch {
+    // localStorage unavailable — non-fatal
+  }
+}
 
 function getWeekBounds(): { weekStart: string; weekEnd: string } {
   const now = new Date();
@@ -40,7 +76,7 @@ function getWeekBounds(): { weekStart: string; weekEnd: string } {
 }
 
 export function useInsights() {
-  const settings = useSettingsStore((s) => s.settings);
+  const settingsAi = useSettingsStore((s) => s.settings.ai);
 
   const [localMetadata, setLocalMetadata] = useState<AggregatedMetadata | null>(null);
   const [insights, setInsights] = useState<WellnessInsight[]>([]);
@@ -49,6 +85,7 @@ export function useInsights() {
   const [gratitudeStreak, setGratitudeStreak] = useState(0);
   const [gratitudeLongestStreak, setGratitudeLongestStreak] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isMetadataReady, setIsMetadataReady] = useState(false);
   const [hasData, setHasData] = useState(false);
   const [entriesThisWeek, setEntriesThisWeek] = useState(0);
   const [topTags, setTopTags] = useState<string[]>([]);
@@ -56,84 +93,79 @@ export function useInsights() {
   const load = useCallback(async () => {
     setIsLoading(true);
     try {
-      const entries = await getAllEntries();
+      // Tier A: lightweight metadata — no decryption, renders immediately
+      const meta = await getInsightsMetadata();
 
-      if (entries.length === 0) {
+      if (meta.total_entries === 0) {
         setHasData(false);
+        setIsMetadataReady(true);
         return;
       }
 
       setHasData(true);
+      setEntriesThisWeek(meta.entries_this_week);
+      setTopTags(meta.top_tags);
+      setIsMetadataReady(true);
 
-      // Entries this week
-      const now = new Date();
-      const weekStart = new Date(now);
-      weekStart.setDate(now.getDate() - now.getDay()); // Sunday
-      weekStart.setHours(0, 0, 0, 0);
-      setEntriesThisWeek(
-        entries.filter((e) => new Date(e.created_at) >= weekStart).length
-      );
+      // Gratitude streak: use localStorage cache if entry count hasn't changed
+      const cached = loadStreakCache();
+      if (cached && cached.entryCount === meta.total_entries) {
+        setGratitudeStreak(cached.streak);
+        setGratitudeLongestStreak(cached.longestStreak);
+      }
 
-      // Top tags across all entries
-      const tagCounts = new Map<string, number>();
-      for (const e of entries) {
-        for (const t of e.tags) {
-          tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+      // Tier B: decrypt last 30 days only for aggregateMetadata
+      const startDate = getDaysAgo(30);
+      const recentEntries = await getEntriesByDateRange(startDate, new Date());
+
+      if (recentEntries.length > 0) {
+        const { localMeta, aiMeta } = aggregateMetadataBoth(recentEntries);
+        setLocalMetadata(localMeta);
+        setPatterns(detectRecurringPatterns(localMeta));
+
+        if (settingsAi.enabled) {
+          const config = createAIServiceConfig(useSettingsStore.getState().settings);
+          const insightPromises: Promise<void>[] = [];
+
+          if (settingsAi.features.wellnessInsights) {
+            insightPromises.push(
+              generateInsights(config, aiMeta).then((result) => {
+                if (result.success && result.data) {
+                  setInsights(result.data);
+                }
+              })
+            );
+          }
+
+          if (settingsAi.features.weeklyReflections) {
+            const { weekStart, weekEnd } = getWeekBounds();
+            insightPromises.push(
+              generateWeeklyReflection(config, aiMeta, weekStart, weekEnd).then((result) => {
+                if (result.success && result.data) {
+                  setWeeklyReflection(result.data);
+                }
+              })
+            );
+          }
+
+          await Promise.allSettled(insightPromises);
         }
       }
-      setTopTags(
-        Array.from(tagCounts.entries())
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 5)
-          .map(([t]) => t)
-      );
 
-      // Local analysis: Open + Mindful entries
-      const meta = aggregateMetadata(entries, 30, false);
-      setLocalMetadata(meta);
-      setPatterns(detectRecurringPatterns(meta));
-
-      // Gratitude streak (local)
-      const gs = calculateGratitudeStreak(entries);
-      setGratitudeStreak(gs.currentStreak);
-      setGratitudeLongestStreak(gs.longestStreak);
-
-      // AI features: Open entries only
-      if (settings.ai.enabled) {
-        const llmMeta = aggregateMetadata(entries, 30, true);
-        const config = createAIServiceConfig(settings);
-
-        const insightPromises: Promise<void>[] = [];
-
-        if (settings.ai.features.wellnessInsights) {
-          insightPromises.push(
-            generateInsights(config, llmMeta).then((result) => {
-              if (result.success && result.data) {
-                setInsights(result.data);
-              }
-            })
-          );
-        }
-
-        if (settings.ai.features.weeklyReflections) {
-          const { weekStart, weekEnd } = getWeekBounds();
-          insightPromises.push(
-            generateWeeklyReflection(config, llmMeta, weekStart, weekEnd).then((result) => {
-              if (result.success && result.data) {
-                setWeeklyReflection(result.data);
-              }
-            })
-          );
-        }
-
-        await Promise.allSettled(insightPromises);
+      // Gratitude streak: recompute if cache is stale (new entries since last visit)
+      if (!cached || cached.entryCount !== meta.total_entries) {
+        const allEntries = await getAllEntries();
+        const gs = calculateGratitudeStreak(allEntries);
+        setGratitudeStreak(gs.currentStreak);
+        setGratitudeLongestStreak(gs.longestStreak);
+        saveStreakCache(gs.currentStreak, gs.longestStreak, meta.total_entries);
       }
     } catch {
       // Silently fall back — local patterns are still shown
     } finally {
       setIsLoading(false);
     }
-  }, [settings]);
+  }, [settingsAi]);
 
   useEffect(() => {
     void load();
@@ -153,8 +185,9 @@ export function useInsights() {
     entriesThisWeek,
     topTags,
     isLoading,
+    isMetadataReady,
     hasData,
-    isAIEnabled: settings.ai.enabled,
+    isAIEnabled: settingsAi.enabled,
     dismissInsight,
     refresh: load,
   };

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -38,6 +38,7 @@ interface StreakCache {
   streak: number;
   longestStreak: number;
   entryCount: number;
+  lastEntryDate: string | null;
 }
 
 function loadStreakCache(): StreakCache | null {
@@ -49,11 +50,11 @@ function loadStreakCache(): StreakCache | null {
   }
 }
 
-function saveStreakCache(streak: number, longestStreak: number, entryCount: number): void {
+function saveStreakCache(streak: number, longestStreak: number, entryCount: number, lastEntryDate: string | null): void {
   try {
     localStorage.setItem(
       STREAK_CACHE_KEY,
-      JSON.stringify({ streak, longestStreak, entryCount })
+      JSON.stringify({ streak, longestStreak, entryCount, lastEntryDate })
     );
   } catch {
     // localStorage unavailable — non-fatal
@@ -92,6 +93,7 @@ export function useInsights() {
 
   const load = useCallback(async () => {
     setIsLoading(true);
+    setIsMetadataReady(false);
     try {
       // Tier A: lightweight metadata — no decryption, renders immediately
       const meta = await getInsightsMetadata();
@@ -107,9 +109,9 @@ export function useInsights() {
       setTopTags(meta.top_tags);
       setIsMetadataReady(true);
 
-      // Gratitude streak: use localStorage cache if entry count hasn't changed
+      // Gratitude streak: use localStorage cache if entry count AND last entry date match
       const cached = loadStreakCache();
-      if (cached && cached.entryCount === meta.total_entries) {
+      if (cached && cached.entryCount === meta.total_entries && cached.lastEntryDate === meta.last_entry_date) {
         setGratitudeStreak(cached.streak);
         setGratitudeLongestStreak(cached.longestStreak);
       }
@@ -152,16 +154,17 @@ export function useInsights() {
         }
       }
 
-      // Gratitude streak: recompute if cache is stale (new entries since last visit)
-      if (!cached || cached.entryCount !== meta.total_entries) {
+      // Gratitude streak: recompute if cache is stale
+      if (!cached || cached.entryCount !== meta.total_entries || cached.lastEntryDate !== meta.last_entry_date) {
         const allEntries = await getAllEntries();
         const gs = calculateGratitudeStreak(allEntries);
         setGratitudeStreak(gs.currentStreak);
         setGratitudeLongestStreak(gs.longestStreak);
-        saveStreakCache(gs.currentStreak, gs.longestStreak, meta.total_entries);
+        saveStreakCache(gs.currentStreak, gs.longestStreak, meta.total_entries, meta.last_entry_date);
       }
     } catch {
       // Silently fall back — local patterns are still shown
+      setIsMetadataReady(true);
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/analyticsService.test.ts
+++ b/src/lib/analyticsService.test.ts
@@ -1,0 +1,139 @@
+import { invoke } from '@tauri-apps/api/core';
+import { getFullAnalytics, getInsightsMetadata } from './analyticsService';
+
+const mockInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('analyticsService', () => {
+  describe('getInsightsMetadata', () => {
+    // Regression: ISSUE-QA-006 — getInsightsMetadata must call get_insights_metadata and return correct shape
+    // Found by /qa on 2026-03-27
+    // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
+
+    it('calls get_insights_metadata with no extra args', async () => {
+      mockInvoke.mockResolvedValue({ entries_this_week: 3, total_entries: 42, top_tags: ['work', 'health'] });
+      await getInsightsMetadata();
+      expect(mockInvoke).toHaveBeenCalledWith('get_insights_metadata');
+    });
+
+    it('returns entries_this_week, total_entries, top_tags as-is', async () => {
+      const payload = { entries_this_week: 5, total_entries: 100, top_tags: ['gratitude', 'sleep'] };
+      mockInvoke.mockResolvedValue(payload);
+      const result = await getInsightsMetadata();
+      expect(result.entries_this_week).toBe(5);
+      expect(result.total_entries).toBe(100);
+      expect(result.top_tags).toEqual(['gratitude', 'sleep']);
+    });
+
+    it('returns zero counts for empty DB', async () => {
+      mockInvoke.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [] });
+      const result = await getInsightsMetadata();
+      expect(result.total_entries).toBe(0);
+      expect(result.top_tags).toHaveLength(0);
+    });
+  });
+
+  describe('getFullAnalytics', () => {
+    // Regression: ISSUE-QA-007 — getFullAnalytics bundle must map all fields to AnalyticsData shape
+    // Found by /qa on 2026-03-27
+    // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
+
+    const mockBundle = {
+      average_mood: 3.7,
+      total_entries: 50,
+      streak_stats: { current_streak: 5, longest_streak: 14, last_entry_date: '2024-06-15' },
+      mood_distribution: [
+        { mood: 1, count: 2 },
+        { mood: 2, count: 5 },
+        { mood: 3, count: 15 },
+        { mood: 4, count: 20 },
+        { mood: 5, count: 8 },
+      ],
+      day_of_week_stats: [
+        { day_of_week: 1, day_name: 'Monday', average_mood: 4.0, entry_count: 10 },
+      ],
+      trend_data: [
+        { date: '2024-06-14', average_mood: 3.5, entry_count: 2 },
+        { date: '2024-06-15', average_mood: 4.0, entry_count: 1 },
+      ],
+    };
+
+    it('calls get_full_analytics_bundle with trendDays param', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      await getFullAnalytics(30);
+      expect(mockInvoke).toHaveBeenCalledWith('get_full_analytics_bundle', { trendDays: 30 });
+    });
+
+    it('uses default trendDays of 30', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      await getFullAnalytics();
+      expect(mockInvoke).toHaveBeenCalledWith('get_full_analytics_bundle', { trendDays: 30 });
+    });
+
+    it('maps averageMood and totalEntries correctly', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      const result = await getFullAnalytics(30);
+      expect(result.averageMood).toBe(3.7);
+      expect(result.totalEntries).toBe(50);
+    });
+
+    it('maps streakStats correctly', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      const result = await getFullAnalytics(30);
+      expect(result.streakStats.currentStreak).toBe(5);
+      expect(result.streakStats.longestStreak).toBe(14);
+      expect(result.streakStats.lastEntryDate).toBe('2024-06-15');
+    });
+
+    it('moodDistribution fills all 5 mood levels (missing levels get count 0)', async () => {
+      mockInvoke.mockResolvedValue({ ...mockBundle, mood_distribution: [{ mood: 3, count: 10 }] });
+      const result = await getFullAnalytics(30);
+      expect(result.moodDistribution).toHaveLength(5);
+      expect(result.moodDistribution[0].count).toBe(0); // mood 1 missing → 0
+      expect(result.moodDistribution[2].count).toBe(10); // mood 3 present
+    });
+
+    it('moodDistribution calculates percentages from total', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      const result = await getFullAnalytics(30);
+      const total = 2 + 5 + 15 + 20 + 8; // 50
+      const mood4 = result.moodDistribution.find((d) => d.mood === 4)!;
+      expect(mood4.percentage).toBeCloseTo((20 / total) * 100);
+    });
+
+    it('dayOfWeekStats fills all 7 days (missing days get 0 entryCount)', async () => {
+      mockInvoke.mockResolvedValue(mockBundle); // only Monday provided
+      const result = await getFullAnalytics(30);
+      expect(result.dayOfWeekStats).toHaveLength(7);
+      const sunday = result.dayOfWeekStats[0];
+      expect(sunday.dayOfWeek).toBe(0);
+      expect(sunday.dayName).toBe('Sunday');
+      expect(sunday.entryCount).toBe(0);
+    });
+
+    it('trendData maps date, averageMood, entryCount', async () => {
+      mockInvoke.mockResolvedValue(mockBundle);
+      const result = await getFullAnalytics(30);
+      expect(result.trendData).toHaveLength(2);
+      expect(result.trendData[0]).toEqual({ date: '2024-06-14', averageMood: 3.5, entryCount: 2 });
+    });
+
+    it('empty DB returns zeroed AnalyticsData', async () => {
+      mockInvoke.mockResolvedValue({
+        average_mood: 0,
+        total_entries: 0,
+        streak_stats: { current_streak: 0, longest_streak: 0, last_entry_date: null },
+        mood_distribution: [],
+        day_of_week_stats: [],
+        trend_data: [],
+      });
+      const result = await getFullAnalytics(30);
+      expect(result.totalEntries).toBe(0);
+      expect(result.moodDistribution.every((d) => d.count === 0)).toBe(true);
+      expect(result.trendData).toHaveLength(0);
+    });
+  });
+});

--- a/src/lib/analyticsService.test.ts
+++ b/src/lib/analyticsService.test.ts
@@ -14,13 +14,13 @@ describe('analyticsService', () => {
     // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
 
     it('calls get_insights_metadata with no extra args', async () => {
-      mockInvoke.mockResolvedValue({ entries_this_week: 3, total_entries: 42, top_tags: ['work', 'health'] });
+      mockInvoke.mockResolvedValue({ entries_this_week: 3, total_entries: 42, top_tags: ['work', 'health'], last_entry_date: '2024-06-15' });
       await getInsightsMetadata();
       expect(mockInvoke).toHaveBeenCalledWith('get_insights_metadata');
     });
 
     it('returns entries_this_week, total_entries, top_tags as-is', async () => {
-      const payload = { entries_this_week: 5, total_entries: 100, top_tags: ['gratitude', 'sleep'] };
+      const payload = { entries_this_week: 5, total_entries: 100, top_tags: ['gratitude', 'sleep'], last_entry_date: '2024-06-15' };
       mockInvoke.mockResolvedValue(payload);
       const result = await getInsightsMetadata();
       expect(result.entries_this_week).toBe(5);
@@ -29,7 +29,7 @@ describe('analyticsService', () => {
     });
 
     it('returns zero counts for empty DB', async () => {
-      mockInvoke.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [] });
+      mockInvoke.mockResolvedValue({ entries_this_week: 0, total_entries: 0, top_tags: [], last_entry_date: null });
       const result = await getInsightsMetadata();
       expect(result.total_entries).toBe(0);
       expect(result.top_tags).toHaveLength(0);

--- a/src/lib/analyticsService.ts
+++ b/src/lib/analyticsService.ts
@@ -180,6 +180,7 @@ export interface InsightsMetadata {
   entries_this_week: number;
   total_entries: number;
   top_tags: string[];
+  last_entry_date: string | null;
 }
 
 /**

--- a/src/lib/analyticsService.ts
+++ b/src/lib/analyticsService.ts
@@ -167,26 +167,73 @@ export async function getOverallStats(): Promise<{ averageMood: number; totalEnt
   return { averageMood, totalEntries };
 }
 
+interface FullAnalyticsBundleRow {
+  average_mood: number;
+  total_entries: number;
+  streak_stats: StreakStatsRow;
+  mood_distribution: MoodDistributionRow[];
+  day_of_week_stats: DayOfWeekStatsRow[];
+  trend_data: DailyStatsRow[];
+}
+
+export interface InsightsMetadata {
+  entries_this_week: number;
+  total_entries: number;
+  top_tags: string[];
+}
+
 /**
- * Get full analytics data (all data combined)
+ * Get all analytics data in a single IPC call (one DB mutex acquisition)
  */
 export async function getFullAnalytics(trendDays: number = 30): Promise<AnalyticsData> {
-  // Fetch all data in parallel
-  const [overallStats, streakStats, moodDistribution, dayOfWeekStats, trendData] =
-    await Promise.all([
-      getOverallStats(),
-      getStreakStats(),
-      getMoodDistribution(),
-      getDayOfWeekStats(),
-      getMoodTrend(trendDays),
-    ]);
+  const bundle = await invoke<FullAnalyticsBundleRow>('get_full_analytics_bundle', {
+    trendDays,
+  });
+
+  const total = bundle.mood_distribution.reduce((sum, row) => sum + row.count, 0);
+  const distribution: MoodDistribution[] = [];
+  for (let mood = 1; mood <= 5; mood++) {
+    const row = bundle.mood_distribution.find((r) => r.mood === mood);
+    distribution.push({
+      mood: mood as MoodLevel,
+      count: row?.count || 0,
+      percentage: total > 0 ? ((row?.count || 0) / total) * 100 : 0,
+    });
+  }
+
+  const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const dayOfWeekStats: DayOfWeekStats[] = [];
+  for (let day = 0; day < 7; day++) {
+    const row = bundle.day_of_week_stats.find((r) => r.day_of_week === day);
+    dayOfWeekStats.push({
+      dayOfWeek: day,
+      dayName: row?.day_name || dayNames[day],
+      averageMood: row?.average_mood || 0,
+      entryCount: row?.entry_count || 0,
+    });
+  }
 
   return {
-    averageMood: overallStats.averageMood,
-    totalEntries: overallStats.totalEntries,
-    streakStats,
-    moodDistribution,
+    averageMood: bundle.average_mood,
+    totalEntries: bundle.total_entries,
+    streakStats: {
+      currentStreak: bundle.streak_stats.current_streak,
+      longestStreak: bundle.streak_stats.longest_streak,
+      lastEntryDate: bundle.streak_stats.last_entry_date,
+    },
+    moodDistribution: distribution,
     dayOfWeekStats,
-    trendData,
+    trendData: bundle.trend_data.map((row) => ({
+      date: row.date,
+      averageMood: row.average_mood,
+      entryCount: row.entry_count,
+    })),
   };
+}
+
+/**
+ * Get lightweight insights metadata (no decryption required)
+ */
+export async function getInsightsMetadata(): Promise<InsightsMetadata> {
+  return invoke<InsightsMetadata>('get_insights_metadata');
 }

--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { encrypt, decrypt, verifyPassword, hashPassword, verifyPasswordHash } from './crypto';
+import { encrypt, decrypt, verifyPassword, hashPassword, verifyPasswordHash, clearKeyCache } from './crypto';
 
 describe('crypto', () => {
   // Note: These tests use real WebCrypto with PBKDF2 (600K iterations).
@@ -137,6 +137,66 @@ describe('crypto', () => {
     it('returns false for near-miss password', async () => {
       const { hash, salt } = await hashPassword('password123');
       expect(await verifyPasswordHash('password124', hash, salt)).toBe(false);
+    });
+  });
+
+  describe('session key cache', () => {
+    beforeEach(() => {
+      clearKeyCache();
+    });
+
+    it('cache hit: multiple encrypts with same password all decrypt correctly', async () => {
+      // Regression: ISSUE-QA-001 — session key cache must return a functionally valid key on hit
+      // Found by /qa on 2026-03-27
+      // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
+      const enc1 = await encrypt('entry one', 'mypassword');
+      const enc2 = await encrypt('entry two', 'mypassword');
+      const enc3 = await encrypt('entry three', 'mypassword');
+
+      // All three must decrypt — verifies cache returns a valid key each time
+      const d1 = await decrypt(enc1.data!, 'mypassword');
+      const d2 = await decrypt(enc2.data!, 'mypassword');
+      const d3 = await decrypt(enc3.data!, 'mypassword');
+
+      expect(d1.data).toBe('entry one');
+      expect(d2.data).toBe('entry two');
+      expect(d3.data).toBe('entry three');
+    });
+
+    it('cache miss: different passwords derive independently', async () => {
+      // Regression: ISSUE-QA-002 — different passwords must not share cache entries
+      // Found by /qa on 2026-03-27
+      const enc = await encrypt('secret text', 'password-A');
+      const result = await decrypt(enc.data!, 'password-B');
+      expect(result.success).toBe(false);
+    });
+
+    it('clearKeyCache forces re-derivation on next decrypt', async () => {
+      // Regression: ISSUE-QA-003 — clearKeyCache must actually bust the cache
+      // Found by /qa on 2026-03-27
+      const enc = await encrypt('text', 'pass');
+      // Warm up the cache
+      await decrypt(enc.data!, 'pass');
+      // Clear it
+      clearKeyCache();
+      // Must still decrypt correctly — re-derives from scratch
+      const result = await decrypt(enc.data!, 'pass');
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('text');
+    });
+
+    it('clearKeyCache prevents stale key from decrypting after password change', async () => {
+      // Regression: ISSUE-QA-004 — lock (clearKeyCache) means old session key cannot decrypt new data
+      // Found by /qa on 2026-03-27
+      const enc = await encrypt('private journal entry', 'old-password');
+      // Warm the cache with old-password
+      await decrypt(enc.data!, 'old-password');
+      // Simulate lock
+      clearKeyCache();
+      // New entry encrypted with new password — old key must not decrypt it
+      const enc2 = await encrypt('new private entry', 'new-password');
+      const result = await decrypt(enc2.data!, 'old-password');
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -61,13 +61,27 @@ function generateRandomBytes(length: number): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(length));
 }
 
+// Session-scoped key cache: salt (base64) → derived CryptoKey
+// Avoids re-running 600k PBKDF2 iterations for the same entry within a session.
+// Cleared on lockJournal() via clearKeyCache().
+const sessionKeyCache = new Map<string, CryptoKey>();
+
+export function clearKeyCache(): void {
+  sessionKeyCache.clear();
+}
+
 /**
  * Derive an AES-256 key from password using PBKDF2
+ * Returns cached key if the same salt was used earlier this session.
  */
 async function deriveKey(
   password: string,
   salt: Uint8Array
 ): Promise<CryptoKey> {
+  const saltKey = `${bufferToBase64(salt.buffer as ArrayBuffer)}:${password}`;
+  const cached = sessionKeyCache.get(saltKey);
+  if (cached) return cached;
+
   // Import password as raw key material
   const passwordKey = await crypto.subtle.importKey(
     'raw',
@@ -78,7 +92,7 @@ async function deriveKey(
   );
 
   // Derive AES-256 key using PBKDF2
-  return crypto.subtle.deriveKey(
+  const key = await crypto.subtle.deriveKey(
     {
       name: 'PBKDF2',
       salt: salt as BufferSource,
@@ -93,6 +107,9 @@ async function deriveKey(
     false, // Not extractable
     ['encrypt', 'decrypt']
   );
+
+  sessionKeyCache.set(saltKey, key);
+  return key;
 }
 
 /**

--- a/src/lib/journalService.test.ts
+++ b/src/lib/journalService.test.ts
@@ -1,0 +1,46 @@
+import { invoke } from '@tauri-apps/api/core';
+
+// Mock crypto module so we can spy on clearKeyCache
+vi.mock('./crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./crypto')>();
+  return {
+    ...actual,
+    clearKeyCache: vi.fn(),
+  };
+});
+
+import { lockJournal, devBypassUnlock, isUnlocked } from './journalService';
+import { clearKeyCache } from './crypto';
+
+const mockClearKeyCache = vi.mocked(clearKeyCache);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('journalService — session management', () => {
+  describe('lockJournal', () => {
+    it('clears the key cache on lock', () => {
+      // Regression: ISSUE-QA-008 — lockJournal must call clearKeyCache so PBKDF2 cache is invalidated
+      // Found by /qa on 2026-03-27
+      // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
+      lockJournal();
+      expect(mockClearKeyCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks journal as locked after call', () => {
+      devBypassUnlock('any-password');
+      expect(isUnlocked()).toBe(true);
+      lockJournal();
+      expect(isUnlocked()).toBe(false);
+    });
+
+    it('is idempotent — calling lock twice does not throw', () => {
+      expect(() => {
+        lockJournal();
+        lockJournal();
+      }).not.toThrow();
+      expect(mockClearKeyCache).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/lib/journalService.test.ts
+++ b/src/lib/journalService.test.ts
@@ -1,5 +1,3 @@
-import { invoke } from '@tauri-apps/api/core';
-
 // Mock crypto module so we can spy on clearKeyCache
 vi.mock('./crypto', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./crypto')>();

--- a/src/lib/journalService.ts
+++ b/src/lib/journalService.ts
@@ -9,6 +9,7 @@ import { invoke } from '@tauri-apps/api/core';
 import {
   encrypt,
   decrypt,
+  clearKeyCache,
   hashPassword,
   verifyPasswordHash,
   type EncryptedData,
@@ -113,10 +114,11 @@ export async function unlockJournal(password: string): Promise<boolean> {
 }
 
 /**
- * Lock the journal (clear session password)
+ * Lock the journal (clear session password and derived key cache)
  */
 export function lockJournal(): void {
   sessionPassword = null;
+  clearKeyCache();
 }
 
 /** Dev-only: set session password without DB verification. Never call in production. */

--- a/src/lib/metadataExtractor.test.ts
+++ b/src/lib/metadataExtractor.test.ts
@@ -1,4 +1,4 @@
-import { extractEntryMetadata, aggregateMetadata, calculateGratitudeStreak, scoreContentMood, scoreEmojiSentiment } from './metadataExtractor';
+import { extractEntryMetadata, aggregateMetadata, aggregateMetadataBoth, calculateGratitudeStreak, scoreContentMood, scoreEmojiSentiment } from './metadataExtractor';
 import type { JournalEntry, MoodLevel } from '../types/journal';
 
 /**
@@ -882,6 +882,55 @@ describe('metadataExtractor', () => {
       const score = scoreEmojiSentiment('😊 😊 😊 😊 😊') ?? 0;
       expect(score).toBeGreaterThanOrEqual(-1);
       expect(score).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('aggregateMetadataBoth', () => {
+    // Regression: ISSUE-QA-005 — aggregateMetadataBoth must match two separate aggregateMetadata calls
+    // Found by /qa on 2026-03-27
+    // Report: .gstack/qa-reports/qa-report-feat-db-performance-2026-03-27.md
+
+    const entries = [
+      createTestEntry({ id: '1', mood: 4, privacyMode: 0, created_at: '2024-06-15T10:00:00.000Z' }),
+      createTestEntry({ id: '2', mood: 2, privacyMode: 1, created_at: '2024-06-14T10:00:00.000Z' }),
+      createTestEntry({ id: '3', mood: 5, privacyMode: 2, created_at: '2024-06-13T10:00:00.000Z' }),
+    ];
+
+    it('localMeta matches aggregateMetadata(entries, 30, false)', () => {
+      const { localMeta } = aggregateMetadataBoth(entries);
+      const expected = aggregateMetadata(entries, 30, false);
+      expect(localMeta).toEqual(expected);
+    });
+
+    it('aiMeta matches aggregateMetadata(entries, 30, true)', () => {
+      const { aiMeta } = aggregateMetadataBoth(entries);
+      const expected = aggregateMetadata(entries, 30, true);
+      expect(aiMeta).toEqual(expected);
+    });
+
+    it('localMeta includes privacyMode 1 (Mindful) entries, aiMeta excludes them', () => {
+      const { localMeta, aiMeta } = aggregateMetadataBoth(entries);
+      // privacyMode 0 (Open) and 1 (Mindful) visible to local; privacyMode 2 (Private) excluded
+      // privacyMode 0 (Open) only for AI
+      expect(localMeta.totalEntries).toBeGreaterThanOrEqual(aiMeta.totalEntries);
+    });
+
+    it('returns independent objects (mutation of one does not affect other)', () => {
+      const { localMeta, aiMeta } = aggregateMetadataBoth(entries);
+      const localCount = localMeta.totalEntries;
+      const aiCount = aiMeta.totalEntries;
+      // Mutate localMeta
+      (localMeta as { totalEntries: number }).totalEntries = 9999;
+      expect(aiMeta.totalEntries).toBe(aiCount);
+      expect(localMeta.totalEntries).toBe(9999);
+      // Restore doesn't matter — just verifying aiMeta unchanged
+      expect(localCount).toBeGreaterThanOrEqual(aiCount);
+    });
+
+    it('empty entry list returns zeroed metadata for both', () => {
+      const { localMeta, aiMeta } = aggregateMetadataBoth([]);
+      expect(localMeta.totalEntries).toBe(0);
+      expect(aiMeta.totalEntries).toBe(0);
     });
   });
 });

--- a/src/lib/metadataExtractor.ts
+++ b/src/lib/metadataExtractor.ts
@@ -270,9 +270,9 @@ export function aggregateMetadata(
 }
 
 /**
- * Aggregate metadata in a single pass for both local (Open+Mindful) and AI (Open-only) consumers.
+ * Aggregate metadata for both local (Open+Mindful) and AI (Open-only) consumers.
  * Equivalent to calling aggregateMetadata(entries, 30, false) + aggregateMetadata(entries, 30, true)
- * but avoids iterating the entries array twice.
+ * as a single convenience call.
  */
 export function aggregateMetadataBoth(entries: JournalEntry[]): {
   localMeta: AggregatedMetadata;

--- a/src/lib/metadataExtractor.ts
+++ b/src/lib/metadataExtractor.ts
@@ -269,6 +269,21 @@ export function aggregateMetadata(
   };
 }
 
+/**
+ * Aggregate metadata in a single pass for both local (Open+Mindful) and AI (Open-only) consumers.
+ * Equivalent to calling aggregateMetadata(entries, 30, false) + aggregateMetadata(entries, 30, true)
+ * but avoids iterating the entries array twice.
+ */
+export function aggregateMetadataBoth(entries: JournalEntry[]): {
+  localMeta: AggregatedMetadata;
+  aiMeta: AggregatedMetadata;
+} {
+  return {
+    localMeta: aggregateMetadata(entries, 30, false),
+    aiMeta: aggregateMetadata(entries, 30, true),
+  };
+}
+
 // ============================================
 // SENTIMENT ANALYSIS (Local)
 // ============================================

--- a/src/pages/InsightsView.tsx
+++ b/src/pages/InsightsView.tsx
@@ -138,7 +138,7 @@ export function InsightsView({ onNavigateToSettings }: InsightsViewProps) {
     isAIEnabled,
     dismissInsight,
     refresh,
-  isMetadataReady,
+    isMetadataReady,
   } = useInsights();
 
   const analytics = useAnalytics();

--- a/src/pages/InsightsView.tsx
+++ b/src/pages/InsightsView.tsx
@@ -138,6 +138,7 @@ export function InsightsView({ onNavigateToSettings }: InsightsViewProps) {
     isAIEnabled,
     dismissInsight,
     refresh,
+  isMetadataReady,
   } = useInsights();
 
   const analytics = useAnalytics();
@@ -304,8 +305,9 @@ export function InsightsView({ onNavigateToSettings }: InsightsViewProps) {
         </div>
       )}
 
-      {/* ── Quick stats grid — bottom line up front ── */}
-      {localMetadata && (
+      {/* ── Quick stats grid — Tier A cards render immediately from DB metadata,
+              Tier B cards (7-day mood, streak) show skeletons until decrypt completes ── */}
+      {isMetadataReady && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
           <div className="rounded-2xl bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 shadow-sm p-4">
             <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 mb-1">This week</p>
@@ -314,21 +316,37 @@ export function InsightsView({ onNavigateToSettings }: InsightsViewProps) {
           </div>
           <div className="rounded-2xl bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 shadow-sm p-4">
             <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 mb-1">7-day mood</p>
-            <p className="text-2xl font-bold text-emerald-500">
-              {localMetadata.moodStats.recentAverage > 0
-                ? localMetadata.moodStats.recentAverage.toFixed(1)
-                : '—'}
-            </p>
-            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 capitalize">{localMetadata.moodStats.trend}</p>
+            {localMetadata ? (
+              <>
+                <p className="text-2xl font-bold text-emerald-500">
+                  {localMetadata.moodStats.recentAverage > 0
+                    ? localMetadata.moodStats.recentAverage.toFixed(1)
+                    : '—'}
+                </p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 capitalize">{localMetadata.moodStats.trend}</p>
+              </>
+            ) : (
+              <div className="h-8 w-10 rounded bg-slate-100 dark:bg-slate-700 animate-pulse mt-1" />
+            )}
           </div>
           <div className="rounded-2xl bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 shadow-sm p-4">
             <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 mb-1">Streak</p>
-            <p className="text-2xl font-bold text-amber-500">{localMetadata.patterns.currentStreak}</p>
-            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">days</p>
+            {localMetadata ? (
+              <>
+                <p className="text-2xl font-bold text-amber-500">{localMetadata.patterns.currentStreak}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">days</p>
+              </>
+            ) : (
+              <div className="h-8 w-10 rounded bg-slate-100 dark:bg-slate-700 animate-pulse mt-1" />
+            )}
           </div>
           <div className="rounded-2xl bg-white dark:bg-slate-800 border border-slate-100 dark:border-slate-700 shadow-sm p-4">
             <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500 mb-1">Best time</p>
-            <p className="text-lg font-bold text-blue-500 capitalize">{localMetadata.patterns.bestTimeOfDay || '—'}</p>
+            {localMetadata ? (
+              <p className="text-lg font-bold text-blue-500 capitalize">{localMetadata.patterns.bestTimeOfDay || '—'}</p>
+            ) : (
+              <div className="h-6 w-14 rounded bg-slate-100 dark:bg-slate-700 animate-pulse mt-1" />
+            )}
             {topTags.length > 0 && (
               <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 truncate">
                 #{topTags[0]}{topTags[1] ? `, #${topTags[1]}` : ''}


### PR DESCRIPTION
## Summary

- **WAL mode + cache pragmas** on DB open (`journal_mode=WAL`, `cache_size=-8000`, `synchronous=NORMAL`) — reduces write-lock contention and improves read throughput
- **`mood_daily_stats` cache table** + insert/update trigger — pre-aggregated daily mood data served in O(1) vs. O(n) full-scan
- **`idx_entries_book_id` index** — speeds up per-book timeline and tag queries
- **WAL checkpoint before export** — prevents partial-frame data in backup files
- **Tiered Insights loading**: Tier A (`get_insights_metadata` — no decrypt, fast) populates stats grid immediately; Tier B (30-day `getEntriesByDateRange` decrypt) runs in background. Users see data in ~100ms instead of waiting for full decrypt
- **PBKDF2 session key cache** (`Map<saltKey, CryptoKey>` in `crypto.ts`) — avoids 600k-iteration re-derive on every entry decrypt during a session; cleared on `lockJournal()`
- **`get_full_analytics_bundle`** new Tauri command — single IPC call returns all analytics in one round-trip
- **Streak cache invalidation fix** — cache now keys on both `total_entries` AND `last_entry_date`; previously, delete-N + add-N in same session could return stale streak data

## Test Coverage

- 544 tests passing (32 test files)
- 13 new regression tests added (ISSUE-QA-001 through QA-013):
  - QA-001–004: PBKDF2 session key cache hit/miss/lock-clear/format-stability
  - QA-005: `aggregateMetadataBoth` wrapper correctness
  - QA-006–007: `getInsightsMetadata` and `getFullAnalytics` IPC shapes
  - QA-008: `lockJournal` clears key cache
  - QA-009–013: `useInsights` hook — Tier A load, empty DB, streak cache hit/miss, AI gate, dismissInsight

## Pre-Landing Review

One finding, auto-fixed:
- **Indentation**: `isMetadataReady` destructure in `InsightsView.tsx` was 2-space; aligned to 4-space with siblings

## Design Review

No findings. Skeleton loading states (`animate-pulse`, `rounded bg-slate-100 dark:bg-slate-700`) are consistent with existing patterns throughout the codebase.

## Adversarial Review

15 findings reviewed; 2 actioned:

| # | Finding | Action |
|---|---------|--------|
| 3 | `sessionPassword` duplicated as Map key | Assessed: no regression vs. existing heap exposure in `journalService.ts` |
| 10 | Streak cache stale on delete-N + add-N | **Fixed**: added `last_entry_date` to `InsightsMetadata` (Rust + TS) and cache key |
| 1,2 | `isMetadataReady` not reset on refresh; not set on error path | **Fixed**: reset to `false` at load start; set to `true` in `catch` block |
| 4,13 | UTC/local date mismatch in streak date comparison | Pre-existing pattern; not introduced by this PR |
| 5–9, 11–12, 14–15 | Deferred or informational | No action |

## Plan Completion

All 9 commits land in bisectable order: feature → tests → fixes → version bump. No squash.

## Test Plan

- [ ] Open Insights view — stats grid renders immediately (< 200ms) before full decrypt
- [ ] Disable AI in settings — `generateInsights` not called
- [ ] Write entry, delete it, write another — streak updates correctly (cache invalidation)
- [ ] Lock and unlock app — session key cache cleared, re-derived on first decrypt
- [ ] Export data — verify no WAL corruption in exported file

🤖 Generated with [Claude Code](https://claude.com/claude-code)