### PR TITLE
feat: Android Wear OS companion + phone bridge polish pass (v0.7.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.15] — 2026-04-02
+
+### Fixed
+- **Wear OS companion: MoodHistory crash on unknown mood level.** `MoodHistory.Entry.mood` now falls back by `level == 3` (neutral) rather than `MOODS[2]` array index, making it safe if mood order changes.
+- **Wear OS companion: AudioFrameParser path traversal.** Frame IDs from the watch are now sanitized (non-alphanumeric characters replaced with `_`) before being used as filenames. Empty audio frames are rejected.
+- **Wear OS companion: channel close failures logged.** `WearListenerService` and `WearPlugin` now log a warning when `channelClient.close()` fails instead of swallowing the error silently.
+- **Wear OS companion: complication cache visibility.** `MoodComplicationService` cache fields marked `@Volatile` for correct visibility across coroutine dispatchers.
+
+### Changed
+- **Wear OS companion: polish pass.** Addresses correctness and reliability issues across the Android phone bridge and Wear OS watch app. Key changes: `AudioFrameParser` extracted as a single parsing source of truth used by both `WearListenerService` (background) and `WearPlugin` (foreground); wire protocol constants consolidated into `WearProtocol`; `BreatheSessionActivity` busy-wait replaced with `AtomicBoolean` + `Channel(CONFLATED)` for correct pause/resume; `OfflineQueue` eviction changed from O(n) to O(1) `ArrayDeque`; `SignalSender` now retries with 250/500/1000 ms exponential backoff; `MoodComplicationService` adds 30-second SharedPrefs cache; `HistoryAdapter` extracted into `MoodHistoryAdapter` for reuse across `HistoryActivity` and `HistoryFragment`; `MoodAdapter` reuses existing `GradientDrawable` instead of allocating per bind.
+
+---
+
 ## [0.7.14] — 2026-04-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p><strong>A calm, encrypted desktop journal with mood tracking, AI insights, and local peer sync</strong></p>
 
 <p>
-<a href="https://github.com/kenlacroix/moodhaven-journal/releases"><img src="https://img.shields.io/badge/version-0.7.14-7c3aed?style=flat-square" alt="Version"></a>
+<a href="https://github.com/kenlacroix/moodhaven-journal/releases"><img src="https://img.shields.io/badge/version-0.7.15-7c3aed?style=flat-square" alt="Version"></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" alt="License"></a>
 <a href="#installation"><img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-0ea5e9?style=flat-square" alt="Platform"></a>
 <a href="#tech-stack"><img src="https://img.shields.io/badge/tests-585%20passing-22c55e?style=flat-square" alt="Tests"></a>
@@ -76,10 +76,10 @@ Grab the latest build from the [Releases](https://github.com/kenlacroix/moodhave
 
 | Platform | Installer | Minimum Version |
 |:---|:---|:---|
-| **Windows** | `MoodHaven_0.7.14_x64-setup.exe` | Windows 10 |
-| **macOS** | `MoodHaven_0.7.14_x64.dmg` | macOS 10.15 Catalina |
-| **Linux** | `moodhaven_0.7.14_amd64.AppImage` | Any modern distro |
-| **Linux (Debian)** | `moodhaven_0.7.14_amd64.deb` | Ubuntu 22.04+ |
+| **Windows** | `MoodHaven_0.7.15_x64-setup.exe` | Windows 10 |
+| **macOS** | `MoodHaven_0.7.15_x64.dmg` | macOS 10.15 Catalina |
+| **Linux** | `moodhaven_0.7.15_amd64.AppImage` | Any modern distro |
+| **Linux (Debian)** | `moodhaven_0.7.15_amd64.deb` | Ubuntu 22.04+ |
 
 ### First Launch
 
@@ -331,6 +331,7 @@ See [CLAUDE.md](CLAUDE.md) for architectural decisions, security guidelines, and
 
 ## Recent Changes
 
+**v0.7.15** — Android Wear OS companion + phone bridge polish: AudioFrameParser extracted as single parsing source of truth, WearProtocol constants object, BreatheSession busy-wait replaced with AtomicBoolean + Channel(CONFLATED), OfflineQueue O(1) eviction, SignalSender exponential backoff retries, MoodComplicationService 30s cache, MoodHistoryAdapter extracted; 5 adversarial review fixes (path traversal guard, @Volatile cache, neutral mood fallback)
 **v0.7.14** — SettingsPage split from 2239-line monolith into 7 focused tab components (GeneralTab, PrivacyTab, SyncTab, AITab, HealthTab, ExportTab, AboutTab); 6 Rust `#[cfg(test)]` unit tests for time capsule seal/unseal logic
 **v0.7.13** — Selective export with tag/mood/date filters and live entry count, `EntryStateBadge` with optimistic UI and `thinking/complete/revisit` states, date comparison fix for filtered exports, credentials stripped from filtered backup files, tags sourced from all books in export picker, 585 tests
 **v0.7.12** — ISO week utilities (`getISOWeekStart`, `countEntriesThisWeek`), 8 new tests for SelectiveExportPanel, `motion-safe:` prefixed on mood-pop animation

--- a/TODOS.md
+++ b/TODOS.md
@@ -158,6 +158,16 @@
 
 ---
 
+## Android Wear Companion (feat/android-wear-companion-polish — v0.7.15)
+
+### WEAR-001: Enable BuildConfig generation in wear module (P3)
+**What:** Add `buildFeatures { buildConfig = true }` to `src-tauri/gen/android/wear/build.gradle.kts` and replace the hardcoded `"com.moodbloom.app"` string in `MoodTileService.kt` with `BuildConfig.APPLICATION_ID`.
+**Why:** `MoodTileService.kt:118` currently has a hardcoded `setPackageName("com.moodbloom.app")` string. If the app's `applicationId` ever changes, this silently breaks tile launch without a compile error. `BuildConfig` is the safe derived constant.
+**Context:** Attempted during companion polish pass (2026-04-02) but BuildConfig generation is not enabled in the wear module's `build.gradle.kts`, causing an unresolved reference. Deferred — the hardcoded value matches the actual applicationId in `build.gradle.kts`.
+**Effort:** human ~15min / CC+gstack ~5min
+
+---
+
 ## Settings Refactor (refactor/settings-page-split-and-capsule-tests — v0.7.14)
 
 ### SETTINGS-001: Extract `use2FASetup` hook (P3)

--- a/active-plans/feat-android-companion-polish.md
+++ b/active-plans/feat-android-companion-polish.md
@@ -1,0 +1,523 @@
+<!-- /autoplan restore point: /home/ken/.gstack/projects/kenlacroix-moodhaven-journal/main-autoplan-restore-20260402-125811.md -->
+# Plan: Android Companion Polish Pass
+
+## Summary
+A focused quality pass on both the Android phone bridge app (`src-tauri/gen/android/app/`) and the Wear OS companion app (`src-tauri/gen/android/wear/`). The apps are functionally complete and run in dev mode; this pass hardens error handling, eliminates code duplication, fixes known bugs, and tightens timing-sensitive logic before release builds are cut.
+
+## Motivation
+Both apps were built feature-first. Core functionality works. The gaps are in polish: duplicated logic, hardcoded constants that should be in BuildConfig, missing null-safety, silent error swallowing, and a handful of actual bugs (SyncFragment shows wrong count, BreatheSessionActivity busy-waits, MoodHistory throws on unknown mood level). These are the kinds of issues that manifest in the field, not in dev.
+
+## Scope
+
+### Android Phone App (`src-tauri/gen/android/app/`)
+
+**P1 — Bugs / Correctness**
+- `WearListenerService` + `WearPlugin`: duplicate audio-parsing logic (parsing framing header, extracting metadata) — extract to shared `AudioFrameParser` helper object
+- `WearPlugin`: `_instance` volatile with no actual thread safety guarantee — simplify to object singleton or companion (Tauri init is single-threaded)
+- `WearPlugin`: `json.optString("id", UUID.randomUUID().toString())` when replaying buffer loses original ID if JSON was malformed — validate JSON at enqueue time in `WearSignalBuffer` instead
+
+**P2 — Hardening**
+- `BiometricPlugin`: unsafe cast `activity as FragmentActivity` (lines 112, 174) — guard with `activity as? FragmentActivity ?: return`
+- `BiometricPlugin`: empty `catch (_: Exception) {}` for KeyStore errors — log via `Log.w()`
+- `WearListenerService`: no cleanup of stale audio files in `voice_memos_incoming/` if bridge fails — add file deletion on failure path
+- `WearListenerService`: no validation of metadata JSON size — add a `byteArray.size > 1_048_576` guard before parsing
+- `WearSignalBuffer`: malformed JSON replayed as-is and fails silently in `drainBuffer()` — validate JSON in `enqueue()`, log and discard on parse failure
+
+**P3 — Constants / Build Config**
+- `WearListenerService`, `WearPlugin`, `FeedbackService`, `RecordFragment`: scattered hardcoded path strings (`/audio_channel`, `/signal`, `/feedback`) — centralize in `WearProtocol` constants object
+- `MoodTileService` + `TileActionActivity`: hardcoded `"com.moodbloom.app"` package name — replace with `BuildConfig.APPLICATION_ID`
+
+---
+
+### Wear OS App (`src-tauri/gen/android/wear/`)
+
+**P1 — Bugs / Correctness**
+- `SyncFragment` line 121: `val total = voiceSent` — button text should be `voiceSent + moodSent`; currently under-reports
+- `MoodHistory`: `MOODS.first { it.level == moodLevel }` throws `NoSuchElementException` if mood level is out of range — use `firstOrNull() ?: MOODS[2]` (neutral fallback)
+- `MoodHistory`: `load(prefs)` called twice (lines 43–44) — `val existing = load(prefs)` and reuse
+- `TileActionActivity`: activity finishes even if signal send fails (line 25 `toIntOrNull()` returns null, `finish()` called unconditionally) — show error haptic and delay finish on failure
+
+**P2 — Hardening / Race Conditions**
+- `BreatheSessionActivity`: `while (isPaused) delay(50)` busy-wait loop — replace with `Mutex`/`Channel` or `suspendCancellableCoroutine` conditional suspend
+- `BreatheSessionActivity`: `vibrate()` called in coroutine without activity-alive check — wrap with `if (lifecycle.currentState.isAtLeast(STARTED))`
+- `BreatheSessionActivity`: `@Volatile isPaused` with no synchronization — switch to `AtomicBoolean` for correct memory model
+- `BreatheSummaryActivity`: auto-dismiss at 6s racy if user taps exactly at boundary — `if (!userInteracted && isActive)` in coroutine
+- `BreatheRingView`: `setModeColor()` calls `Color.parseColor()` without try-catch — add catch, fall back to `Color.parseColor("#8b5cf6")`
+- `BreatheModeDetailActivity`: `btnBegin.isEnabled = false` but no timeout to re-enable if `HealthSnapshot.capture()` hangs — add 12s coroutine timeout with `withTimeoutOrNull`
+- `RecordingSession`: `onAutoStop` callback posted to main thread without fragment-alive guard — check `callback != null && activity?.isDestroyed == false`
+
+**P3 — Duplication / Code Quality**
+- `HistoryActivity.HistoryAdapter` + `HistoryFragment` both implement mood-tap list — extract to `MoodHistoryAdapter` in shared file
+- `BreatheFragment`: `Calendar.getInstance().get(HOUR_OF_DAY)` — use `LocalTime.now().hour` (API 26+, Wear OS 3+ is API 30)
+- `MoodComplicationService`: calls `MoodHistory.load()` on every complication update — add 30s in-memory cache (field + timestamp)
+- `MoodAdapter`: `GradientDrawable` created on every `onBindViewHolder` — create once per bind and recycle or use `setBackgroundColor`
+- `OfflineQueue`: `takeLast(MAX_ENTRIES)` O(n) on full queue — use `ArrayDeque` with `removeFirst()` instead of `ConcurrentLinkedQueue` + `takeLast()`
+
+**P4 — Low-friction Polish**
+- Extract all hardcoded UI strings to `wear/src/main/res/values/strings.xml`: "Log mood", "Syncing…", "Sync now", "Recording…", haptic feedback labels
+- Hardcoded `"com.moodbloom.wear"` in any cross-process references — replace with `BuildConfig.APPLICATION_ID`
+- `HealthSnapshot`: downgrade post-timeout `Log.d()` to `Log.i()` for visibility in field logs
+- `SignalSender.drainAndSend()`: add exponential backoff (250ms, 500ms, 1s) before giving up — currently retries all at once on every app-open
+
+---
+
+## Files Touched
+
+### Phone App
+| File | Change |
+|------|--------|
+| `app/src/main/java/com/moodbloom/app/WearListenerService.kt` | Extract audio framing to `AudioFrameParser`, add size validation, add cleanup on failure |
+| `app/src/main/java/com/moodbloom/app/WearPlugin.kt` | Use `AudioFrameParser`, simplify singleton, fix UUID fallback |
+| `app/src/main/java/com/moodbloom/app/WearSignalBuffer.kt` | Validate JSON at enqueue time |
+| `app/src/main/java/com/moodbloom/app/BiometricPlugin.kt` | Safe cast, log KeyStore exceptions |
+| `app/src/main/java/com/moodbloom/app/WearProtocol.kt` | **New file**: path constants (`/audio_channel`, `/signal`, `/feedback`) |
+
+### Wear OS App
+| File | Change |
+|------|--------|
+| `wear/src/main/java/com/moodbloom/wear/SyncFragment.kt` | Fix `total = voiceSent + moodSent` |
+| `wear/src/main/java/com/moodbloom/wear/MoodHistory.kt` | `firstOrNull()` fallback, deduplicate `load()` call |
+| `wear/src/main/java/com/moodbloom/wear/TileActionActivity.kt` | Error haptic + delayed finish on send failure |
+| `wear/src/main/java/com/moodbloom/wear/BreatheSessionActivity.kt` | `AtomicBoolean`, `Channel`-based pause, lifecycle guard on vibrate |
+| `wear/src/main/java/com/moodbloom/wear/BreatheSummaryActivity.kt` | `isActive` guard on auto-dismiss |
+| `wear/src/main/java/com/moodbloom/wear/BreatheRingView.kt` | try-catch in `setModeColor()` |
+| `wear/src/main/java/com/moodbloom/wear/BreatheModeDetailActivity.kt` | `withTimeoutOrNull(12_000)` on HR capture |
+| `wear/src/main/java/com/moodbloom/wear/RecordingSession.kt` | Fragment-alive guard in `onAutoStop` |
+| `wear/src/main/java/com/moodbloom/wear/MoodHistoryAdapter.kt` | **New file**: extracted from HistoryActivity + HistoryFragment |
+| `wear/src/main/java/com/moodbloom/wear/HistoryActivity.kt` | Use `MoodHistoryAdapter` |
+| `wear/src/main/java/com/moodbloom/wear/HistoryFragment.kt` | Use `MoodHistoryAdapter`, fix `onResume()` re-inflation |
+| `wear/src/main/java/com/moodbloom/wear/BreatheFragment.kt` | `LocalTime.now().hour` |
+| `wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt` | 30s in-memory cache |
+| `wear/src/main/java/com/moodbloom/wear/MoodAdapter.kt` | Fix `GradientDrawable` allocation in `onBindViewHolder` |
+| `wear/src/main/java/com/moodbloom/wear/OfflineQueue.kt` | `ArrayDeque` for O(1) eviction |
+| `wear/src/main/java/com/moodbloom/wear/SignalSender.kt` | Backoff on `drainAndSend()` |
+| `wear/src/main/res/values/strings.xml` | Extract hardcoded UI strings |
+
+## Out of Scope
+- New features (Phase 3–5 of watch roadmap: journal creation from watch, sync relay)
+- Unit tests (neither app has a test harness; adding one is a separate task)
+- i18n beyond English string extraction
+- Kotlin/Jetpack Compose migration (Wear Compose is a separate effort)
+- Android phone app UI (MainActivity.kt is a thin Tauri wrapper; the UI is the Tauri WebView)
+
+## Success Criteria
+- No `NoSuchElementException` from `MoodHistory` on any mood level value
+- SyncFragment shows correct combined count
+- BreatheSession pause/resume cycle passes manual test (no stuck state)
+- No hardcoded package names in Kotlin source
+- `AudioFrameParser` is the single source of truth for framing protocol parsing
+- All P1 bugs addressed; all P2 items addressed; P3/P4 addressed where trivial
+
+## Effort
+- Human: ~1 day
+- CC+gstack: ~45 min
+
+---
+
+# /autoplan Review
+
+## Phase 1: CEO Review
+
+### Step 0A — Premise Challenge
+
+| Premise | Status | Verdict |
+|---------|--------|---------|
+| `gen/android/` is owned source, never regenerated | Confirmed by user | Valid |
+| Apps are functionally complete, only polish needed | Validated by full code read — no stubs, no missing flows | Valid |
+| Phone app UI needs no attention (Tauri WebView) | MainActivity is 15-line stub | Valid |
+| Tests out of scope (no existing test harness) | Confirmed — no test dirs in gen/android | Valid |
+| minSdk 24 (phone) / minSdk 30 (wear) | Confirmed from build.gradle files | Valid; `LocalTime` change is wear-only (min 30), safe |
+| BiometricPlugin is live, not dead code | Not validated by plan; subagent raised concern | **Soft risk** — see Decision #4 |
+
+### Step 0B — Existing Code Leverage Map
+
+| Sub-problem | Existing code | Gap |
+|------------|---------------|-----|
+| Audio framing protocol | `AudioTransferService.kt` (watch), `WearListenerService.kt` (phone) | Parsing logic duplicated — need `AudioFrameParser` |
+| Signal buffering | `WearSignalBuffer.kt` | Solid; needs JSON-at-enqueue validation |
+| Mood persistence (watch) | `OfflineQueue.kt` | O(n) eviction; `ArrayDeque` fix is mechanical |
+| Mood history display | `HistoryActivity.HistoryAdapter` + `HistoryFragment` | Duplicated adapter — extract `MoodHistoryAdapter` |
+| Protocol path constants | Scattered strings in 5 files | `WearProtocol.kt` needed |
+| Breathe session state | `BreatheSessionActivity.kt` | Volatile + busy-wait — needs `AtomicBoolean` + `Channel` |
+| Transfer failure visibility | `SyncFragment.kt` | **Missing** — no error state when transfer fails (added to plan below) |
+
+### Step 0C — Dream State Diagram
+
+```
+CURRENT (dev mode only)
+  ├── 3 P1 bugs: SyncFragment under-counts, MoodHistory throws, TileActivity silent failure
+  ├── Dual audio-parsing logic (2 files must be kept in sync)
+  ├── Hardcoded "/audio_channel", "/signal", "/feedback" and "com.moodbloom.app" in 5+ places
+  ├── BreatheSession: volatile + busy-wait (incorrect memory model, spins CPU)
+  └── Transfer failure: user sees nothing
+
+THIS PLAN → v1.0 release candidate
+  ├── P1 bugs fixed
+  ├── AudioFrameParser: single parse path, both WearPlugin and WearListenerService use it
+  ├── WearProtocol: all path constants in one place
+  ├── BreatheSession: AtomicBoolean + Channel-based pause (correct + efficient)
+  ├── SyncFragment: shows error state when transfer fails (added by review)
+  └── All hardcoded package names use BuildConfig.APPLICATION_ID
+
+12-MONTH IDEAL (beyond this plan)
+  ├── Watch can queue + preview voice memos independently
+  ├── Pipeline health screen: Setup → Connected → Synced → Error
+  ├── Possible native Tauri Android (bridge becomes optional or removed)
+  └── Complication shows sync status + mood, not just last mood
+```
+
+Delta: this plan closes the gap between "works in dev" and "shippable release build".
+
+### Step 0D — Mode: HOLD SCOPE
+
+Polish pass. No feature additions. Cherry-pick one blast-radius expansion: SyncFragment transfer failure error state (already touches SyncFragment, 20 lines). All other expansions deferred to roadmap.
+
+### Step 0E — Temporal Interrogation
+
+| Phase | Work | Risk |
+|-------|------|------|
+| Hour 1–2 | Fix 3 P1 bugs | Low — surgical changes |
+| Hour 2–4 | Extract AudioFrameParser, WearProtocol, MoodHistoryAdapter | Medium — refactor touches 5 files |
+| Hour 4–6 | BreatheSession AtomicBoolean + Channel pause | Medium — concurrent code, needs manual test |
+| Hour 6–8 | BiometricPlugin null safety, WearSignalBuffer JSON validation, lifecycle guards | Low |
+| Hour 8+ | P3/P4: ArrayDeque, string extraction, BuildConfig package names | Low — mechanical |
+
+### Step 0F — Mode Confirmed: HOLD SCOPE + 1 blast-radius expansion
+
+---
+
+### CEO DUAL VOICES — CONSENSUS TABLE [subagent-only]
+
+```
+CEO DUAL VOICES — CONSENSUS TABLE:
+═══════════════════════════════════════════════════════════════
+  Dimension                           Claude  Codex  Consensus
+  ──────────────────────────────────── ─────── ─────── ─────────
+  1. Premises valid?                   YES     N/A    [subagent-only]
+  2. Right problem to solve?           YES*    N/A    [subagent-only]
+  3. Scope calibration correct?        YES*    N/A    [subagent-only]
+  4. Alternatives sufficiently explored? YES   N/A    [subagent-only]
+  5. Competitive/market risks covered? WARN    N/A    [subagent-only]
+  6. 6-month trajectory sound?         WARN    N/A    [subagent-only]
+═══════════════════════════════════════════════════════════════
+* = with minor additions (see decisions below)
+WARN = flagged but auto-decided to proceed (see decisions)
+```
+
+---
+
+### CEO Sections 1–10
+
+**Section 1 — Problem Statement**
+The problem is well-defined: harden before release. The subagent's reframe ("pipeline health UX is the real adoption blocker") is valid but is a product expansion, not a correctness issue. This plan's scope is code quality. The product adoption concern is noted as a roadmap item. No action required within this plan.
+
+**Section 2 — Error & Rescue Registry**
+
+| Error | Where | Current behavior | Fixed behavior |
+|-------|-------|-----------------|----------------|
+| `NoSuchElementException` on unknown mood level | `MoodHistory.kt:26` | Crash | `firstOrNull() ?: MOODS[2]` |
+| SyncFragment shows wrong total | `SyncFragment.kt:121` | Under-reports (voice only) | `voiceSent + moodSent` |
+| TileActivity silent failure on send error | `TileActionActivity.kt:25` | Finishes silently | Error haptic + delayed finish |
+| Biometric unsafe cast crash | `BiometricPlugin.kt:112,174` | Crash if not FragmentActivity | Safe-cast with early return |
+| KeyStore errors silently swallowed | `BiometricPlugin.kt:240` | No log | `Log.w()` |
+| BreatheSession stuck on pause | `BreatheSessionActivity.kt:148` | Busy-wait with `delay(50)` | `Channel`-based conditional suspend |
+| Vibrate called on dead activity | `BreatheSessionActivity.kt:114` | Potential crash | Lifecycle `isAtLeast(STARTED)` guard |
+| `BreatheRingView.setModeColor()` throws | `BreatheRingView.kt:32` | Crash on invalid hex | try-catch + fallback color |
+| HR capture hangs indefinitely | `BreatheModeDetailActivity.kt:69` | Button stuck disabled | `withTimeoutOrNull(12_000)` |
+| JSON malformed in signal buffer | `WearSignalBuffer.kt` | Replayed as-is, fails in drainBuffer | Validate at enqueue, discard with log |
+| Transfer failure invisible to user | `SyncFragment` | No error state | Error state added (new) |
+
+**Section 3 — Failure Modes Registry**
+
+| Failure Mode | Severity | Detection | Mitigation |
+|-------------|----------|-----------|-----------|
+| Both AudioFrameParser refactors diverge post-refactor | High | Code review | Single class, both callers |
+| `WearProtocol` path constants not updated everywhere | High | grep at PR time | 5 files identified in plan |
+| AtomicBoolean swap breaks pause UX | Medium | Manual breathe test | Manual test in success criteria |
+| MoodHistoryAdapter extraction misses edge case | Low | HistoryActivity + HistoryFragment behavior match | Visual check |
+| `withTimeoutOrNull(12_000)` too short for slow HR read | Low | Field report | 12s is generous; adjustable |
+
+**Section 4 — Business Impact**
+This plan directly enables release APK cuts. Without P1 fixes, the app crashes in the field. Without P2, race conditions will manifest on physical watch hardware (coroutine timing is less predictable on wearable SOCs than on emulator). Impact is clear: no release without this.
+
+**Section 5 — User Impact**
+Three flows are directly broken today:
+- User sees wrong sync count → confusion → assumes sync failed even when it didn't.
+- MoodHistory crashes → History screen blank → user thinks app is broken.
+- BreatheSession can get stuck → user holds wrist in breathe pose forever.
+All three are P1. All three are fixed.
+
+**Section 6 — Technical Debt**
+`AudioFrameParser` extraction is the most important debt item. The framing protocol (4-byte BE length + metadata JSON + audio bytes) is currently in two files. If the wire format ever changes, both must be updated in sync. This is a latent bug factory. Eliminating it is worth the refactor cost.
+
+**Section 7 — Dependencies**
+No external dependencies added. All changes are within `gen/android/`. No Tauri command changes required. No Rust changes required.
+
+**Section 8 — Risk Assessment**
+Highest-risk change: `BreatheSessionActivity` concurrency rewrite. This is real concurrent code that affects UX in a timing-sensitive way. Mitigation: manual breathe test in success criteria.
+
+Second-highest: `AudioFrameParser` extraction — refactoring parse logic shared across two files is easy to get 95% right and break the 5% edge case. Mitigation: test a recording transfer end-to-end after refactor.
+
+**Section 9 — What Exists vs What's New**
+Everything in P1–P4 modifies existing code. Two new files: `WearProtocol.kt` (constants, no logic) and `MoodHistoryAdapter.kt` (extracted, no new logic). No new dependencies. No new Tauri commands.
+
+**Section 10 — NOT In Scope**
+- Pipeline health check / setup wizard (roadmap)
+- Tauri Android maturity spike (acknowledged; user can do async)
+- Physical device test gate (beyond plan scope — success criteria use build-time checks)
+- Usage telemetry to justify P3/P4 (apply P1: completeness — the bugs are real regardless)
+- Phase 3–5 watch features (separate plan)
+- Test harness (separate plan)
+
+**What Already Exists**
+- All 35 Kotlin files listed in "Files Touched" exist in the repo
+- `AudioTransferService` implements the framing protocol (source for `AudioFrameParser`)
+- `HistoryActivity.HistoryAdapter` is the source for `MoodHistoryAdapter`
+- `SharedPreferences` used consistently throughout — no SQLite in Android/Wear apps
+
+### CEO Completion Summary
+
+| Item | Decision |
+|------|----------|
+| Mode | HOLD SCOPE |
+| Premises | All valid (6/6) |
+| P1 bugs | 3 confirmed, all in plan |
+| P2 hardening | 8 items, all valid |
+| P3/P4 cleanup | All mechanical, proceed |
+| Blast-radius expansion | SyncFragment transfer failure error state (added) |
+| Deferred to roadmap | Pipeline health UX, Tauri Android spike, physical device gate |
+| Dual voices | Subagent only (Codex unavailable) |
+
+---
+
+## Phase 1 → Phase 2 Transition
+
+Phase 1 complete. Subagent: 6 concerns (2 critical/high addressed by auto-decision, 4 high/medium → 1 in-scope addition, 3 deferred to roadmap). No user challenges. Passing to Phase 2 (Design).
+
+---
+
+## Phase 2: Design Review
+
+### Design Scope
+This plan touches 3 visual components on Wear OS: `ArcProgressView`, `BreatheRingView`, `TileActionActivity` (full-screen confirmation). UI scope is confirmed — the plan modifies Fragment/Activity code but most changes are behavioral, not visual. Design review focuses on interaction states and wearable UX patterns.
+
+### Design Litmus Scorecard [subagent-only]
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| 1. Information hierarchy | 7/10 | SyncFragment page (page 4) is information-dense for a small screen. Queue counts, connection status, sync time all compete. |
+| 2. Interaction states (loading/error/empty) | 4/10 | **Gap.** Transfer failure has no error state (being added). Breathe HR capture shows "…" with no timeout feedback. TileActivity confirmation relies solely on color (not accessible). |
+| 3. Responsive strategy | 8/10 | Round/square watch face handled by `WearableRecyclerView`. No issues. |
+| 4. Accessibility | 5/10 | Haptic feedback is sole error signal in TileActivity. No content descriptions on mood emoji in tiles/complications. Color-only differentiation (mood colors) is a concern. |
+| 5. User journey | 7/10 | Record → Transfer → Appear on desktop is the core flow. The gap is failure visibility (addressed in plan). |
+| 6. Design system alignment | 6/10 | Mood colors match desktop (`#ef4444`, `#f97316`, `#eab308`, `#84cc16`, `#10b981`). Hardcoded in `MoodPickerScreen.kt` — should verify they match `tailwind.config.js` tokens. |
+| 7. Specificity of UI decisions | 6/10 | Breathe ring animation is well-specified. Tile layout and complication text are correct. Error states under-specified. |
+
+**Design issues auto-decided:**
+
+- `TileActionActivity` shows error only via haptic — add `tvStatus.text = "Not sent"` + red tint on failure path. Completeness 8/10 vs 5/10. → ADD to P1/P2. AUTO-DECIDED (P1: completeness).
+- `MoodPickerScreen.kt` hardcodes mood hex colors — verify they match `tailwind.config.js` tokens. If they match, no action. If not, align to `#10b981`/`#84cc16`/`#eab308`/`#f97316`/`#ef4444`. → ADD verification step. AUTO-DECIDED (P5: explicit over clever).
+- Complication `MoodComplicationService`: empty state shows "Log mood" (hardcoded) — extract to strings.xml already covered by P4 strings extraction. No separate action.
+- Breathe HR capture: `btnBegin.isEnabled = false` with "…" text has no timeout feedback beyond the `withTimeoutOrNull(12_000)` fix already in plan. The fix is sufficient — button re-enables and shows error after timeout. No additional action.
+
+### Phase 2 → Phase 3 Transition
+
+Design complete. 2 additions: TileActivity visual error state, mood color token verification. Codex unavailable; [subagent-only]. Passing to Phase 3.
+
+---
+
+## Phase 3: Eng Review
+
+### Step 0 — Scope Challenge
+
+Read all 35 Kotlin files (via Explore agent + build.gradle check). Code is real, buildable, and matches what the plan claims to modify. No phantom files. All 17 modified files and 2 new files exist or have clear parent context.
+
+Architecture assessment:
+- Phone: `MainActivity → BiometricPlugin + WearPlugin → WearListenerService + WearSignalBuffer`
+- Watch: `MainActivity (ViewPager2) → [History|Record|Mood|Breathe|Sync]Fragment → AudioTransferService + SignalSender + OfflineQueue`
+- Wire protocol: `[4B length][metadata JSON][audio bytes]` — currently in `AudioTransferService.kt` (watch) and parsed again in `WearListenerService.kt` + `WearPlugin.kt` (phone)
+
+### Step 0.5 — Eng Dual Voices [subagent-only]
+
+```
+ENG DUAL VOICES — CONSENSUS TABLE:
+═══════════════════════════════════════════════════════════════
+  Dimension                           Claude  Codex  Consensus
+  ──────────────────────────────────── ─────── ─────── ─────────
+  1. Architecture sound?               YES     N/A    [subagent-only]
+  2. Test coverage sufficient?         N/A*    N/A    [subagent-only]
+  3. Performance risks addressed?      YES     N/A    [subagent-only]
+  4. Security threats covered?         YES     N/A    [subagent-only]
+  5. Error paths handled?              YES**   N/A    [subagent-only]
+  6. Deployment risk manageable?       YES     N/A    [subagent-only]
+═══════════════════════════════════════════════════════════════
+* = No test harness; by design out of scope
+** = with additions from review (error state, TileActivity visual feedback)
+```
+
+### Section 1 — Architecture ASCII Diagram
+
+```
+PHONE APP (Tauri Android)
+┌────────────────────────────────────────────────────┐
+│ MainActivity                                        │
+│   ├── BiometricPlugin (fingerprint → Tauri IPC)    │
+│   └── WearPlugin (singleton, Tauri IPC bridge)     │
+│         ├── ChannelCallback → processAudioChannel()│
+│         │     └── AudioFrameParser (NEW)           │
+│         └── drainBuffer() ← WearSignalBuffer       │
+│                                                     │
+│ WearListenerService (background, Wear Data Layer)  │
+│   ├── onMessageReceived("/signal") → WearPlugin    │
+│   └── onChannelOpened("/audio_channel")            │
+│         └── AudioFrameParser (NEW) ← shared        │
+└────────────────────────────────────────────────────┘
+              ↕ Tauri IPC (invoke/emit)
+┌────────────────────────────────────────────────────┐
+│ Tauri WebView (React/TypeScript frontend)           │
+│   └── useWearVoiceMemos / useWearSignals hooks      │
+└────────────────────────────────────────────────────┘
+
+WEAR OS APP
+┌────────────────────────────────────────────────────┐
+│ MainActivity (ViewPager2, 5 pages)                 │
+│   ├── Page 0: HistoryFragment → MoodHistoryAdapter (NEW) │
+│   ├── Page 1: RecordFragment → RecordingSession    │
+│   │                          → AudioTransferService│
+│   │                              (sends via ChannelAPI) │
+│   ├── Page 2: MoodPickerFragment → SignalSender    │
+│   │                              → OfflineQueue (ArrayDeque) │
+│   ├── Page 3: BreatheFragment → BreatheModeDetailActivity │
+│   │                           → BreatheSessionActivity (AtomicBoolean) │
+│   │                           → BreatheSummaryActivity │
+│   └── Page 4: SyncFragment (shows error state NEW) │
+│                                                     │
+│ MoodTileService / TileActionActivity (Wear Tile)   │
+│ MoodComplicationService (watch face complication)  │
+│ FeedbackService (haptic from phone)                │
+└────────────────────────────────────────────────────┘
+              ↕ Wear Data Layer (ChannelAPI + MessageAPI)
+              ↕
+         [Phone App above]
+```
+
+New coupling introduced: `AudioFrameParser` is imported by both `WearPlugin` and `WearListenerService`. This is a dependency, but it's intentional — it's the whole point of the extraction. Risk: if `AudioFrameParser` has a bug, it fails in both places. Mitigation: the parser is pure (no I/O), making it easy to reason about.
+
+**Section 2 — Code Quality**
+
+DRY violations being fixed:
+- Audio parsing: 2 → 1 (`AudioFrameParser`)
+- HistoryAdapter: 2 → 1 (`MoodHistoryAdapter`)
+- Protocol paths: 5 → 1 (`WearProtocol`)
+- Package name: 3 → 1 (`BuildConfig.APPLICATION_ID`)
+
+New naming introduced: `AudioFrameParser` (parse framing), `WearProtocol` (constants), `MoodHistoryAdapter` (adapter). All follow existing conventions.
+
+**Section 3 — Test Review (no test harness; by design)**
+
+No unit tests exist in `gen/android/`. The plan explicitly excludes adding a test harness. This is a documented decision, not a gap.
+
+Test diagram for manual QA (success criteria checklist):
+
+```
+UX Flow                          Manual Test
+─────────────────────────────────────────────────────
+Record voice memo on watch       Record → transfer arrives in SyncFragment ✓
+Mood tap from tile               TileAction → signal visible in desktop ✓
+Breathe session pause/resume     Pause mid-exhale → resume → session continues ✓
+Breathe session to summary       Complete 3 cycles → summary shows HR delta ✓
+Transfer failure (phone off)     Watch records → SyncFragment shows error state ✓
+History page shows last 10 moods History → scroll → all entries visible ✓
+Mood complication updates        Tap mood → complication updates within 30s ✓
+```
+
+**Section 4 — Performance**
+
+- `OfflineQueue` O(n) eviction → `ArrayDeque.removeFirst()` O(1). Trivial but correct.
+- `GradientDrawable` in `onBindViewHolder` → create once or use `setBackgroundColor`. Reduces object allocation on every scroll.
+- `MoodComplicationService` SharedPrefs on every update → 30s cache. Reduces disk I/O on watch (relevant — watch storage I/O is slower than phone).
+- `MoodHistory.load()` called twice in 2 lines → called once. Trivial.
+- `BreatheSessionActivity` `while (isPaused) delay(50)` → `Channel`-based suspend. Eliminates ~20 coroutine wakeups/second during pause.
+
+All performance changes are improvements. No regressions introduced.
+
+**Section 5 — Security**
+
+From BiometricPlugin review:
+- Unsafe `activity as FragmentActivity` can crash — but does NOT expose data. Fix is stability, not security.
+- IV stored plaintext next to ciphertext in SharedPreferences — standard AES-GCM pattern. No change needed.
+- Biometric key invalidated on new enrollment (`setInvalidatedByBiometricEnrollment(true)`) — correct.
+
+From WearListenerService:
+- Metadata JSON size validation (1MB guard) — added in plan. Good.
+- No signal source verification (any node on Data Layer can send `/signal`) — acceptable risk for a single-user device. Out of scope.
+
+No new attack surface introduced. `WearProtocol` centralizes path strings; if someone were to intercept Data Layer messages, centralization makes the protocol more auditable.
+
+**Section 6 — Deployment Risk**
+
+Low. All changes are within `gen/android/`. No changes to:
+- Rust backend or Tauri commands
+- TypeScript/React frontend
+- SQLite schema
+- Desktop app behavior
+
+The only deployment risk is APK signing — both `app` and `wear` modules must be signed with the same key (Wear OS requirement for phone-watch communication). This is a build configuration concern, not a code concern. Already true today.
+
+### Eng Completion Summary
+
+| Item | Status |
+|------|--------|
+| Architecture diagram | Produced |
+| All 35 files read | Done |
+| P1 bugs validated | All 3 confirmed + TileActivity visual error added |
+| P2 hardening validated | All 8 items correct + BreatheRingView catch verified |
+| P3/P4 validated | All mechanical, correct |
+| New files | `AudioFrameParser.kt`, `WearProtocol.kt`, `MoodHistoryAdapter.kt` |
+| Test plan | Manual QA checklist (7 scenarios) |
+| Performance | 5 improvements, 0 regressions |
+| Security | No new surface; 1 addition (JSON size guard) already in plan |
+| Deployment risk | Low |
+
+---
+
+## Cross-Phase Themes
+
+**Theme: Silent failures** — flagged in CEO (transfer failure UX), Design (TileActivity haptic-only), and Eng (WearSignalBuffer JSON, BiometricPlugin KeyStore swallow). High-confidence signal. Resolution: all silent failures addressed in plan (transfer error state added to SyncFragment, TileActivity gets visual error, JSON validated at enqueue, KeyStore logged).
+
+No other cross-phase themes — remaining concerns were phase-specific.
+
+---
+
+## Decision Audit Trail
+
+| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
+|---|-------|----------|----------------|-----------|-----------|----------|
+| 1 | CEO | Tauri Android maturity spike before hardening | Taste | P6 (bias toward action) | Code exists, runs in dev, user confirmed ownership. Spike is async research, not blocking. Add roadmap note. | Don't block plan on architecture speculation |
+| 2 | CEO | Add SyncFragment transfer failure error state to scope | Mechanical | P2 (boil lakes) | SyncFragment already in plan, ~20 lines, same file | Not adding full pipeline health screen (too large) |
+| 3 | CEO | minSdk validation for LocalTime change | Mechanical | P5 (explicit) | Wear minSdk=30, LocalTime is API 26+. Safe. No action needed. | — |
+| 4 | CEO | Keep BiometricPlugin hardening in scope | Taste | P1 (completeness) | Code exists; unsafe cast is a real crash risk regardless of usage | Remove if biometric is confirmed dead code |
+| 5 | CEO | Keep all Breathe hardening items | Mechanical | P1 (completeness) | Real race conditions regardless of usage data | — |
+| 6 | CEO | Add transfer failure error state to SyncFragment | Mechanical | P2 (boil lakes) | In blast radius; ~20 lines; fixes a user-visible gap | — |
+| 7 | CEO | Physical device test: not a hard gate in success criteria | Taste | P6 (bias toward action) | Release APK build + emulator is the gate; physical device is a follow-up | Blocking release on physical device availability |
+| 8 | Design | Add TileActivity visual error state (text + tint on failure) | Mechanical | P1 (completeness) | Haptic-only error is inaccessible; 5 lines | — |
+| 9 | Design | Verify mood color tokens match tailwind.config.js | Mechanical | P5 (explicit) | Colors hardcoded in MoodPickerScreen — verify match, align if not | — |
+| 10 | Eng | AudioFrameParser as shared pure parser (no I/O) | Mechanical | P5 (explicit) | Pure function; easy to reason about; no hidden state | Stateful parser with buffer |
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/autoplan` | Strategy & scope | 1 | clean | 6 concerns; 4 auto-decided; 2 deferred to roadmap |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | unavailable | Codex not installed |
+| Eng Review | `/autoplan` | Architecture & tests | 1 | clean | 10 auto-decisions; all mechanical |
+| Design Review | `/autoplan` (UI scope) | Wear OS UX gaps | 1 | issues_open | 2 additions: TileActivity visual error, color token verify |
+
+**VERDICT:** REVIEWED. 10 auto-decisions made. 0 user challenges. 2 taste decisions (see gate below). Codex unavailable — single model review. Ready for implementation after approval.
+
+**Additions to plan from review:**
+1. SyncFragment: add transfer failure error state (P2, ~20 lines)
+2. TileActionActivity: add `tvStatus.text = "Not sent"` + red tint on send failure (P1)
+3. Success criteria: verify mood color token match (done — confirmed matching)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moodhaven-journal",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "A calm, secure mood tracking and journaling app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moodhaven-journal"
-version = "0.7.14"
+version = "0.7.15"
 description = "A calm, secure mood tracking and journaling app"
 authors = ["Moodbloom"]
 license = "MIT"

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/AudioFrameParser.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/AudioFrameParser.kt
@@ -1,0 +1,96 @@
+package com.moodbloom.app
+
+import android.util.Log
+import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * AudioFrameParser — single source of truth for the watch-to-phone audio framing protocol.
+ *
+ * Wire format (big-endian):
+ *   [4 bytes]  metadata JSON length (unsigned int)
+ *   [N bytes]  metadata JSON (UTF-8)
+ *     Required fields: id (String), duration_ms (Long)
+ *     Optional fields: timestamp (ISO-8601 String), health (JSON String)
+ *   [remaining] raw .m4a audio bytes
+ *
+ * Both [WearListenerService] (background) and [WearPlugin] (foreground) use this
+ * parser. A bug here affects both paths equally — and is easy to test in isolation.
+ */
+object AudioFrameParser {
+
+    private const val TAG = "AudioFrameParser"
+
+    data class AudioFrame(
+        val id: String,
+        val timestamp: String,
+        val durationMs: Long,
+        val healthJson: String?,
+        val audioBytes: ByteArray,
+    )
+
+    /**
+     * Parse a complete audio frame from [allBytes].
+     *
+     * Returns [AudioFrame] on success, or null with a logged error on failure.
+     */
+    fun parse(allBytes: ByteArray): AudioFrame? {
+        if (allBytes.size < 5) {
+            Log.e(TAG, "Frame too short: ${allBytes.size} bytes (minimum 5)")
+            return null
+        }
+
+        val metaLen: Int = ByteBuffer.wrap(allBytes, 0, 4).order(ByteOrder.BIG_ENDIAN).int
+        if (metaLen <= 0) {
+            Log.e(TAG, "Invalid metadata length: $metaLen")
+            return null
+        }
+        if (metaLen > WearProtocol.MAX_METADATA_BYTES) {
+            Log.e(TAG, "Metadata length $metaLen exceeds ${WearProtocol.MAX_METADATA_BYTES} — rejecting frame")
+            return null
+        }
+        if (metaLen > allBytes.size - 4) {
+            Log.e(TAG, "Metadata length $metaLen overflows frame (total=${allBytes.size})")
+            return null
+        }
+
+        val metaBytes = allBytes.sliceArray(4 until 4 + metaLen)
+        val audioBytes = allBytes.sliceArray(4 + metaLen until allBytes.size)
+
+        val meta = try {
+            JSONObject(String(metaBytes, Charsets.UTF_8))
+        } catch (e: Exception) {
+            Log.e(TAG, "Metadata JSON parse failed: ${e.message}")
+            return null
+        }
+
+        val id = meta.optString("id").takeIf { it.isNotBlank() }
+        if (id == null) {
+            Log.e(TAG, "Frame missing required 'id' field")
+            return null
+        }
+
+        val timestamp = meta.optString("timestamp").takeIf { it.isNotBlank() } ?: nowIso8601()
+        val durationMs = meta.optLong("duration_ms", 0L)
+        val healthJson = meta.optString("health").takeIf { it.isNotBlank() }
+
+        return AudioFrame(
+            id = id,
+            timestamp = timestamp,
+            durationMs = durationMs,
+            healthJson = healthJson,
+            audioBytes = audioBytes,
+        )
+    }
+
+    private fun nowIso8601(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+        sdf.timeZone = TimeZone.getTimeZone("UTC")
+        return sdf.format(Date())
+    }
+}

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/AudioFrameParser.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/AudioFrameParser.kt
@@ -62,6 +62,11 @@ object AudioFrameParser {
         val metaBytes = allBytes.sliceArray(4 until 4 + metaLen)
         val audioBytes = allBytes.sliceArray(4 + metaLen until allBytes.size)
 
+        if (audioBytes.isEmpty()) {
+            Log.e(TAG, "Frame contains no audio bytes (total=${allBytes.size} metaLen=$metaLen)")
+            return null
+        }
+
         val meta = try {
             JSONObject(String(metaBytes, Charsets.UTF_8))
         } catch (e: Exception) {
@@ -69,10 +74,15 @@ object AudioFrameParser {
             return null
         }
 
-        val id = meta.optString("id").takeIf { it.isNotBlank() }
-        if (id == null) {
+        val rawId = meta.optString("id").takeIf { it.isNotBlank() }
+        if (rawId == null) {
             Log.e(TAG, "Frame missing required 'id' field")
             return null
+        }
+        // Sanitize id: only allow alphanumerics, hyphens, and underscores to prevent path traversal
+        val id = rawId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+        if (id != rawId) {
+            Log.w(TAG, "id sanitized: '$rawId' → '$id'")
         }
 
         val timestamp = meta.optString("timestamp").takeIf { it.isNotBlank() } ?: nowIso8601()

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/BiometricPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/BiometricPlugin.kt
@@ -2,6 +2,7 @@ package com.moodbloom.app
 
 import android.app.Activity
 import android.content.Context
+import android.util.Log
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
@@ -20,6 +21,7 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
+private const val TAG = "BiometricPlugin"
 private const val KEY_ALIAS = "MoodBloomBiometricKey"
 private const val PREFS_NAME = "moodbloom_biometric"
 private const val PREF_ENCRYPTED_PW = "encrypted_password"
@@ -100,6 +102,10 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
         }
 
         activity.runOnUiThread {
+            val fa = activity as? FragmentActivity ?: run {
+                invoke.reject("BiometricPlugin requires FragmentActivity")
+                return@runOnUiThread
+            }
             try {
                 val cipher = buildEncryptCipher()
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
@@ -109,7 +115,7 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
                     .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                     .build()
 
-                BiometricPrompt(activity as FragmentActivity, executor, callback)
+                BiometricPrompt(fa, executor, callback)
                     .authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
             } catch (e: Exception) {
                 invoke.reject("Failed to start biometric: ${e.message}")
@@ -162,6 +168,10 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
         }
 
         activity.runOnUiThread {
+            val fa = activity as? FragmentActivity ?: run {
+                invoke.reject("BiometricPlugin requires FragmentActivity")
+                return@runOnUiThread
+            }
             try {
                 val cipher = buildDecryptCipher(iv)
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
@@ -171,7 +181,7 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
                     .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                     .build()
 
-                BiometricPrompt(activity as FragmentActivity, executor, callback)
+                BiometricPrompt(fa, executor, callback)
                     .authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
             } catch (e: Exception) {
                 // Cipher init failed — key likely invalidated by new biometric enrollment
@@ -237,6 +247,8 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
         try {
             val ks = KeyStore.getInstance("AndroidKeyStore").also { it.load(null) }
             if (ks.containsAlias(KEY_ALIAS)) ks.deleteEntry(KEY_ALIAS)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            Log.w(TAG, "KeyStore cleanup failed: ${e.message}")
+        }
     }
 }

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearListenerService.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearListenerService.kt
@@ -143,7 +143,9 @@ class WearListenerService : WearableListenerService() {
                 Log.e(TAG, "Audio channel error: ${e.message}", e)
                 outFile?.delete()  // clean up partial file on failure
             } finally {
-                try { channelClient.close(channel).await() } catch (_: Exception) {}
+                try { channelClient.close(channel).await() } catch (e: Exception) {
+                    Log.w(TAG, "Channel close failed: ${e.message}")
+                }
             }
         }
     }

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearListenerService.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearListenerService.kt
@@ -1,6 +1,7 @@
 package com.moodbloom.app
 
 import android.util.Log
+import org.json.JSONObject
 import com.google.android.gms.wearable.ChannelClient
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.Wearable
@@ -11,12 +12,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import org.json.JSONObject
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
+import java.time.Instant
 
 /**
  * WearListenerService — phone-side Wear OS Data Layer receiver.
@@ -38,17 +35,7 @@ import java.util.TimeZone
 class WearListenerService : WearableListenerService() {
 
     companion object {
-        private const val TAG              = "WearListenerService"
-        const val PATH_SIGNAL              = "/signal"
-        const val PATH_VOICE_MEMO_META     = "/voice_memo"   // legacy metadata path (kept for compat)
-        const val CHANNEL_AUDIO            = "/audio_channel"
-        const val INCOMING_DIR             = "voice_memos_incoming"
-
-        private fun nowIso8601(): String {
-            val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-            sdf.timeZone = TimeZone.getTimeZone("UTC")
-            return sdf.format(Date())
-        }
+        private const val TAG = "WearListenerService"
     }
 
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -71,9 +58,9 @@ class WearListenerService : WearableListenerService() {
         }
 
         when (event.path) {
-            PATH_SIGNAL          -> handleSignalMessage(event.sourceNodeId, payload)
-            PATH_VOICE_MEMO_META -> Log.i(TAG, "Legacy /voice_memo message ignored — using ChannelAPI")
-            else                 -> Log.w(TAG, "Unhandled path: ${event.path}")
+            WearProtocol.PATH_SIGNAL          -> handleSignalMessage(event.sourceNodeId, payload)
+            WearProtocol.PATH_VOICE_MEMO_META -> Log.i(TAG, "Legacy /voice_memo message ignored — using ChannelAPI")
+            else                              -> Log.w(TAG, "Unhandled path: ${event.path}")
         }
     }
 
@@ -97,7 +84,7 @@ class WearListenerService : WearableListenerService() {
 
         WearPlugin.getInstance()?.bridgeFromWatch(
             id        = id,
-            timestamp = timestamp ?: nowIso8601(),
+            timestamp = timestamp ?: Instant.now().toString(),
             type      = type,
             source    = "watch",
             payload   = payload,
@@ -111,7 +98,7 @@ class WearListenerService : WearableListenerService() {
     // ── ChannelAPI (audio transfer) ───────────────────────────────────────────
 
     override fun onChannelOpened(channel: ChannelClient.Channel) {
-        if (channel.path != CHANNEL_AUDIO) {
+        if (channel.path != WearProtocol.CHANNEL_AUDIO) {
             Log.w(TAG, "Unexpected channel path: ${channel.path}")
             return
         }
@@ -120,69 +107,41 @@ class WearListenerService : WearableListenerService() {
         val channelClient = Wearable.getChannelClient(this)
 
         ioScope.launch {
+            var outFile: File? = null
             try {
                 val inputStream = channelClient.getInputStream(channel).await()
-
-                // Read all bytes (max ~3 min × 32 kbps ≈ 720 KB — fits in memory)
                 val allBytes = inputStream.readBytes()
                 inputStream.close()
 
-                if (allBytes.size < 5) {
-                    Log.e(TAG, "Channel data too short: ${allBytes.size} bytes")
-                    return@launch
-                }
+                val frame = AudioFrameParser.parse(allBytes) ?: return@launch
 
-                // Parse 4-byte big-endian metadata length header
-                // Explicit Int type avoids Kotlin overload-resolution ambiguity on
-                // downstream arithmetic (sliceArray bounds use metaLen as Int).
-                val metaLen: Int = java.nio.ByteBuffer.wrap(allBytes, 0, 4)
-                    .order(java.nio.ByteOrder.BIG_ENDIAN).int
+                Log.i(TAG, "Audio received: id=${frame.id} duration=${frame.durationMs}ms size=${frame.audioBytes.size} bytes")
 
-                if (metaLen <= 0 || metaLen > allBytes.size - 4) {
-                    Log.e(TAG, "Invalid metadata length: $metaLen (total=${allBytes.size})")
-                    return@launch
-                }
-
-                val metaBytes  = allBytes.sliceArray(4 until 4 + metaLen)
-                val audioBytes = allBytes.sliceArray(4 + metaLen until allBytes.size)
-                val meta       = JSONObject(String(metaBytes, Charsets.UTF_8))
-
-                val id          = meta.optString("id").takeIf { it.isNotBlank() }
-                    ?: run { Log.e(TAG, "Missing id in audio metadata"); return@launch }
-                val timestamp   = meta.optString("timestamp").takeIf { it.isNotBlank() } ?: nowIso8601()
-                val durationMs  = meta.optLong("duration_ms", 0L)
-                val healthJson  = meta.optString("health").takeIf { it.isNotBlank() }
-
-                Log.i(TAG, "Audio received: id=$id duration=${durationMs}ms size=${audioBytes.size} bytes")
-
-                // Save to filesDir/voice_memos_incoming/<id>.m4a
-                val incomingDir = File(filesDir, INCOMING_DIR).also { it.mkdirs() }
-                val outFile     = File(incomingDir, "$id.m4a")
-                outFile.writeBytes(audioBytes)
-
+                val incomingDir = File(filesDir, WearProtocol.INCOMING_DIR).also { it.mkdirs() }
+                outFile = File(incomingDir, "${frame.id}.m4a")
+                outFile.writeBytes(frame.audioBytes)
                 Log.i(TAG, "Audio saved: ${outFile.absolutePath}")
 
-                // Send feedback haptic to watch
                 try {
                     Wearable.getMessageClient(this@WearListenerService)
-                        .sendMessage(channel.nodeId, "/feedback", "received".toByteArray())
+                        .sendMessage(channel.nodeId, WearProtocol.PATH_FEEDBACK, "received".toByteArray())
                         .await()
                 } catch (e: Exception) {
                     Log.w(TAG, "Feedback send failed: ${e.message}")
                 }
 
-                // Bridge to TypeScript via WearPlugin
                 WearPlugin.getInstance()?.bridgeVoiceMemo(
-                    id             = id,
-                    timestamp      = timestamp,
-                    durationMs     = durationMs,
-                    healthJson     = healthJson,
-                    incomingFile   = outFile.name,
-                    nodeId         = channel.nodeId,
-                ) ?: Log.w(TAG, "WearPlugin not ready — voice memo $id saved but not bridged yet")
+                    id           = frame.id,
+                    timestamp    = frame.timestamp,
+                    durationMs   = frame.durationMs,
+                    healthJson   = frame.healthJson,
+                    incomingFile = outFile.name,
+                    nodeId       = channel.nodeId,
+                ) ?: Log.w(TAG, "WearPlugin not ready — voice memo ${frame.id} saved but not bridged yet")
 
             } catch (e: Exception) {
                 Log.e(TAG, "Audio channel error: ${e.message}", e)
+                outFile?.delete()  // clean up partial file on failure
             } finally {
                 try { channelClient.close(channel).await() } catch (_: Exception) {}
             }

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearPlugin.kt
@@ -17,8 +17,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import org.json.JSONObject
 import java.io.File
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -80,7 +78,7 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         // Registering here ensures audio arrives regardless of app state.
         val cb = object : ChannelClient.ChannelCallback() {
             override fun onChannelOpened(channel: ChannelClient.Channel) {
-                if (channel.path != WearListenerService.CHANNEL_AUDIO) {
+                if (channel.path != WearProtocol.CHANNEL_AUDIO) {
                     Log.w(TAG, "Plugin: unexpected channel path: ${channel.path}")
                     return
                 }
@@ -159,53 +157,32 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
             val allBytes = inputStream.readBytes()
             inputStream.close()
 
-            if (allBytes.size < 5) {
-                Log.e(TAG, "Plugin: channel data too short: ${allBytes.size} bytes")
-                return
-            }
+            val frame = AudioFrameParser.parse(allBytes) ?: return
+            Log.i(TAG, "Plugin: audio received id=${frame.id} duration=${frame.durationMs}ms size=${frame.audioBytes.size}")
 
-            val metaLen: Int = ByteBuffer.wrap(allBytes, 0, 4).order(ByteOrder.BIG_ENDIAN).int
-            if (metaLen <= 0 || metaLen > allBytes.size - 4) {
-                Log.e(TAG, "Plugin: invalid metadata length: $metaLen (total=${allBytes.size})")
-                return
-            }
-
-            val metaBytes  = allBytes.sliceArray(4 until 4 + metaLen)
-            val audioBytes = allBytes.sliceArray(4 + metaLen until allBytes.size)
-            val meta       = JSONObject(String(metaBytes, Charsets.UTF_8))
-
-            val id         = meta.optString("id").takeIf { it.isNotBlank() }
-                ?: run { Log.e(TAG, "Plugin: missing id in audio metadata"); return }
-            val timestamp  = meta.optString("timestamp").takeIf { it.isNotBlank() } ?: nowIso8601()
-            val durationMs = meta.optLong("duration_ms", 0L)
-            val healthJson = meta.optString("health").takeIf { it.isNotBlank() }
-
-            Log.i(TAG, "Plugin: audio received id=$id duration=${durationMs}ms size=${audioBytes.size}")
-
-            val incomingDir = File(activity.filesDir, WearListenerService.INCOMING_DIR).also { it.mkdirs() }
-            val outFile     = File(incomingDir, "$id.m4a")
+            val incomingDir = File(activity.filesDir, WearProtocol.INCOMING_DIR).also { it.mkdirs() }
+            val outFile = File(incomingDir, "${frame.id}.m4a")
 
             if (outFile.exists()) {
-                Log.i(TAG, "Plugin: $id already saved — skipping duplicate")
+                Log.i(TAG, "Plugin: ${frame.id} already saved — skipping duplicate")
             } else {
-                outFile.writeBytes(audioBytes)
+                outFile.writeBytes(frame.audioBytes)
                 Log.i(TAG, "Plugin: audio saved ${outFile.absolutePath}")
             }
 
-            // Acknowledge to the watch
             try {
                 Wearable.getMessageClient(activity)
-                    .sendMessage(channel.nodeId, "/feedback", "received".toByteArray())
+                    .sendMessage(channel.nodeId, WearProtocol.PATH_FEEDBACK, "received".toByteArray())
                     .await()
             } catch (e: Exception) {
                 Log.w(TAG, "Plugin: feedback send failed: ${e.message}")
             }
 
             bridgeVoiceMemo(
-                id           = id,
-                timestamp    = timestamp,
-                durationMs   = durationMs,
-                healthJson   = healthJson,
+                id           = frame.id,
+                timestamp    = frame.timestamp,
+                durationMs   = frame.durationMs,
+                healthJson   = frame.healthJson,
                 incomingFile = outFile.name,
                 nodeId       = channel.nodeId,
             )
@@ -222,8 +199,10 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         for (rawJson in buffered) {
             try {
                 val json = JSONObject(rawJson)
+                val id = json.optString("id").takeIf { it.isNotBlank() }
+                if (id == null) { Log.w(TAG, "Dropping buffered signal with missing id"); continue }
                 bridgeFromWatch(
-                    id = json.optString("id", java.util.UUID.randomUUID().toString()),
+                    id = id!!,
                     timestamp = json.optString("timestamp", nowIso8601()),
                     type = json.optString("type", "unknown"),
                     source = json.optString("source", "watch"),

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearPlugin.kt
@@ -190,7 +190,9 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         } catch (e: Exception) {
             Log.e(TAG, "Plugin: audio channel error: ${e.message}", e)
         } finally {
-            try { channelClient.close(channel).await() } catch (_: Exception) {}
+            try { channelClient.close(channel).await() } catch (e: Exception) {
+                Log.w(TAG, "Plugin: channel close failed: ${e.message}")
+            }
         }
     }
 

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearProtocol.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearProtocol.kt
@@ -1,0 +1,28 @@
+package com.moodbloom.app
+
+/**
+ * WearProtocol — canonical path constants for the Wear OS Data Layer wire protocol.
+ *
+ * All message paths, channel paths, and directory names used by WearListenerService,
+ * WearPlugin, and AudioFrameParser are defined here. Any change to the wire protocol
+ * must be reflected on both sides (phone + watch) simultaneously.
+ */
+object WearProtocol {
+    /** MessageAPI path for mood-tap signal envelopes from the watch. */
+    const val PATH_SIGNAL = "/signal"
+
+    /** MessageAPI path for legacy voice-memo metadata (no longer sent by watch; kept for compat). */
+    const val PATH_VOICE_MEMO_META = "/voice_memo"
+
+    /** ChannelAPI path for audio stream transfers from the watch. */
+    const val CHANNEL_AUDIO = "/audio_channel"
+
+    /** MessageAPI path for haptic feedback sent from phone → watch. */
+    const val PATH_FEEDBACK = "/feedback"
+
+    /** Subdirectory under filesDir where incoming audio files are staged. */
+    const val INCOMING_DIR = "voice_memos_incoming"
+
+    /** Maximum byte size of the metadata JSON header (1 MB guard against malformed frames). */
+    const val MAX_METADATA_BYTES = 1_048_576
+}

--- a/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearSignalBuffer.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodbloom/app/WearSignalBuffer.kt
@@ -19,8 +19,14 @@ object WearSignalBuffer {
 
     private val queue: ConcurrentLinkedQueue<String> = ConcurrentLinkedQueue()
 
-    /** Add a raw JSON signal envelope to the buffer */
+    /** Add a raw JSON signal envelope to the buffer. Discards malformed JSON at enqueue time. */
     fun enqueue(rawJson: String) {
+        try {
+            org.json.JSONObject(rawJson)
+        } catch (e: Exception) {
+            Log.w(TAG, "Discarding malformed signal JSON: ${e.message} — raw=${rawJson.take(60)}")
+            return
+        }
         if (queue.size >= MAX_BUFFER) {
             val dropped = queue.poll()
             Log.w(TAG, "Buffer full — dropped oldest signal: ${dropped?.take(60)}")

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheFragment.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheFragment.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.WearableLinearLayoutManager
 import androidx.wear.widget.WearableRecyclerView
-import java.util.Calendar
+import java.time.LocalTime
 import kotlin.math.abs
 import kotlinx.coroutines.launch
 
@@ -88,7 +88,7 @@ class BreatheFragment : Fragment() {
             chipView.visibility = View.GONE
             return
         }
-        val hour      = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+        val hour      = LocalTime.now().hour
         val suggested = BreathingMode.suggest(lastHr, hour)
         if (suggested == null) {
             chipView.visibility = View.GONE

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheModeDetailActivity.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheModeDetailActivity.kt
@@ -7,6 +7,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * BreatheModeDetailActivity — shows mode description, cycle adjuster, and Begin button.
@@ -69,14 +70,15 @@ class BreatheModeDetailActivity : FragmentActivity() {
             btnBegin.isEnabled = false
             btnBegin.text      = "…"
             lifecycleScope.launch {
-                // Non-blocking resting HR capture (≤10s timeout)
-                val hrJson  = HealthSnapshot.capture(applicationContext)
+                // Non-blocking resting HR capture — 12s hard timeout so btnBegin always re-enables
+                val hrJson = withTimeoutOrNull(12_000L) { HealthSnapshot.capture(applicationContext) }
                 val hrBefore = hrJson?.let {
                     try { org.json.JSONObject(it).optInt("hr", 0).takeIf { v -> v > 0 } }
                     catch (_: Exception) { null }
                 }
                 // Cache for suggestion chip in BreatheFragment
                 hrBefore?.let { HealthSnapshot.lastHr = it }
+                btnBegin.isEnabled = true
                 startSession(hrBefore)
             }
         }

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheSessionActivity.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheSessionActivity.kt
@@ -14,9 +14,11 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * BreatheSessionActivity — full-screen guided breathing session.
@@ -49,10 +51,11 @@ class BreatheSessionActivity : FragmentActivity() {
     private lateinit var btnResume:     Button
     private lateinit var btnEnd:        Button
 
-    private var sessionJob:  Job     = Job()
-    @Volatile private var isPaused:  Boolean = false
-    @Volatile private var skipPhase: Boolean = false
-    private var startMs:     Long    = 0L
+    private var sessionJob:  Job          = Job()
+    private val isPaused:    AtomicBoolean = AtomicBoolean(false)
+    private val resumeSignal: Channel<Unit> = Channel(Channel.CONFLATED)
+    private val skipPhase:   AtomicBoolean = AtomicBoolean(false)
+    private var startMs:     Long          = 0L
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -119,7 +122,7 @@ class BreatheSessionActivity : FragmentActivity() {
 
     private suspend fun runPhase(phase: Phase, durationSec: Int) {
         vibratePhaseStart(phase)
-        skipPhase = false
+        skipPhase.set(false)
 
         val expanded  = phase == Phase.INHALE || phase == Phase.HOLD1
         val targetF   = if (expanded) 0.90f else 0.40f
@@ -133,10 +136,10 @@ class BreatheSessionActivity : FragmentActivity() {
 
         // Count down second by second
         for (remaining in durationSec downTo 1) {
-            if (!lifecycleScope.isActive || skipPhase) break
+            if (!lifecycleScope.isActive || skipPhase.get()) break
             tvCountdown.text = remaining.toString()
             awaitSecond()
-            if (skipPhase) break
+            if (skipPhase.get()) break
         }
     }
 
@@ -144,8 +147,8 @@ class BreatheSessionActivity : FragmentActivity() {
     private suspend fun awaitSecond() {
         val deadline = System.currentTimeMillis() + 1_000L
         while (System.currentTimeMillis() < deadline) {
-            if (!lifecycleScope.isActive || skipPhase) return
-            while (isPaused) delay(50)
+            if (!lifecycleScope.isActive || skipPhase.get()) return
+            if (isPaused.get()) resumeSignal.receive()   // suspend until hidePause() sends
             delay(40)
         }
     }
@@ -153,20 +156,21 @@ class BreatheSessionActivity : FragmentActivity() {
     // ── Pause overlay ─────────────────────────────────────────────────────────
 
     private fun showPause() {
-        isPaused              = true
+        isPaused.set(true)
         pauseOverlay.visibility = View.VISIBLE
     }
 
     private fun hidePause() {
-        isPaused              = false
+        isPaused.set(false)
         pauseOverlay.visibility = View.GONE
+        resumeSignal.trySend(Unit)   // wake the suspended awaitSecond coroutine
     }
 
     // ── Crown / bezel — skip to next phase ───────────────────────────────────
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
         if (event.action == MotionEvent.ACTION_SCROLL) {
-            skipPhase = true
+            skipPhase.set(true)
             return true
         }
         return super.onGenericMotionEvent(event)
@@ -208,6 +212,7 @@ class BreatheSessionActivity : FragmentActivity() {
     }
 
     private fun vibrate(pattern: LongArray) {
+        if (!lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)) return
         try {
             val vibrator: Vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 (getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheSummaryActivity.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/BreatheSummaryActivity.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
@@ -85,10 +86,10 @@ class BreatheSummaryActivity : FragmentActivity() {
             navigateToRecord(prefill = null)
         }
 
-        // Auto-dismiss after 6 seconds
+        // Auto-dismiss after 6 seconds (lifecycleScope cancels if activity is destroyed)
         lifecycleScope.launch {
             delay(6_000)
-            if (!userInteracted) navigateToRecord(prefill = null)
+            if (isActive && !userInteracted) navigateToRecord(prefill = null)
         }
     }
 

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/HistoryActivity.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/HistoryActivity.kt
@@ -1,19 +1,15 @@
 package com.moodbloom.wear
 
-import android.graphics.Color
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
-import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.WearableLinearLayoutManager
 import androidx.wear.widget.WearableRecyclerView
 
 /**
  * HistoryActivity — shows the last [MoodHistory.MAX] mood taps logged from this watch.
- * Launched from MainActivity's 📋 history button.
+ * Launched from MainActivity's history button.
  */
 class HistoryActivity : FragmentActivity() {
 
@@ -21,8 +17,7 @@ class HistoryActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_history)
 
-        val entries = MoodHistory.load(this)
-
+        val entries   = MoodHistory.load(this)
         val emptyText = findViewById<TextView>(R.id.emptyText)
         val list      = findViewById<WearableRecyclerView>(R.id.historyList)
 
@@ -33,42 +28,9 @@ class HistoryActivity : FragmentActivity() {
             emptyText.visibility = View.GONE
             list.isEdgeItemsCenteringEnabled = true
             list.layoutManager = WearableLinearLayoutManager(this)
-            list.adapter = HistoryAdapter(entries)
+            list.adapter = MoodHistoryAdapter(entries)
         }
 
         findViewById<View>(R.id.backBtn).setOnClickListener { finish() }
-    }
-
-    // ── Adapter ───────────────────────────────────────────────────────────────
-
-    private class HistoryAdapter(
-        private val entries: List<MoodHistory.Entry>,
-    ) : RecyclerView.Adapter<HistoryAdapter.VH>() {
-
-        inner class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
-            val dot:   View     = itemView.findViewById(R.id.historyDot)
-            val emoji: TextView = itemView.findViewById(R.id.historyEmoji)
-            val label: TextView = itemView.findViewById(R.id.historyLabel)
-            val time:  TextView = itemView.findViewById(R.id.historyTime)
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
-            val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.item_history, parent, false)
-            return VH(view)
-        }
-
-        override fun onBindViewHolder(holder: VH, position: Int) {
-            val entry = entries[position]
-            val mood  = entry.mood
-            val color = try { Color.parseColor(mood.colorHex) } catch (_: IllegalArgumentException) { Color.GRAY }
-
-            holder.dot.background?.setTint(color)
-            holder.emoji.text = mood.emoji
-            holder.label.text = mood.label
-            holder.time.text  = entry.displayTime()
-        }
-
-        override fun getItemCount(): Int = entries.size
     }
 }

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/HistoryFragment.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/HistoryFragment.kt
@@ -1,79 +1,50 @@
 package com.moodbloom.wear
 
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.RecyclerView
 import androidx.wear.widget.WearableLinearLayoutManager
 import androidx.wear.widget.WearableRecyclerView
 
 /**
- * HistoryFragment — leftmost swipe page.
+ * HistoryFragment — leftmost swipe page (page 0).
  * Shows the last [MoodHistory.MAX] mood taps logged from this watch.
  */
 class HistoryFragment : Fragment() {
+
+    private var list: WearableRecyclerView? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View = inflater.inflate(R.layout.fragment_history, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val entries   = MoodHistory.load(requireContext())
-        val emptyText = view.findViewById<TextView>(R.id.emptyText)
-        val list      = view.findViewById<WearableRecyclerView>(R.id.historyList)
-
-        if (entries.isEmpty()) {
-            emptyText.visibility = View.VISIBLE
-            list.visibility = View.GONE
-            return
-        }
-
-        emptyText.visibility = View.GONE
-        list.isEdgeItemsCenteringEnabled = true
-        list.layoutManager = WearableLinearLayoutManager(requireContext())
-        list.adapter = HistoryAdapter(entries)
+        list = view.findViewById(R.id.historyList)
+        refreshList(view)
     }
 
     override fun onResume() {
         super.onResume()
-        // Refresh list when user swipes back here
-        view?.let { onViewCreated(it, null) }
+        view?.let { refreshList(it) }
     }
 
-    // ── Adapter ───────────────────────────────────────────────────────────────
+    private fun refreshList(view: View) {
+        val entries   = MoodHistory.load(requireContext())
+        val emptyText = view.findViewById<TextView>(R.id.emptyText)
+        val listView  = view.findViewById<WearableRecyclerView>(R.id.historyList)
 
-    private class HistoryAdapter(
-        private val entries: List<MoodHistory.Entry>,
-    ) : RecyclerView.Adapter<HistoryAdapter.VH>() {
-
-        inner class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
-            val dot:   View     = itemView.findViewById(R.id.historyDot)
-            val emoji: TextView = itemView.findViewById(R.id.historyEmoji)
-            val label: TextView = itemView.findViewById(R.id.historyLabel)
-            val time:  TextView = itemView.findViewById(R.id.historyTime)
+        if (entries.isEmpty()) {
+            emptyText.visibility = View.VISIBLE
+            listView.visibility  = View.GONE
+            return
         }
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
-            val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.item_history, parent, false)
-            return VH(view)
-        }
-
-        override fun onBindViewHolder(holder: VH, position: Int) {
-            val entry = entries[position]
-            val mood  = entry.mood
-            val color = try { Color.parseColor(mood.colorHex) } catch (_: IllegalArgumentException) { Color.GRAY }
-
-            holder.dot.background?.setTint(color)
-            holder.emoji.text = mood.emoji
-            holder.label.text = mood.label
-            holder.time.text  = entry.displayTime()
-        }
-
-        override fun getItemCount(): Int = entries.size
+        emptyText.visibility = View.GONE
+        listView.isEdgeItemsCenteringEnabled = true
+        listView.layoutManager = WearableLinearLayoutManager(requireContext())
+        listView.adapter = MoodHistoryAdapter(entries)
     }
 }

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodAdapter.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodAdapter.kt
@@ -41,14 +41,17 @@ class MoodAdapter(
 
         val color = try { Color.parseColor(mood.colorHex) } catch (_: IllegalArgumentException) { Color.GRAY }
 
-        val density = holder.itemView.context.resources.displayMetrics.density
-        val drawable = GradientDrawable().apply {
-            shape        = GradientDrawable.RECTANGLE
-            cornerRadius = 36f * density
-            setColor(color)
-            alpha = 90
+        // Reuse existing background drawable instead of allocating a new GradientDrawable per bind
+        val pill = holder.colorPill.background as? GradientDrawable ?: run {
+            val density = holder.itemView.context.resources.displayMetrics.density
+            GradientDrawable().also {
+                it.shape        = GradientDrawable.RECTANGLE
+                it.cornerRadius = 36f * density
+                it.alpha        = 90
+                holder.colorPill.background = it
+            }
         }
-        holder.colorPill.background = drawable
+        pill.setColor(color)
 
         // ✓ badge if this is the last sent mood; otherwise level number
         if (mood.level == lastSentLevel) {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
@@ -25,8 +25,8 @@ import androidx.wear.watchface.complications.datasource.SuspendingComplicationDa
 class MoodComplicationService : SuspendingComplicationDataSourceService() {
 
     // 30-second in-memory cache to avoid hitting SharedPrefs on every watch face tick
-    private var cachedEntry: MoodHistory.Entry? = null
-    private var cacheTimestampMs: Long = 0L
+    @Volatile private var cachedEntry: MoodHistory.Entry? = null
+    @Volatile private var cacheTimestampMs: Long = 0L
     private val cacheTtlMs = 30_000L
 
     override fun getPreviewData(type: ComplicationType): ComplicationData? {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
@@ -24,6 +24,11 @@ import androidx.wear.watchface.complications.datasource.SuspendingComplicationDa
  */
 class MoodComplicationService : SuspendingComplicationDataSourceService() {
 
+    // 30-second in-memory cache to avoid hitting SharedPrefs on every watch face tick
+    private var cachedEntry: MoodHistory.Entry? = null
+    private var cacheTimestampMs: Long = 0L
+    private val cacheTtlMs = 30_000L
+
     override fun getPreviewData(type: ComplicationType): ComplicationData? {
         val sample = MOODS.first()  // level 5 "Great" as preview
         return when (type) {
@@ -34,8 +39,15 @@ class MoodComplicationService : SuspendingComplicationDataSourceService() {
     }
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? {
-        val history = MoodHistory.load(this)
-        val latest  = history.firstOrNull()
+        val now = System.currentTimeMillis()
+        val latest = if (now - cacheTimestampMs < cacheTtlMs) {
+            cachedEntry
+        } else {
+            val entry = MoodHistory.load(this).firstOrNull()
+            cachedEntry = entry
+            cacheTimestampMs = now
+            entry
+        }
 
         return if (latest == null) {
             // No history yet — prompt user to log

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistory.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistory.kt
@@ -23,7 +23,9 @@ object MoodHistory {
         val moodLevel: Int,
         val timestamp: String,   // ISO-8601
     ) {
-        val mood: MoodItem get() = MOODS.firstOrNull { it.level == moodLevel } ?: MOODS[2]
+        val mood: MoodItem get() = MOODS.firstOrNull { it.level == moodLevel }
+            ?: MOODS.firstOrNull { it.level == 3 }  // neutral fallback by level, not array index
+            ?: MOODS.first()
 
         /** e.g. "Today 09:14" or "Mon 21:32" */
         fun displayTime(): String = try {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistory.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistory.kt
@@ -23,7 +23,7 @@ object MoodHistory {
         val moodLevel: Int,
         val timestamp: String,   // ISO-8601
     ) {
-        val mood: MoodItem get() = MOODS.first { it.level == moodLevel }
+        val mood: MoodItem get() = MOODS.firstOrNull { it.level == moodLevel } ?: MOODS[2]
 
         /** e.g. "Today 09:14" or "Mon 21:32" */
         fun displayTime(): String = try {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistoryAdapter.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodHistoryAdapter.kt
@@ -1,0 +1,45 @@
+package com.moodbloom.wear
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * MoodHistoryAdapter — shared adapter for mood history lists.
+ *
+ * Used by both [HistoryActivity] (standalone screen) and [HistoryFragment] (page 0).
+ * Extracted to eliminate duplicate adapter implementations.
+ */
+class MoodHistoryAdapter(
+    private val entries: List<MoodHistory.Entry>,
+) : RecyclerView.Adapter<MoodHistoryAdapter.VH>() {
+
+    class VH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val dot:   View     = itemView.findViewById(R.id.historyDot)
+        val emoji: TextView = itemView.findViewById(R.id.historyEmoji)
+        val label: TextView = itemView.findViewById(R.id.historyLabel)
+        val time:  TextView = itemView.findViewById(R.id.historyTime)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_history, parent, false)
+        return VH(view)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val entry = entries[position]
+        val mood  = entry.mood
+        val color = try { Color.parseColor(mood.colorHex) } catch (_: IllegalArgumentException) { Color.GRAY }
+
+        holder.dot.background?.setTint(color)
+        holder.emoji.text = mood.emoji
+        holder.label.text = mood.label
+        holder.time.text  = entry.displayTime()
+    }
+
+    override fun getItemCount(): Int = entries.size
+}

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/OfflineQueue.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/OfflineQueue.kt
@@ -37,8 +37,9 @@ object OfflineQueue {
             moodLevel = moodLevel,
         )
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val existing = load(prefs)
-        val updated = (existing + entry).takeLast(MAX_ENTRIES)
+        val updated = ArrayDeque(load(prefs))
+        if (updated.size >= MAX_ENTRIES) updated.removeFirst()
+        updated.addLast(entry)
         save(prefs, updated)
         Log.i(TAG, "Queued signal mood=${moodLevel} (queue size=${updated.size})")
     }

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/RecordFragment.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/RecordFragment.kt
@@ -143,7 +143,7 @@ class RecordFragment : Fragment() {
         if (!hasPerm(Manifest.permission.RECORD_AUDIO)) perms += Manifest.permission.RECORD_AUDIO
         if (perms.isNotEmpty()) { requestMic.launch(perms.toTypedArray()); return }
 
-        val s = RecordingSession(requireContext(), onAutoStop = { stopRecording() })
+        val s = RecordingSession(requireContext(), onAutoStop = { if (isAdded) stopRecording() })
         if (!s.start()) { statusText.text = "Mic unavailable"; return }
 
         session = s

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SignalSender.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SignalSender.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.google.android.gms.tasks.Tasks
 import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.time.Instant
@@ -63,7 +64,7 @@ object SignalSender {
 
             var sent = 0
             for (p in pending) {
-                val ok = trySend(context, p.id, p.timestamp, p.moodLevel)
+                val ok = trySendWithBackoff(context, p.id, p.timestamp, p.moodLevel)
                 if (ok) sent++ else OfflineQueue.enqueue(context, p.moodLevel)
             }
             Log.i(TAG, "drainAndSend: sent $sent/${pending.size}")
@@ -71,6 +72,21 @@ object SignalSender {
         }
 
     // ── Internal ──────────────────────────────────────────────────────────────
+
+    // Delays between retries: immediate → 250 ms → 500 ms → 1 s → give up
+    private val RETRY_DELAYS_MS = longArrayOf(250L, 500L, 1_000L)
+
+    private suspend fun trySendWithBackoff(
+        context: Context, id: String, timestamp: String, moodLevel: Int,
+    ): Boolean {
+        if (trySend(context, id, timestamp, moodLevel)) return true
+        for ((i, delayMs) in RETRY_DELAYS_MS.withIndex()) {
+            delay(delayMs)
+            Log.w(TAG, "trySendWithBackoff: retry ${i + 1} (mood=$moodLevel, after ${delayMs}ms)")
+            if (trySend(context, id, timestamp, moodLevel)) return true
+        }
+        return false
+    }
 
     private fun buildEnvelope(id: String, timestamp: String, moodLevel: Int): ByteArray {
         val envelope = JSONObject().apply {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SyncFragment.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SyncFragment.kt
@@ -77,7 +77,7 @@ class SyncFragment : Fragment() {
         moodQueueCount.text      = "$moodQ"
 
         retryBtn.visibility = if (totalQ > 0) View.VISIBLE else View.GONE
-        retryBtn.text = "↑ Sync now"
+        retryBtn.text = getString(R.string.sync_now)
     }
 
     private fun checkConnection() {
@@ -104,22 +104,25 @@ class SyncFragment : Fragment() {
     }
 
     private fun drainQueues() {
-        retryBtn.text      = "Syncing…"
+        val ctx = requireContext()
+        val hadItems = AudioQueue.size(ctx) > 0 || OfflineQueue.size(ctx) > 0
+
+        retryBtn.text = getString(R.string.sync_syncing)
         retryBtn.isEnabled = false
 
         lifecycleScope.launch {
-            // Drain voice memos
-            val voiceSent = AudioTransferService.drainQueue(requireContext())
-            if (voiceSent > 0) {
-                repeat(voiceSent) { SyncStats.recordSynced(requireContext()) }
-            }
-            // Drain mood signals
-            SignalSender.drainAndSend(requireContext())
+            val voiceSent = AudioTransferService.drainQueue(ctx)
+            if (voiceSent > 0) repeat(voiceSent) { SyncStats.recordSynced(ctx) }
+            val moodSent = SignalSender.drainAndSend(ctx)
 
             updateCounters()
             retryBtn.isEnabled = true
-            val total = voiceSent
-            retryBtn.text = if (total > 0) "✓ Sent $total" else "↑ Sync now"
+            val total = voiceSent + moodSent
+            retryBtn.text = when {
+                total > 0  -> getString(R.string.sync_sent, total)
+                hadItems   -> getString(R.string.sync_failed)
+                else       -> getString(R.string.sync_now)
+            }
         }
     }
 }

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/TileActionActivity.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/TileActionActivity.kt
@@ -1,12 +1,15 @@
 package com.moodbloom.wear
 
-import android.app.Activity
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.widget.FrameLayout
 import android.widget.TextView
-import androidx.lifecycle.lifecycleScope
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -54,8 +57,20 @@ class TileActionActivity : FragmentActivity() {
         MoodHistory.record(this, mood.level)
 
         lifecycleScope.launch {
-            SignalSender.sendMoodTap(this@TileActionActivity, mood.level)
-            // Refresh the tile so the highlighted button updates
+            val sent = SignalSender.sendMoodTap(this@TileActionActivity, mood.level)
+            if (!sent) {
+                // Signal queued — show error state so user knows it will retry
+                root.setBackgroundColor(Color.parseColor("#7F1D1D"))
+                label.text = "${mood.emoji}\nQueued"
+                try {
+                    val vib = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        (getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+                    } else {
+                        @Suppress("DEPRECATION") getSystemService(VIBRATOR_SERVICE) as Vibrator
+                    }
+                    vib.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 30, 60, 30), -1))
+                } catch (_: Exception) {}
+            }
             androidx.wear.tiles.TileService.getUpdater(this@TileActionActivity)
                 .requestUpdate(MoodTileService::class.java)
             delay(1200)

--- a/src-tauri/gen/android/wear/src/main/res/values/strings.xml
+++ b/src-tauri/gen/android/wear/src/main/res/values/strings.xml
@@ -3,4 +3,9 @@
     <string name="app_name">MoodBloom</string>
     <string name="tile_label">MoodBloom Mood</string>
     <string name="complication_label">MoodBloom</string>
+    <string name="complication_log_mood">Log mood</string>
+    <string name="sync_now">Sync now</string>
+    <string name="sync_syncing">Syncing…</string>
+    <string name="sync_sent">Sent %d</string>
+    <string name="sync_failed">Sync failed</string>
 </resources>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MoodHaven",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "identifier": "com.moodhaven.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

**Correctness fixes (phone bridge):**
- `AudioFrameParser` extracted as the single source of truth for the watch→phone binary framing protocol. Both `WearListenerService` (background) and `WearPlugin` (foreground) now use it — duplicate parsing logic removed.
- `WearProtocol` object added with all wire protocol constants (`PATH_SIGNAL`, `CHANNEL_AUDIO`, `INCOMING_DIR`, `PATH_FEEDBACK`, `MAX_METADATA_BYTES`). Eliminates scattered string literals.
- `WearListenerService`: adds `outFile?.delete()` cleanup on audio channel failure; logs channel close failures instead of swallowing them.
- `WearPlugin`: same channel close logging fix; removes now-unused `ByteBuffer/ByteOrder` imports.
- `BiometricPlugin`: safe `FragmentActivity` cast (`as?` + early return) replaces crash-inducing hard cast.

**Correctness fixes (wear app):**
- `MoodHistory`: `NoSuchElementException` crash on unknown mood level fixed — `firstOrNull { it.level == moodLevel }` with level-3 neutral fallback replaces unsafe `first {}`.
- `BreatheSessionActivity`: busy-wait `while (isPaused) delay(50)` replaced with `AtomicBoolean` + `Channel(CONFLATED)` for correct pause/resume without CPU spin.
- `BreatheModeDetailActivity`: HR capture wrapped in `withTimeoutOrNull(12_000L)`; button always re-enables so the UI is never permanently stuck.
- `RecordFragment`: `if (isAdded)` guard added to `onAutoStop` lambda to prevent fragment lifecycle crash.
- `SyncFragment`: shows combined sent+pending count rather than pending-only count.

**Performance / reliability:**
- `OfflineQueue`: eviction changed from O(n) `takeLast()` to O(1) `ArrayDeque.removeFirst()`.
- `SignalSender`: `trySendWithBackoff()` retries at 250/500/1000 ms on send failure.
- `MoodComplicationService`: 30-second in-memory cache on `MoodHistory.load()` with `@Volatile` fields.
- `MoodAdapter`: reuses existing `GradientDrawable` per bind instead of allocating a new one.

**Refactor:**
- `HistoryAdapter` extracted into standalone `MoodHistoryAdapter` — shared by `HistoryActivity` and `HistoryFragment`.
- `HistoryFragment.onResume()` calls shared `refreshList()` instead of re-calling `onViewCreated()`.

**Pre-landing review fixes (from ship):**
- `AudioFrameParser`: empty audio frames rejected; frame `id` sanitized against path traversal before use as filename.
- `MoodHistory`: fallback uses `level == 3` semantic lookup, not `MOODS[2]` array index.

## Test Coverage

All changed files are Android Kotlin — outside Vitest's scope. No TypeScript application code changed. 585/585 existing tests passing.

Both APKs verified on physical hardware:
- Phone: Pixel 9 — Tauri bridge running, no WearPlugin/WearListenerService errors in logcat
- Watch: Pixel Watch 3 — APK installed clean, no FATAL EXCEPTIONs

**Manual QA checklist** (device-only, cannot be automated):
- [ ] Mood tap → signal lands in desktop
- [ ] Offline mood taps drain correctly on reconnect
- [ ] Voice memo record → transfer → transcription flow
- [ ] Breathe session pause/resume (no stuck state)
- [ ] Sync fragment: "Sync now" → shows Syncing… → result
- [ ] Biometric enroll + authenticate + INVALIDATED path

## Pre-Landing Review

**AUTO-FIXED (5 issues):**
- `AudioFrameParser.kt:63` — empty audio array accepted → reject with Log.e
- `AudioFrameParser.kt:72` — id used as filename without sanitization → strip non-`[a-zA-Z0-9_-]` chars
- `MoodComplicationService.kt:28-29` — cache fields not volatile → `@Volatile`
- `MoodHistory.kt:26` — `MOODS[2]` array-index fallback → level==3 lookup with `MOODS.first()` as final guard
- `WearListenerService.kt:146`, `WearPlugin.kt:193` — channel close failure swallowed → `Log.w` in both

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Greptile Review

No existing PR — Greptile review not applicable.

## Plan Completion

```
COMPLETION: 7/8 DONE, 0 PARTIAL, 0 NOT DONE, 1 CHANGED
CHANGED: MoodTileService hardcoded package name — BuildConfig not generated in wear module (safe; matches build.gradle.kts applicationId). Tracked as WEAR-001 in TODOS.md.
```

## TODOS

- **Added:** WEAR-001 — Enable BuildConfig in wear module + replace hardcoded package name in MoodTileService (P3)

## Test plan

- [x] 585/585 Vitest tests passing (38 test files)
- [x] `tsc --noEmit` clean
- [x] `cargo check` clean
- [x] Wear APK installs on Pixel Watch 3 (Wear OS 3.0) — no FATAL EXCEPTIONs in logcat
- [x] Phone bridge running on Pixel 9 — no MoodBloom errors in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)