### PR TITLE
chore(security): suppress confirmed Semgrep false positives (#52)

### DIFF
--- a/src-tauri/src/commands/journal.rs
+++ b/src-tauri/src/commands/journal.rs
@@ -374,7 +374,7 @@ mod tests {
     /// must give the same hash as encoding → decoding the salt.
     #[test]
     fn test_salt_must_be_decoded_before_derive() {
-        let password = "parity-check";
+        let password = "parity-check"; // nosemgrep: rust-hardcoded-secret (test fixture only)
         let salt_bytes = [
             0xaau8, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
             0x88, 0x99,

--- a/src/stores/booksStore.ts
+++ b/src/stores/booksStore.ts
@@ -78,7 +78,7 @@ export const useBooksStore = create<BooksState>((set, get) => ({
       const key = 'mb_pending_book_tombstones';
       const existing: string[] = JSON.parse(localStorage.getItem(key) ?? '[]');
       if (!existing.includes(id)) {
-        localStorage.setItem(key, JSON.stringify([...existing, id]));
+        localStorage.setItem(key, JSON.stringify([...existing, id])); // nosemgrep: localstorage-sensitive (book tombstone UUIDs, not secrets)
       }
     } catch { /* non-critical */ }
 


### PR DESCRIPTION
## Summary
- Adds inline `nosemgrep` suppressions for the two findings from the 2026-04-13 weekly Semgrep scan (#52).
- Both findings were confirmed false positives in the issue body; this PR applies the recommended suppressions verbatim with justification comments.

## Findings

| File:Line | Rule | Why it's a false positive |
|-----------|------|---------------------------|
| \`src-tauri/src/commands/journal.rs:377\` | \`rust-hardcoded-secret\` | Test fixture inside \`#[test] fn test_salt_must_be_decoded_before_derive\` — used for PBKDF2 parity verification, never a real credential. |
| \`src/stores/booksStore.ts:81\` | \`localstorage-sensitive\` | \`localStorage\` value is a list of book UUIDs (tombstone markers for sync), not a secret. Repeat finding from #39. |

## Test plan
- [ ] CI test workflow passes (no behavior change — comments only)
- [ ] Next weekly Semgrep run no longer flags either line
- [ ] Close #52 on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)