### PR TITLE
feat(stillhaven): journal handoff — close the somatic processing loop

### DIFF
--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -168,6 +168,15 @@ commands.allow = [
   "get_due_capsules",
   "unseal_entry",
   "get_mood_delta",
+  # StillHaven (somatic session module)
+  "still_create_session",
+  "still_record_activation",
+  "still_complete_session",
+  "still_abandon_session",
+  "still_list_sessions",
+  "still_get_session_with_samples",
+  # Journal ↔ session link
+  "link_journal_entry_to_session",
 ]
 
 [default]

--- a/src-tauri/src/commands/journal.rs
+++ b/src-tauri/src/commands/journal.rs
@@ -236,6 +236,18 @@ pub fn patch_entry_status(
     db::patch_entry_status(&db, &id, &status)
 }
 
+/// Link a journal entry to a StillHaven session.
+#[tauri::command]
+pub fn link_journal_entry_to_session(
+    db: State<Database>,
+    lock: State<'_, AppLockState>,
+    entry_id: String,
+    session_id: String,
+) -> Result<(), String> {
+    require_unlocked(&lock)?;
+    db::link_journal_entry_to_session(&db, &entry_id, &session_id)
+}
+
 /// Sync tags for an entry (replaces all existing tags).
 #[tauri::command]
 pub fn sync_entry_tags(

--- a/src-tauri/src/commands/peer_sync_engine/conflict.rs
+++ b/src-tauri/src/commands/peer_sync_engine/conflict.rs
@@ -189,6 +189,7 @@ pub fn db_get_entries_full(
                 unsealed_at: r.get(12)?,
                 tags,
                 status: None,
+                session_id: None,
             })
         })
         .map_err(|e| format!("query entries full: {e}"))?

--- a/src-tauri/src/commands/time_capsule.rs
+++ b/src-tauri/src/commands/time_capsule.rs
@@ -144,6 +144,7 @@ pub fn get_due_capsules(
             unsealed_at,
             tags: parse_tags(tags_str),
             status: None,
+            session_id: None,
         })
     });
 

--- a/src-tauri/src/db/journal.rs
+++ b/src-tauri/src/db/journal.rs
@@ -41,6 +41,8 @@ pub struct JournalEntryRow {
     pub unsealed_at: Option<String>,
     /// Entry state: 'thinking' | 'complete' | 'revisit' (default: 'complete')
     pub status: Option<String>,
+    /// StillHaven session this entry was written after (nullable)
+    pub session_id: Option<String>,
 }
 
 /// Journal entry metadata (without content, for list views)
@@ -66,7 +68,7 @@ pub fn parse_tags(tags_str: Option<String>) -> Vec<String> {
 /// 4  location_weather, 5  book_id, 6  pinned, 7  created_at,
 /// 8  updated_at, 9  sealed_until, 10 capsule_type,
 /// 11 linked_original_id, 12 unsealed_at, 13 tags (GROUP_CONCAT),
-/// 14 status
+/// 14 status, 15 session_id
 pub fn map_entry_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<JournalEntryRow> {
     let content_json_opt: Option<String> = row.get(1)?;
     let sealed_until: Option<String> = row.get(9)?;
@@ -75,6 +77,7 @@ pub fn map_entry_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<JournalEntryRo
     let unsealed_at: Option<String> = row.get(12)?;
     let tags_str: Option<String> = row.get(13)?;
     let status: Option<String> = row.get(14).ok().flatten();
+    let session_id: Option<String> = row.get(15).ok().flatten();
 
     // Withhold content for entries that are sealed but not yet revealed.
     let is_sealed = sealed_until.is_some() && unsealed_at.is_none();
@@ -108,6 +111,7 @@ pub fn map_entry_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<JournalEntryRo
         unsealed_at,
         tags: parse_tags(tags_str),
         status,
+        session_id,
     })
 }
 
@@ -137,7 +141,7 @@ pub fn create_entry(
 
     conn.query_row(
         "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                 COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
          FROM journal_entries je
          LEFT JOIN entry_tags et ON je.id = et.entry_id
@@ -174,6 +178,21 @@ pub fn patch_entry_status(db: &Database, id: &str, status: &str) -> Result<(), S
         params![status, id],
     )
     .map_err(|e| format!("Failed to patch status: {}", e))?;
+    Ok(())
+}
+
+/// Link a journal entry to a StillHaven session.
+pub fn link_journal_entry_to_session(
+    db: &Database,
+    entry_id: &str,
+    session_id: &str,
+) -> Result<(), String> {
+    let conn = db.conn.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE journal_entries SET session_id = ?1 WHERE id = ?2",
+        params![session_id, entry_id],
+    )
+    .map_err(|e| format!("Failed to link entry to session: {}", e))?;
     Ok(())
 }
 
@@ -266,7 +285,7 @@ pub fn get_entry(db: &Database, id: &str) -> Result<Option<JournalEntryRow>, Str
 
     let result = conn.query_row(
         "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                 COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
          FROM journal_entries je
          LEFT JOIN entry_tags et ON je.id = et.entry_id
@@ -293,7 +312,7 @@ pub fn get_all_entries(db: &Database, limit: Option<i32>) -> Result<Vec<JournalE
     let mut stmt = conn
         .prepare(&format!(
             "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                     COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
              FROM journal_entries je
              LEFT JOIN entry_tags et ON je.id = et.entry_id
@@ -324,7 +343,7 @@ pub fn get_entries_by_date_range(
     let mut stmt = conn
         .prepare(
             "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                     COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
              FROM journal_entries je
              LEFT JOIN entry_tags et ON je.id = et.entry_id
@@ -351,7 +370,7 @@ pub fn get_entries_on_this_day(db: &Database) -> Result<Vec<JournalEntryRow>, St
     let mut stmt = conn
         .prepare(
             "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                    je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                     COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
              FROM journal_entries je
              LEFT JOIN entry_tags et ON je.id = et.entry_id
@@ -400,7 +419,7 @@ pub fn update_entry(
 
     conn.query_row(
         "SELECT je.id, je.encrypted_content, je.mood, je.privacy_mode, je.location_weather, je.book_id, je.pinned, je.created_at, je.updated_at,
-                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status,
+                je.sealed_until, je.capsule_type, je.linked_original_id, je.unsealed_at, je.status, je.session_id,
                 COALESCE(GROUP_CONCAT(t.name, ','), '') as tags
          FROM journal_entries je
          LEFT JOIN entry_tags et ON je.id = et.entry_id

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -131,6 +131,12 @@ impl Database {
             [],
         );
 
+        // Runtime migration: StillHaven session link (J3)
+        let _ = conn.execute(
+            "ALTER TABLE journal_entries ADD COLUMN session_id TEXT",
+            [],
+        );
+
         // Runtime migration: media attachments table
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS entry_media (

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -209,6 +209,7 @@ pub fn run() {
             commands::patch_entry_location_weather,
             commands::patch_entry_pinned,
             commands::patch_entry_status,
+            commands::link_journal_entry_to_session,
             commands::sync_entry_tags,
             commands::get_book_tags,
             // Statistics

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ function MainApp() {
    * without needing to navigate away.
    */
   const [writingKey, setWritingKey] = useState(0);
+  const [handoffHtml, setHandoffHtml] = useState<string | null>(null);
   const [sealingEntryId, setSealingEntryId] = useState<string | null>(null);
   const [timelineRefresh, setTimelineRefresh] = useState(0);
 
@@ -278,6 +279,8 @@ function MainApp() {
               <WritingView
                 key={selectedEntryId ?? `new-${writingKey}`}
                 entryId={selectedEntryId}
+                initialHtml={handoffHtml}
+                onInitialHtmlConsumed={() => setHandoffHtml(null)}
                 onEntrySaved={() => {/* timeline refreshes on next navigation */}}
                 onNewEntry={handleNewEntry}
                 onNavigateToSTTSettings={() => handleNavigateToSettings('speech-to-text')}
@@ -332,7 +335,14 @@ function MainApp() {
           {/* StillHaven — somatic companion module (feature flag + user opt-in) */}
           {currentView === 'still' && import.meta.env.VITE_FEATURE_STILL && stillhavenEnabled && (
             <ErrorBoundary>
-              <StillView />
+              <StillView
+                onHandoff={(html) => {
+                  setHandoffHtml(html);
+                  setSelectedEntryId(null);
+                  setWritingKey((k) => k + 1);
+                  setCurrentView('writing');
+                }}
+              />
             </ErrorBoundary>
           )}
         </div>

--- a/src/hooks/useStillBioFeedback.ts
+++ b/src/hooks/useStillBioFeedback.ts
@@ -34,6 +34,8 @@ export function useStillBioFeedback({ enabled, baseSpeed }: Options): Result {
     }
 
     let cancelled = false;
+    let unlistenFn: (() => void) | null = null;
+
     // Dynamic import keeps the web bundle clean — tauri event module is absent there.
     import('@tauri-apps/api/event').then(({ listen }) => {
       if (cancelled) return;
@@ -73,11 +75,15 @@ export function useStillBioFeedback({ enabled, baseSpeed }: Options): Result {
             setIsAdapting(false);
           }
         }, STALE_MS);
+      }).then((unlisten) => {
+        if (cancelled) { unlisten(); return; }
+        unlistenFn = unlisten;
       }).catch(() => { /* Tauri not available */ });
     }).catch(() => { /* module unavailable in web build */ });
 
     return () => {
       cancelled = true;
+      unlistenFn?.();
       if (staleTimerRef.current) clearTimeout(staleTimerRef.current);
     };
   }, [enabled, baseSpeed]);

--- a/src/lib/backend/browser-invoke.ts
+++ b/src/lib/backend/browser-invoke.ts
@@ -41,6 +41,7 @@ import {
   dbStillUpdateSession,
   dbStillListSessions,
   dbStillGetSessionWithSamples,
+  dbLinkJournalEntryToSession,
   type BrowserEntryRow,
   type BrowserBook,
   type BrowserStillSession,
@@ -510,6 +511,9 @@ async function dispatch(command: string, p: Params): Promise<any> {
     }
     case 'still_get_session_with_samples': {
       return dbStillGetSessionWithSamples(p.id as string);
+    }
+    case 'link_journal_entry_to_session': {
+      return dbLinkJournalEntryToSession(p.entryId as string, p.sessionId as string);
     }
 
     // Session bridge — no-op in browser

--- a/src/lib/backend/browser.ts
+++ b/src/lib/backend/browser.ts
@@ -132,6 +132,7 @@ export interface BrowserEntryRow {
   linked_original_id: string | null;
   unsealed_at: string | null;
   status: string | null;
+  session_id?: string | null;
 }
 
 // --------------------------------------------------------------------------
@@ -551,6 +552,19 @@ export async function dbStillGetSessionWithSamples(
     .filter((s) => s.session_id === id)
     .sort((a, b) => a.sampled_at.localeCompare(b.sampled_at));
   return { session, samples };
+}
+
+export async function dbLinkJournalEntryToSession(
+  entryId: string,
+  sessionId: string,
+): Promise<void> {
+  const db = await openDB();
+  const t = tx(db, 'journal_entries', 'readwrite');
+  const store = t.objectStore('journal_entries');
+  const existing = await get<BrowserEntryRow>(store, entryId);
+  if (existing) {
+    await put(store, { ...existing, session_id: sessionId });
+  }
 }
 
 // --------------------------------------------------------------------------

--- a/src/lib/services/journalService.ts
+++ b/src/lib/services/journalService.ts
@@ -152,13 +152,26 @@ export function getSessionPassword(): string | null {
 /**
  * Create a new journal entry (encrypts content automatically)
  */
+function extractAndStripSessionId(html: string): { cleaned: string; sessionId: string | null } {
+  const match = html.match(/<span[^>]+data-still-session-id="([^"]+)"[^>]*>.*?<\/span>/);
+  if (!match) return { cleaned: html, sessionId: null };
+  return {
+    cleaned: html.replace(match[0], ''),
+    sessionId: match[1],
+  };
+}
+
 export async function createEntry(
   data: JournalEntryFormData & { locationWeather?: LocationWeather; bookId?: string }
 ): Promise<JournalEntry> {
   const password = getPassword();
 
+  // Strip hidden StillHaven session marker before encrypting
+  const { cleaned: cleanedContent, sessionId } = extractAndStripSessionId(data.content);
+  const contentToSave = sessionId ? cleanedContent : data.content;
+
   // Encrypt the content
-  const result = await encrypt(data.content, password);
+  const result = await encrypt(contentToSave, password);
 
   if (!result.success || !result.data) {
     throw new Error(result.error || 'Encryption failed');
@@ -182,10 +195,17 @@ export async function createEntry(
     await invoke('sync_entry_tags', { id, tags: data.tags });
   }
 
+  // Link to StillHaven session if marker was present
+  if (sessionId) {
+    linkEntryToSession(id, sessionId).catch((e) => {
+      console.warn('[journalService] session link failed (non-fatal):', e);
+    });
+  }
+
   // Return decrypted entry
   return {
     id: row.id,
-    content: data.content, // We already have the plaintext
+    content: contentToSave, // plaintext with session marker stripped
     mood: row.mood as MoodLevel,
     privacyMode: (row.privacy_mode ?? 0) as PrivacyMode,
     tags: data.tags,
@@ -469,6 +489,13 @@ export async function patchEntryLocationWeather(
  */
 export async function patchEntryPinned(id: string, pinned: boolean): Promise<void> {
   await invoke('patch_entry_pinned', { id, pinned });
+}
+
+/**
+ * Link a journal entry to a StillHaven session after the entry is created.
+ */
+export async function linkEntryToSession(entryId: string, sessionId: string): Promise<void> {
+  await invoke('link_journal_entry_to_session', { entryId, sessionId });
 }
 
 /**

--- a/src/modules/stillhaven/handoff.ts
+++ b/src/modules/stillhaven/handoff.ts
@@ -1,0 +1,68 @@
+import type { ViewType } from '../../components/layout/Sidebar';
+import type { StillSession, StillActivationSample } from '../../lib/stillService';
+
+function protocolLabel(protocol: string): string {
+  switch (protocol) {
+    case 'general_activation': return 'general grounding';
+    case 'fake_danger': return 'fake danger reset';
+    default: return protocol.replace(/_/g, ' ');
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0
+    ? `${m} minute${m !== 1 ? 's' : ''}${s > 0 ? ` ${s}s` : ''}`
+    : `${s} seconds`;
+}
+
+export function renderSessionTemplate(
+  session: StillSession,
+  preSample: StillActivationSample,
+  postSample: StillActivationSample,
+): string {
+  const delta = preSample.activation - postSample.activation;
+  const deltaStr =
+    delta > 0
+      ? `down ${delta}`
+      : delta < 0
+      ? `up ${Math.abs(delta)}`
+      : 'unchanged';
+
+  const hrvLine =
+    postSample.hrv_manual !== null
+      ? `<p><strong>HRV:</strong> ${postSample.hrv_manual} ms (manual)</p>`
+      : preSample.hrv_manual !== null
+      ? `<p><strong>HRV (pre):</strong> ${preSample.hrv_manual} ms</p>`
+      : '';
+
+  const noteLine =
+    postSample.note
+      ? `<p><em>${postSample.note}</em></p>`
+      : '';
+
+  return [
+    `<span data-still-session-id="${session.id}" style="display:none"></span>`,
+    `<h3>StillHaven — ${formatDuration(session.duration_seconds)}, ${protocolLabel(session.protocol)}</h3>`,
+    `<p><strong>Activation:</strong> ${preSample.activation} → ${postSample.activation} (${deltaStr})</p>`,
+    hrvLine,
+    `<p><strong>What shifted, if anything?</strong></p>`,
+    noteLine || `<p></p>`,
+    `<p></p>`,
+  ].filter(Boolean).join('\n');
+}
+
+export function handoffToJournal(args: {
+  setCurrentView: (v: ViewType) => void;
+  setPendingHandoffHtml: (html: string) => void;
+  bumpWritingKey: () => void;
+  session: StillSession;
+  preSample: StillActivationSample;
+  postSample: StillActivationSample;
+}): void {
+  const html = renderSessionTemplate(args.session, args.preSample, args.postSample);
+  args.setPendingHandoffHtml(html);
+  args.bumpWritingKey();
+  args.setCurrentView('writing');
+}

--- a/src/modules/stillhaven/handoff.ts
+++ b/src/modules/stillhaven/handoff.ts
@@ -1,6 +1,14 @@
 import type { ViewType } from '../../components/layout/Sidebar';
 import type { StillSession, StillActivationSample } from '../../lib/stillService';
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function protocolLabel(protocol: string): string {
   switch (protocol) {
     case 'general_activation': return 'general grounding';
@@ -39,7 +47,7 @@ export function renderSessionTemplate(
 
   const noteLine =
     postSample.note
-      ? `<p><em>${postSample.note}</em></p>`
+      ? `<p><em>${escapeHtml(postSample.note)}</em></p>`
       : '';
 
   return [

--- a/src/modules/stillhaven/index.tsx
+++ b/src/modules/stillhaven/index.tsx
@@ -14,11 +14,13 @@ import {
   stillAbandonSession,
   stillListSessions,
   type StillSession,
+  type StillActivationSample,
 } from '../../lib/stillService';
 import { getStatus, getContext } from '../../lib/services/ouraService';
 import type { OuraHealthContext } from '../../types/oura';
 import { biometricToSpeed } from './engine/bioMapping';
 import { useStillBioFeedback } from '../../hooks/useStillBioFeedback';
+import { renderSessionTemplate } from './handoff';
 import type { EngineConfig } from './engine/bilateralEngine';
 
 const WELCOME_SEEN_KEY = 'mb_still_welcome_seen';
@@ -57,9 +59,16 @@ interface SummaryData {
   preActivation: number;
   postActivation: number;
   durationSeconds: number;
+  session: StillSession;
+  preSample: StillActivationSample;
+  postSample: StillActivationSample;
 }
 
-export function StillView(): React.JSX.Element {
+interface StillViewProps {
+  onHandoff?: (html: string) => void;
+}
+
+export function StillView({ onHandoff }: StillViewProps): React.JSX.Element {
   const [scene, setScene] = useState<SceneState>('loading');
   const [abandonedSession, setAbandonedSession] = useState<StillSession | null>(null);
   const [checkIn, setCheckIn] = useState<CheckInData>({ protocol: null, preActivation: null });
@@ -68,6 +77,8 @@ export function StillView(): React.JSX.Element {
 
   const sessionIdRef = useRef<string | null>(null);
   const sessionStartRef = useRef<number>(0);
+  const sessionRowRef = useRef<StillSession | null>(null);
+  const preSampleRef = useRef<StillActivationSample | null>(null);
   const ouraCtxRef = useRef<Pick<OuraHealthContext, 'readinessScore' | 'stressSummary'> | null>(null);
   const [ouraConnected, setOuraConnected] = useState(false);
   const protocolSpeedRef = useRef<number>(1.0);
@@ -156,9 +167,12 @@ export function StillView(): React.JSX.Element {
       bilateralMode: 'audio',
       durationSeconds: 0,
       startedAt: now,
-    }).then(() =>
-      stillRecordActivation({ sessionId: id, phase: 'pre', activation: preActivation })
-    ).catch(() => {/* silent — data loss here is acceptable vs blocking the session */});
+    }).then((sess) => {
+      sessionRowRef.current = sess;
+      return stillRecordActivation({ sessionId: id, phase: 'pre', activation: preActivation });
+    }).then((sample) => {
+      preSampleRef.current = sample;
+    }).catch(() => {/* silent — data loss here is acceptable vs blocking the session */});
 
     // MUST remain synchronous — AudioContext requires user gesture.
     // Protocol + activation level determine starting rhythm speed; Oura data refines it.
@@ -188,8 +202,9 @@ export function StillView(): React.JSX.Element {
     const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
     const now = new Date().toISOString();
 
+    let postSample: StillActivationSample | null = null;
     try {
-      await stillRecordActivation({
+      postSample = await stillRecordActivation({
         sessionId: id,
         phase: 'post',
         activation: postActivation,
@@ -202,13 +217,34 @@ export function StillView(): React.JSX.Element {
       // best-effort; don't block the user from seeing summary
     }
 
+    const effectivePre = checkIn.preActivation ?? postActivation;
+    // Build synthetic samples for handoff if DB writes failed
+    const preSample: StillActivationSample = preSampleRef.current ?? {
+      id: 0, session_id: id, phase: 'pre', activation: effectivePre,
+      hrv_manual: null, hrv_source: null, note: null,
+      sampled_at: new Date().toISOString(),
+    };
+    const postSampleFinal: StillActivationSample = postSample ?? {
+      id: 0, session_id: id, phase: 'post', activation: postActivation,
+      hrv_manual: hrv ?? null, hrv_source: hrv !== null ? 'manual' : null,
+      note: note.trim() || null, sampled_at: now,
+    };
+
     setSummary({
-      preActivation: checkIn.preActivation ?? postActivation,
+      preActivation: effectivePre,
       postActivation,
       durationSeconds,
+      session: sessionRowRef.current ?? {
+        id, protocol: checkIn.protocol ?? 'general_activation',
+        environment: 'underwater', bilateral_mode: 'audio',
+        duration_seconds: durationSeconds, started_at: now,
+        completed_at: now, abandoned_at: null, created_at: now,
+      },
+      preSample,
+      postSample: postSampleFinal,
     });
     setScene('summary');
-  }, [checkOut, checkIn.preActivation]);
+  }, [checkOut, checkIn.preActivation, checkIn.protocol]);
 
   const handleRestart = useCallback(() => {
     sessionIdRef.current = null;
@@ -357,13 +393,27 @@ export function StillView(): React.JSX.Element {
             {delta > 0 ? `${delta} point${delta !== 1 ? 's' : ''} lower` : `${Math.abs(delta)} point${Math.abs(delta) !== 1 ? 's' : ''} higher`}
           </p>
         )}
-        <button
-          type="button"
-          onClick={handleRestart}
-          className="px-6 py-2.5 rounded-full border border-neutral-200 text-neutral-600 text-sm hover:bg-neutral-50 transition-colors"
-        >
-          New session
-        </button>
+        <div className="flex flex-col gap-2 w-full max-w-xs">
+          {onHandoff && (
+            <button
+              type="button"
+              onClick={() => {
+                const html = renderSessionTemplate(summary.session, summary.preSample, summary.postSample);
+                onHandoff(html);
+              }}
+              className="w-full px-6 py-2.5 rounded-full bg-[#F28C38] text-white text-sm font-semibold shadow hover:bg-[#e07c28] transition-colors"
+            >
+              Write about it
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleRestart}
+            className="w-full px-6 py-2.5 rounded-full border border-neutral-200 text-neutral-600 text-sm hover:bg-neutral-50 transition-colors"
+          >
+            New session
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/pages/WritingView.tsx
+++ b/src/pages/WritingView.tsx
@@ -57,6 +57,10 @@ interface WritingViewProps {
   onEntrySaved?: () => void;
   onNewEntry?: () => void;
   onNavigateToSTTSettings?: () => void;
+  /** Pre-filled HTML injected once on mount (e.g. StillHaven handoff). */
+  initialHtml?: string | null;
+  /** Called after initialHtml has been consumed so the parent can clear it. */
+  onInitialHtmlConsumed?: () => void;
   /** Optional ref populated with a function that immediately flushes any
    *  pending auto-save. Useful for callers (e.g. breakout window) that need
    *  to save before closing without waiting for the debounce timer. */
@@ -153,7 +157,7 @@ const PRIVACY_ACTIVE_COLORS: Record<PrivacyMode, string> = {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, onNavigateToSTTSettings, saveRef }: WritingViewProps) {
+export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, onNavigateToSTTSettings, initialHtml, onInitialHtmlConsumed, saveRef }: WritingViewProps) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [contentText, setContentText] = useState('');
@@ -177,6 +181,15 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
   const [isEditorFocused, setIsEditorFocused] = useState(false);
   const [pendingInsert, setPendingInsert] = useState<string | null>(null);
   const [pendingInsertHtml, setPendingInsertHtml] = useState<string | null>(null);
+
+  // Seed from StillHaven handoff (fires once on mount when initialHtml is provided)
+  useEffect(() => {
+    if (initialHtml) {
+      setPendingInsertHtml(initialHtml);
+      onInitialHtmlConsumed?.();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Tracks the DB entry ID created by the first auto-save.


### PR DESCRIPTION
## Summary

Closes the full StillHaven loop: **check-in → session → check-out → journal entry**.

After a session completes, the user sees a **"Write about it"** button on the summary screen. Tapping it navigates to WritingView with a pre-filled entry:

```
StillHaven — 5 minutes, general grounding
Activation: 7 → 4 (down 3)
HRV: 38 ms (manual)
What shifted, if anything?

[cursor here]
```

The session is automatically linked to the entry via a hidden `data-still-session-id` marker that is stripped before encryption — no session data leaks into the stored content.

### What changed

- **DB:** `journal_entries.session_id TEXT` column (runtime ALTER J3)
- **Rust:** `JournalEntryRow` + all SELECT queries updated; `link_journal_entry_to_session` command
- **`journalService.createEntry`:** strips hidden marker from HTML before encrypting, fires `linkEntryToSession` after entry is created (non-fatal if it fails)
- **`browser.ts` / `browser-invoke.ts`:** IDB shim for the new command
- **`handoff.ts`:** `renderSessionTemplate` + `handoffToJournal`
- **`StillView`:** `onHandoff` prop; "Write about it" button in summary; `SummaryData` carries session + sample rows
- **`App.tsx`:** `handoffHtml` state; `StillView` receives `onHandoff`; `WritingView` receives `initialHtml`
- **`WritingView`:** `initialHtml` + `onInitialHtmlConsumed` props; seeds `pendingInsertHtml` on mount

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 702 pass
- [ ] `cargo check` — clean
- [ ] Complete a StillHaven session → summary screen shows "Write about it" button
- [ ] Tap "Write about it" → navigates to writing view with pre-filled template
- [ ] Template contains activation delta, HRV if entered, protocol, duration
- [ ] Auto-save fires → entry is saved with session_id linked in DB
- [ ] "New session" still works (no regression)
- [ ] Browser build: `npm run build:web` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)