### PR TITLE
ci: add workflow_dispatch trigger to Tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
One-line addition to enable manual/API invocation of the Tests workflow via `gh workflow run test.yml --ref main`.

## Why
Prerequisite for scheduled Claude Code Routines that want to trigger CI against main on a cadence (e.g., a weekly clippy watch that catches new Rust lints before they block open PRs, or a nightly advisory scan that runs cargo deny/audit).

Without this trigger, routines have to either (a) force a no-op commit to main to trigger \`push\`, or (b) simulate a PR event — both awkward. \`workflow_dispatch\` is the clean path.

## Blast radius
Zero behavior change on existing \`push\` and \`pull_request\` triggers. Only adds a new way to start the workflow.

## Test plan
- [ ] After merge, verify \`gh workflow run test.yml --ref main\` starts a run
- [ ] Existing push/PR CI still fires normally