### PR TITLE
fix: resolve CI build failures (sidecar stub, npm audit, cargo fmt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
             BIN="build/bin/whisper-cli"
           fi
 
+          mkdir -p "$GITHUB_WORKSPACE/src-tauri/binaries"
           cp "$BIN" "$GITHUB_WORKSPACE/src-tauri/binaries/${{ matrix.whisper_binary }}"
           chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/${{ matrix.whisper_binary }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,13 +90,13 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Create stub whisper sidecar (non-Linux)
-        if: matrix.os != 'ubuntu-latest'
+      - name: Create stub whisper sidecar
         shell: bash
         run: |
           # tauri-build validates sidecar existence at compile time.
           # Create a stub binary for the current host triple so cargo check passes
-          # on Windows/macOS without shipping a real whisper binary in CI.
+          # without shipping a real whisper binary in CI.
+          mkdir -p src-tauri/binaries
           TRIPLE=$(rustc -vV | sed -n 's/host: //p')
           EXT=""
           if [[ "$TRIPLE" == *"windows"* ]]; then EXT=".exe"; fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moodhaven-journal",
-  "version": "0.7.7",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moodhaven-journal",
-      "version": "0.7.7",
+      "version": "0.7.12",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -913,10 +913,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -982,10 +983,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3014,10 +3016,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3737,10 +3740,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4142,10 +4146,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5155,10 +5160,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6286,10 +6292,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },

--- a/src-tauri/src/commands/peer_discovery.rs
+++ b/src-tauri/src/commands/peer_discovery.rs
@@ -545,7 +545,8 @@ fn run_discovery(
                 let _ = app.emit("peer:discovered", &peer);
                 log::info!(
                     "[peer] Discovered: {} ({})",
-                    peer.device_name, peer.device_id
+                    peer.device_name,
+                    peer.device_id
                 );
             }
 

--- a/src-tauri/src/commands/peer_pairing.rs
+++ b/src-tauri/src/commands/peer_pairing.rs
@@ -457,7 +457,8 @@ fn run_pairing_server(
                 let _ = app.emit("peer:paired", &trusted);
                 log::info!(
                     "[pairing] Paired with {} ({})",
-                    trusted.device_name, trusted.device_id
+                    trusted.device_name,
+                    trusted.device_id
                 );
 
                 // Clear token and stop serving
@@ -667,7 +668,8 @@ pub async fn peer_accept_pairing(
     let _ = app.emit("peer:paired", &trusted);
     log::info!(
         "[pairing] Accepted pairing with {} ({})",
-        trusted.device_name, trusted.device_id
+        trusted.device_name,
+        trusted.device_id
     );
 
     Ok(trusted)

--- a/src-tauri/src/commands/peer_sync_engine.rs
+++ b/src-tauri/src/commands/peer_sync_engine.rs
@@ -698,7 +698,9 @@ fn db_get_entries_full(conn: &Connection, ids: &[String]) -> Result<Vec<JournalE
                         mood: r.get(2)?,
                         privacy_mode: r.get(3)?,
                         location_weather: r.get(4)?,
-                        book_id: r.get::<_, Option<String>>(5)?.unwrap_or_else(|| "default".to_string()),
+                        book_id: r
+                            .get::<_, Option<String>>(5)?
+                            .unwrap_or_else(|| "default".to_string()),
                         pinned: r.get::<_, i32>(6)? != 0,
                         created_at: r.get(7)?,
                         updated_at: r.get(8)?,
@@ -894,7 +896,9 @@ fn do_serve_restore(
 
     log::info!(
         "[restore] Serving DB ({} bytes, {} chunks) to {}",
-        total_bytes, total_chunks, client_name
+        total_bytes,
+        total_chunks,
+        client_name
     );
 
     let _ = app.emit(
@@ -1064,7 +1068,9 @@ fn do_full_restore_client(app: &AppHandle, peer_device_id: &str, host: &str) -> 
                 };
                 log::debug!(
                     "[restore] Received chunk {}/{} ({:.1}%)",
-                    chunks_received, total_chunks, pct
+                    chunks_received,
+                    total_chunks,
+                    pct
                 );
                 let _ = app.emit(
                     "peer:restore_progress",
@@ -1084,7 +1090,8 @@ fn do_full_restore_client(app: &AppHandle, peer_device_id: &str, host: &str) -> 
             } => {
                 log::info!(
                     "[restore] Transfer complete: {} bytes in {} chunks",
-                    total_bytes, chunks
+                    total_bytes,
+                    chunks
                 );
                 break;
             }
@@ -1696,7 +1703,9 @@ fn do_sync_client(app: &AppHandle, peer_device_id: &str, host: &str) -> Result<(
         Msg::NotTrusted { server_device_id } => {
             // The server no longer has us in its trusted list — auto-revoke it
             // from our side so both devices are in sync without manual intervention.
-            log::warn!("[sync] Client: server {server_device_id} does not trust us — auto-revoking");
+            log::warn!(
+                "[sync] Client: server {server_device_id} does not trust us — auto-revoking"
+            );
             let _ = remove_trusted_device(app, peer_device_id);
             let _ = app.emit(
                 "peer:peer_revoked_us",

--- a/src-tauri/src/commands/time_capsule.rs
+++ b/src-tauri/src/commands/time_capsule.rs
@@ -87,40 +87,36 @@ pub fn get_due_capsules(
          LIMIT 1"
     );
 
-    let result = conn.query_row(
-        &sql,
-        [],
-        |row| {
-            let content_json: String = row.get(1)?;
-            let sealed_until: Option<String> = row.get(9)?;
-            let capsule_type: Option<String> = row.get(10)?;
-            let linked_original_id: Option<String> = row.get(11)?;
-            let unsealed_at: Option<String> = row.get(12)?;
-            let tags_str: Option<String> = row.get(13)?;
+    let result = conn.query_row(&sql, [], |row| {
+        let content_json: String = row.get(1)?;
+        let sealed_until: Option<String> = row.get(9)?;
+        let capsule_type: Option<String> = row.get(10)?;
+        let linked_original_id: Option<String> = row.get(11)?;
+        let unsealed_at: Option<String> = row.get(12)?;
+        let tags_str: Option<String> = row.get(13)?;
 
-            let encrypted_content: EncryptedContent = serde_json::from_str(&content_json)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+        let encrypted_content: EncryptedContent = serde_json::from_str(&content_json)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
 
-            Ok(JournalEntryRow {
-                id: row.get(0)?,
-                encrypted_content: Some(encrypted_content),
-                mood: row.get(2)?,
-                privacy_mode: row.get(3)?,
-                location_weather: row.get(4)?,
-                book_id: row
-                    .get::<_, Option<String>>(5)?
-                    .unwrap_or_else(|| "default".to_string()),
-                pinned: row.get::<_, i32>(6)? != 0,
-                created_at: row.get(7)?,
-                updated_at: row.get(8)?,
-                sealed_until,
-                capsule_type,
-                linked_original_id,
-                unsealed_at,
-                tags: parse_tags(tags_str),
-            })
-        },
-    );
+        Ok(JournalEntryRow {
+            id: row.get(0)?,
+            encrypted_content: Some(encrypted_content),
+            mood: row.get(2)?,
+            privacy_mode: row.get(3)?,
+            location_weather: row.get(4)?,
+            book_id: row
+                .get::<_, Option<String>>(5)?
+                .unwrap_or_else(|| "default".to_string()),
+            pinned: row.get::<_, i32>(6)? != 0,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
+            sealed_until,
+            capsule_type,
+            linked_original_id,
+            unsealed_at,
+            tags: parse_tags(tags_str),
+        })
+    });
 
     match result {
         Ok(entry) => Ok(Some(entry)),
@@ -190,5 +186,8 @@ pub fn get_mood_delta(
         )
         .unwrap_or(None);
 
-    Ok(MoodDelta { avg_since, mood_today })
+    Ok(MoodDelta {
+        avg_since,
+        mood_today,
+    })
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -194,7 +194,6 @@ pub fn map_entry_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<JournalEntryRo
     })
 }
 
-
 /// Database state managed by Tauri
 pub struct Database {
     pub conn: Mutex<Connection>,
@@ -273,13 +272,22 @@ impl Database {
         );
 
         // Runtime migrations: time capsule columns
-        let _ = conn.execute("ALTER TABLE journal_entries ADD COLUMN sealed_until TEXT", []);
-        let _ = conn.execute("ALTER TABLE journal_entries ADD COLUMN capsule_type TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE journal_entries ADD COLUMN sealed_until TEXT",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE journal_entries ADD COLUMN capsule_type TEXT",
+            [],
+        );
         let _ = conn.execute(
             "ALTER TABLE journal_entries ADD COLUMN linked_original_id TEXT",
             [],
         );
-        let _ = conn.execute("ALTER TABLE journal_entries ADD COLUMN unsealed_at TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE journal_entries ADD COLUMN unsealed_at TEXT",
+            [],
+        );
 
         // Runtime migration: media attachments table
         conn.execute_batch(
@@ -1092,9 +1100,7 @@ pub fn get_full_analytics_bundle(
 
     // Mood distribution
     let mut dist_stmt = conn
-        .prepare(
-            "SELECT mood, COUNT(*) as count FROM journal_entries GROUP BY mood ORDER BY mood",
-        )
+        .prepare("SELECT mood, COUNT(*) as count FROM journal_entries GROUP BY mood ORDER BY mood")
         .map_err(|e| format!("Distribution prepare failed: {}", e))?;
 
     let mood_distribution = dist_stmt
@@ -1110,7 +1116,13 @@ pub fn get_full_analytics_bundle(
 
     // Day of week stats
     let day_names = [
-        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
     ];
     let mut dow_stmt = conn
         .prepare(
@@ -1125,7 +1137,10 @@ pub fn get_full_analytics_bundle(
             let dow: i32 = row.get(0)?;
             Ok(DayOfWeekStats {
                 day_of_week: dow,
-                day_name: day_names.get(dow as usize).unwrap_or(&"Unknown").to_string(),
+                day_name: day_names
+                    .get(dow as usize)
+                    .unwrap_or(&"Unknown")
+                    .to_string(),
                 average_mood: row.get(1)?,
                 entry_count: row.get(2)?,
             })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,7 +48,8 @@ pub fn run() {
                 if pending.exists() {
                     log::info!(
                         "[restore] Applying pending DB restore: {:?} → {:?}",
-                        pending, db_path
+                        pending,
+                        db_path
                     );
                     if let Err(e) = std::fs::rename(&pending, &db_path) {
                         log::error!("[restore] WARNING: failed to apply pending DB: {e}");
@@ -87,7 +88,10 @@ pub fn run() {
                     "debug" => log::LevelFilter::Debug,
                     other => {
                         if !other.is_empty() {
-                            log::warn!("[startup] unknown log_level {:?}, defaulting to Warn", other);
+                            log::warn!(
+                                "[startup] unknown log_level {:?}, defaulting to Warn",
+                                other
+                            );
                         }
                         log::LevelFilter::Warn
                     }


### PR DESCRIPTION
## Summary

- **npm audit HIGH CVE**: Patched `picomatch` (method injection + ReDoS) and `brace-expansion` via `npm audit fix`. Remaining 4 vulns are `moderate` (esbuild/vite) and require a breaking Vite 8 upgrade — they don't block the `--audit-level=high` gate.
- **Sidecar stub failures (Windows/macOS)**: `src-tauri/binaries/` is gitignored so it doesn't exist in CI. The stub creation step in `test.yml` was missing `mkdir -p` before the `touch`, causing exit 1.
- **Linux `cargo check` panic**: The stub creation step had `if: matrix.os != 'ubuntu-latest'`, so Linux never got a stub. `tauri-build` then panicked at `build.rs:10` because the sidecar path didn't exist.
- **Linux build failure (`build.yml`)**: Same root cause — `mkdir -p` was missing before the `cp` of the built whisper binary.
- **`cargo fmt --check` failure**: Multiple Rust files across `peer_discovery.rs`, `peer_pairing.rs`, `peer_sync_engine.rs`, `time_capsule.rs`, `db/mod.rs`, and `lib.rs` didn't pass `rustfmt`. Applied `cargo fmt` to resolve.

## Test plan

- [x] `npm audit --audit-level=high` exits 0
- [x] `cargo fmt --check` exits 0
- [x] 550 frontend tests pass
- [x] Pre-existing typecheck errors in `useInsights.test.ts` confirmed present on `main` before this branch (not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)