### PR TITLE
chore: unblock Rust CI — Rust 1.95 clippy fixes + advisory bumps

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
  "hidapi",
  "num",
  "pad",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "strum",
  "strum_macros",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "moodhaven-journal"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2763,7 +2763,7 @@ dependencies = [
  "log",
  "mdns-sd",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -3349,7 +3349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3359,7 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3743,7 +3743,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3806,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3817,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4155,7 +4155,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -4224,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5155,7 +5155,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5576,7 +5576,7 @@ dependencies = [
  "constant_time_eq",
  "hmac",
  "qrcodegen-image",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "sha2",
  "url",

--- a/src-tauri/src/commands/peer_discovery.rs
+++ b/src-tauri/src/commands/peer_discovery.rs
@@ -187,7 +187,7 @@ pub fn get_local_ipv4() -> Option<std::net::Ipv4Addr> {
 
     if !candidates.is_empty() {
         // Highest preference first; stable sort keeps deterministic order within a tier.
-        candidates.sort_by(|a, b| b.0.cmp(&a.0));
+        candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
         log::debug!(
             "[peer] LAN IP candidates: {:?}",
             candidates

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -411,11 +411,10 @@ pub async fn download_and_install_update(
         file.write_all(&chunk)
             .map_err(|e| format!("Write error: {e}"))?;
         downloaded += chunk.len() as u64;
-        let percent = if total > 0 {
-            ((downloaded * 100) / total).min(100) as u8
-        } else {
-            0
-        };
+        let percent = (downloaded * 100)
+            .checked_div(total)
+            .map(|p| p.min(100) as u8)
+            .unwrap_or(0);
         let _ = app.emit(
             "update-progress",
             DownloadProgress {


### PR DESCRIPTION
## Summary
Rust 1.95.0 added two new clippy lints that flag pre-existing code patterns. CI runs `cargo clippy --all-targets -- -D warnings`, so every open PR is currently red on the Rust matrix until this lands.

| File:Line | Lint | Fix |
|---|---|---|
| `src-tauri/src/commands/peer_discovery.rs:190` | `clippy::unnecessary_sort_by` | `sort_by(\|a, b\| b.0.cmp(&a.0))` → `sort_by_key(\|c\| std::cmp::Reverse(c.0))` |
| `src-tauri/src/commands/updater.rs:414` | `clippy::manual_checked_ops` | `if total > 0 { (downloaded * 100 / total).min(100) as u8 } else { 0 }` → `(downloaded * 100).checked_div(total).map(\|p\| p.min(100) as u8).unwrap_or(0)` |

Both fixes are behaviorally identical to the originals.

## Why now
Blocks PR #55 (semgrep suppressions) and PR #56 (rand/rustls-webpki bumps) from passing CI. Once this lands, both rebase + rerun should be green.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes locally on Rust 1.95.0
- [x] `cargo fmt --check` clean
- [ ] CI Rust matrix (ubuntu / windows / macOS) green