### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4224,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Nightly advisory scan (2026-05-02) found one new vulnerability with an in-range patch fix. Bumped via `cargo update -p rustls-webpki` — Cargo.lock only, no manifest changes.

## Closed advisories

| ID | Crate | Old → New | Advisory |
|---|---|---|---|
| RUSTSEC-2026-0104 | rustls-webpki | 0.103.12 → 0.103.13 | https://rustsec.org/advisories/RUSTSEC-2026-0104 |

RUSTSEC-2026-0104 is a reachable panic in CRL parsing in rustls-webpki. Reaches us transitively through `tauri-plugin-http → reqwest → rustls → rustls-webpki` (and a few other rustls consumers like `quinn`, `hyper-rustls`).

## Verification

- `cargo audit` — no vulnerabilities (19 allowed warnings, all pre-existing transitive unmaintained/unsound advisories already in `audit.toml` / `deny.toml` ignore lists)
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `npm run check:all` — passes (typecheck, lint:ci, vitest, check:deny, check:audit)

## Needs manual review

None new. The unsound advisory **RUSTSEC-2026-0097** (rand 0.7.3, transitive via `phf_generator → selectors → kuchikiki → wry/tauri-utils`) remains as a warning — no fix exists upstream and the affected codepath (`rand::rng()` with a custom logger) is not exercised by build-time codegen. Consider adding it to `audit.toml` / `deny.toml` ignore lists in a follow-up if the noise is unwanted.

## Test plan

- [ ] CI green: typecheck, lint, tests, check:deny, check:audit
- [ ] Tauri build matrix green on Linux/Windows/macOS (verifies the patch bump doesn't break the Rust build outside of this sandboxed env)

---
_Generated by [Claude Code](https://claude.ai/code/session_012xoRN6cL8F9j3VZbHzi7QJ)_