### PR TITLE
chore: packaging hygiene — PKG-001 (dompurify devDep) + PS-004 (AAB checksums)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -170,10 +170,8 @@ Added `buildFeatures { buildConfig = true }` to `wear/build.gradle.kts`. Replace
 `wear/build.gradle.kts` now uses `applicationId = "com.moodhaven.app"` (aligned with phone). Fixed in commit `a4ab1a7`.
 **Completed:** v0.8.3.1 (2026-04-09)
 
-### PS-004: Add checksums for Android AAB artifacts (P3)
-**What:** `scripts/generate-checksums.cjs` only hashes `.AppImage`, `.exe`, `.dmg`, and `.msi`. The new `app-release.aab` and `wear-release.aab` artifacts (added in PS-002) have no integrity metadata in `latest-release.json`.
-**Why:** Without checksums, the updater cannot verify AAB integrity before installation.
-**Effort:** human ~10min / CC ~5min
+### ~~PS-004: Add checksums for Android AAB artifacts (P3)~~ ✅ RESOLVED (2026-04-17)
+**Completed:** Added `.aab` to `ASSET_EXTENSIONS` in `scripts/generate-checksums.cjs` and to the asset filter in `scripts/update-latest-release-json.cjs`. AAB artifacts now appear in `checksums.txt` and `latest-release.json` alongside the desktop installers.
 
 ---
 
@@ -239,9 +237,5 @@ Added `buildFeatures { buildConfig = true }` to `wear/build.gradle.kts`. Replace
 
 ## Packaging Debt
 
-### PKG-001: Move @types/dompurify to devDependencies
-**What:** `@types/dompurify` is currently in `dependencies` (package.json:44) instead of `devDependencies`. Type-only packages should not be in production deps.
-**Why:** Produces a misleading dependency graph; inflates npm audit surface area. No runtime impact (Vite tree-shakes it out).
-**Fix:** `npm install --save-dev @types/dompurify && npm uninstall @types/dompurify` (effectively just move it). Verify `npm run typecheck` passes.
-**Priority:** P4 (cosmetic)
-**Effort:** human ~5min / CC+gstack ~5min
+### ~~PKG-001: Move @types/dompurify to devDependencies~~ ✅ RESOLVED (2026-04-17)
+**Completed:** Moved `@types/dompurify` from `dependencies` to `devDependencies` in `package.json`; refreshed `package-lock.json` (which incidentally caught a stale `version` bump from 0.9.0 → 0.9.4). `npm run typecheck` clean.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moodhaven-journal",
-  "version": "0.9.0",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moodhaven-journal",
-      "version": "0.9.0",
+      "version": "0.9.4",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -25,7 +25,6 @@
         "@tiptap/react": "^3.15.3",
         "@tiptap/starter-kit": "^3.15.3",
         "@tiptap/suggestion": "^3.18.0",
-        "@types/dompurify": "^3.0.5",
         "@types/qrcode": "^1.5.6",
         "dompurify": "^3.3.3",
         "qrcode": "^1.5.4",
@@ -42,6 +41,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^25.1.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -2822,6 +2822,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "*"
@@ -2903,6 +2904,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@tiptap/react": "^3.15.3",
     "@tiptap/starter-kit": "^3.15.3",
     "@tiptap/suggestion": "^3.18.0",
-    "@types/dompurify": "^3.0.5",
     "@types/qrcode": "^1.5.6",
     "dompurify": "^3.3.3",
     "qrcode": "^1.5.4",
@@ -55,6 +54,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/cli": "^2.0.0",
+    "@types/dompurify": "^3.0.5",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/scripts/generate-checksums.cjs
+++ b/scripts/generate-checksums.cjs
@@ -30,8 +30,8 @@ if (!TAG) {
 const ARTIFACTS_DIR = path.join(process.cwd(), 'artifacts');
 const CHECKSUM_FILE = path.join(process.cwd(), 'checksums.txt');
 
-// Extensions we want to checksum (updater assets + installers)
-const ASSET_EXTENSIONS = ['.AppImage', '.exe', '.dmg', '.msi'];
+// Extensions we want to checksum (updater assets + installers + Android bundles)
+const ASSET_EXTENSIONS = ['.AppImage', '.exe', '.dmg', '.msi', '.aab'];
 
 // ── Collect all platform assets ────────────────────────────────────────────────
 function findAssets(dir) {

--- a/scripts/update-latest-release-json.cjs
+++ b/scripts/update-latest-release-json.cjs
@@ -43,7 +43,8 @@ const assets = release.assets
       n.endsWith('.AppImage') ||
       n.endsWith('-setup.exe') ||
       n.endsWith('.dmg') ||
-      n.endsWith('.apk')
+      n.endsWith('.apk') ||
+      n.endsWith('.aab')
     );
   })
   .map((a) => ({


### PR DESCRIPTION
## Summary
Two TODOS.md cleanups bundled together — both are tiny config-only changes.

### PKG-001: `@types/dompurify` → devDependencies
Type-only package that shouldn't sit in `dependencies`. No runtime impact (Vite tree-shakes types). Side effect: `package-lock.json` was stale at version `0.9.0`; refreshing it picked up the `0.9.4` bump for free.

### PS-004: AAB integrity
- `scripts/generate-checksums.cjs` — added `.aab` to `ASSET_EXTENSIONS` so the Play Store bundles land in `checksums.txt`.
- `scripts/update-latest-release-json.cjs` — added `.aab` to the asset filter so `latest-release.json` lists them alongside the desktop installers.

## Test plan
- [x] `npm run typecheck` clean
- [ ] CI green (waiting on #57 to land — see "Blocked by" below)
- [ ] Next release cycle: confirm `app-release.aab` and `wear-release.aab` show up in both `checksums.txt` and the `latest-release.json` asset array

## Blocked by
- #57 (Rust 1.95 clippy fixes) — unrelated, but every PR's Rust matrix is currently red until that lands.

Closes the PKG-001 and PS-004 entries in `TODOS.md`.