### PR TITLE
feat(v1.1.0): Android companion + Play Store [DRAFT — tracking]

### DIFF
--- a/active-plans/v1.1.0-android.md
+++ b/active-plans/v1.1.0-android.md
@@ -1,0 +1,57 @@
+# v1.1.0 — Android Companion + Play Store
+
+> **Branch:** `feat/v1.1.0-android`
+> **Depends on:** v1.0.0 tagged and stable
+> **Source of truth for milestone gate:** `active-plans/roadmap-v1.0.md` v1.1.0 section
+> **Status:** scaffold — Play Store atomic work already shipped in v1.0 cycle; this PR tracks remaining QA + release work.
+
+---
+
+## Play Store (ATOMIC — done in v1.0 cycle)
+
+- [x] **WEAR-002** — Align `applicationId` in phone + wear `build.gradle`
+  > Done in commit `a4ab1a7 fix(android): align wear applicationId with phone app (com.moodhaven.app)`.
+  > Verified: `src-tauri/gen/android/app/build.gradle.kts:31` + `src-tauri/gen/android/wear/build.gradle.kts:30` both `applicationId = "com.moodhaven.app"`.
+
+- [x] **PS-004** — Add SHA-256 checksums for AAB artifacts to `latest-release.json`
+  > Done in PR #58 (`chore: packaging hygiene — PKG-001 + PS-004`).
+  > Update script: `scripts/update-latest-release-json.cjs` and `scripts/generate-checksums.cjs`.
+
+---
+
+## Final QA + Polish
+
+- [ ] Run `/qa` on phone app; fix all P0/P1 findings
+- [ ] Run `/qa` on wear app; fix all P0/P1 findings
+- [ ] Run `/design-review` on wear app — colors, spacing, animation quality consistent with desktop
+- [ ] Final `/design-review` pass after fixes
+
+---
+
+## Gate
+
+- [x] Both `build.gradle.kts` show `applicationId = "com.moodhaven.app"`
+- [ ] Wear + phone `/qa` reports: zero P0/P1 issues
+- [ ] Wear + phone `/design-review` reports: consistent with desktop
+- [ ] Android E2E: voice memo record on watch → transfer to phone → transcription on desktop
+- [ ] Bump `1.1.0` in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `VERSION`
+- [ ] Update `CHANGELOG.md` — add v1.1.0 entry
+- [ ] Run `/review` → `/ship` → merge to `main`
+
+---
+
+## Out of Scope
+
+- **P1–P4 Android polish** — already shipped in `fix/android-companion-polish` (see roadmap Decision Log 2026-04-08).
+- **StillHaven** — slotted as v1.2.0, separate milestone (see `active-plans/stillhaven-module.md`).
+- **WP-001–004 web port phase 2** — deferred post-v1.0 (LAN sync bridge daemon, whisper.wasm STT, WebAuthn in browser).
+
+---
+
+## Notes for Reviewer
+
+When this PR is ready to merge:
+1. The version bump commit should land here (not separately on main).
+2. CHANGELOG.md gets a `## [1.1.0] — YYYY-MM-DD` section in the same commit as the version bump.
+3. After merge, tag `v1.1.0` and the same `tauri-action` pipeline ships installers + AAB.
+4. Run `TAG=v1.1.0 node scripts/update-latest-release-json.cjs` to refresh the website pointer.


### PR DESCRIPTION
> **Draft tracking PR.** Held open across the v1.1.0 cycle. Do not merge until the gate at the bottom of \`active-plans/v1.1.0-android.md\` is fully checked.

## Status snapshot (2026-05-19)

- **Atomic Play Store work is already done** — happily. WEAR-002 (\`applicationId\` alignment in phone + wear \`build.gradle.kts\`) and PS-004 (AAB SHA-256 checksums in \`latest-release.json\`) both landed during the v1.0 cycle. See \`active-plans/v1.1.0-android.md\` for commit + PR refs.
- **Remaining v1.1.0 work:**
  - \`/qa\` on phone app — find + fix P0/P1
  - \`/qa\` on wear app — find + fix P0/P1
  - \`/design-review\` on wear app (visual parity with desktop)
  - Android E2E: voice memo on watch → transfer to phone → transcription on desktop
  - Bump version → 1.1.0 in package.json + Cargo.toml + tauri.conf.json + VERSION
  - CHANGELOG entry
  - Tag \`v1.1.0\`, run \`scripts/update-latest-release-json.cjs\`

## Source of truth

Full milestone block lives in \`active-plans/roadmap-v1.0.md\` (v1.1.0 section). This PR's body and \`active-plans/v1.1.0-android.md\` are the day-to-day tracking; the roadmap is the canonical gate.

## Why a draft PR?

So that:
- Commits accumulate on a single tracked branch instead of a flurry of small \`fix(android): …\` PRs against main.
- CI runs on every push catches regressions before the eventual final tag.
- Reviewers can see the cumulative diff at any time.

## Not in this PR's scope

- StillHaven (v1.2.0, see \`active-plans/stillhaven-module.md\`).
- Web port phase 2 (deferred post-1.0).
- Watch Phase 5 AI enrichment (deferred post-1.0).

## Test plan

- [ ] CI green on every push to this branch
- [ ] \`/qa\` reports clean for phone + wear
- [ ] \`/design-review\` reports clean for wear
- [ ] Android E2E succeeds on a real device pair
- [ ] Version bumps land in a single commit (atomic across the four version sources)
- [ ] CHANGELOG \`## [1.1.0]\` entry written
- [ ] Convert from draft to ready-for-review only after the gate is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)