### PR TITLE
feat(wrist-loop): v1.5.0 — watch ⊙ Still button triggers StillHaven on desktop

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearListenerService.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearListenerService.kt
@@ -58,9 +58,10 @@ class WearListenerService : WearableListenerService() {
         }
 
         when (event.path) {
-            WearProtocol.PATH_SIGNAL          -> handleSignalMessage(event.sourceNodeId, payload)
-            WearProtocol.PATH_VOICE_MEMO_META -> Log.i(TAG, "Legacy /voice_memo message ignored — using ChannelAPI")
-            else                              -> Log.w(TAG, "Unhandled path: ${event.path}")
+            WearProtocol.PATH_SIGNAL           -> handleSignalMessage(event.sourceNodeId, payload)
+            WearProtocol.PATH_STILLHAVEN_START -> handleStillhavenStart(event.sourceNodeId)
+            WearProtocol.PATH_VOICE_MEMO_META  -> Log.i(TAG, "Legacy /voice_memo message ignored — using ChannelAPI")
+            else                               -> Log.w(TAG, "Unhandled path: ${event.path}")
         }
     }
 
@@ -93,6 +94,12 @@ class WearListenerService : WearableListenerService() {
             WearSignalBuffer.enqueue(rawJson)
             Log.w(TAG, "WearPlugin not ready; buffered signal $id")
         }
+    }
+
+    private fun handleStillhavenStart(nodeId: String) {
+        Log.i(TAG, "StillHaven start requested from watch node=$nodeId")
+        WearPlugin.getInstance()?.bridgeStillhavenStart(nodeId)
+            ?: Log.w(TAG, "WearPlugin not ready; StillHaven start dropped")
     }
 
     // ── ChannelAPI (audio transfer) ───────────────────────────────────────────

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearPlugin.kt
@@ -53,6 +53,9 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         /** Tauri event name for connection state changes */
         const val EVENT_CONNECTION = "wear://connection"
 
+        /** Tauri event name emitted when the watch requests a StillHaven session start */
+        const val EVENT_STILLHAVEN_START = "wear://stillhaven_start"
+
         @Volatile
         private var _instance: WearPlugin? = null
 
@@ -141,6 +144,21 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         }
         trigger(EVENT_VOICE_MEMO, event)
         Log.d(TAG, "Emitted $EVENT_VOICE_MEMO: id=$id duration=${durationMs}ms")
+    }
+
+    // ── Bridge from WearListenerService (StillHaven start) ───────────────────
+
+    /**
+     * Called by WearListenerService when the watch sends a /stillhaven/start message.
+     * Emits a Tauri event so the TypeScript layer can navigate to the StillHaven view.
+     */
+    fun bridgeStillhavenStart(nodeId: String) {
+        val event = JSObject().apply {
+            put("nodeId", nodeId)
+            put("requestedAt", nowIso8601())
+        }
+        trigger(EVENT_STILLHAVEN_START, event)
+        Log.d(TAG, "Emitted $EVENT_STILLHAVEN_START from node=$nodeId")
     }
 
     // ── Foreground ChannelAPI audio processing ────────────────────────────────

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearProtocol.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearProtocol.kt
@@ -17,6 +17,9 @@ object WearProtocol {
     /** ChannelAPI path for audio stream transfers from the watch. */
     const val CHANNEL_AUDIO = "/audio_channel"
 
+    /** MessageAPI path for "start a StillHaven grounding session on the desktop" from watch → phone. */
+    const val PATH_STILLHAVEN_START = "/stillhaven/start"
+
     /** MessageAPI path for haptic feedback sent from phone → watch. */
     const val PATH_FEEDBACK = "/feedback"
 

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/RecordFragment.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/RecordFragment.kt
@@ -46,9 +46,10 @@ class RecordFragment : Fragment() {
     private lateinit var queueBadge:       TextView
     private lateinit var longPressHint:    TextView
     private lateinit var arcProgress:      ArcProgressView
-    private lateinit var moodShortcutBtn:  TextView
+    private lateinit var moodShortcutBtn:    TextView
     private lateinit var breatheShortcutBtn: TextView
-    private lateinit var pageRoot:         ScrollView
+    private lateinit var groundShortcutBtn:  TextView
+    private lateinit var pageRoot:           ScrollView
 
     // ── State ─────────────────────────────────────────────────────────────────
 
@@ -96,11 +97,13 @@ class RecordFragment : Fragment() {
         arcProgress        = view.findViewById(R.id.arcProgress)
         moodShortcutBtn    = view.findViewById(R.id.moodShortcutBtn)
         breatheShortcutBtn = view.findViewById(R.id.breatheShortcutBtn)
+        groundShortcutBtn  = view.findViewById(R.id.groundShortcutBtn)
 
         recordBtn.setOnClickListener { onRecordTap() }
         recordBtn.setOnLongClickListener { onRecordLongPress(); true }
         moodShortcutBtn.setOnClickListener { (activity as? Callback)?.onNavigateToMoodPicker() }
         breatheShortcutBtn.setOnClickListener { (activity as? Callback)?.onNavigateToBreathe() }
+        groundShortcutBtn.setOnClickListener { onGroundTap() }
 
         setIdleUI()
         refreshQueueBadge()
@@ -132,6 +135,16 @@ class RecordFragment : Fragment() {
 
     private fun onRecordTap() {
         if (session?.isRecording == true) stopRecording() else startRecording()
+    }
+
+    private fun onGroundTap() {
+        if (session?.isRecording == true) return  // don't interrupt a recording
+        hapticTap(requireContext())
+        statusText.text = "Starting on desktop…"
+        lifecycleScope.launch {
+            SignalSender.sendStillhavenStart(requireContext())
+            view?.postDelayed({ if (isAdded) setIdleUI() }, 2_000)
+        }
     }
 
     private fun onRecordLongPress() {

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SignalSender.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/SignalSender.kt
@@ -24,6 +24,7 @@ object SignalSender {
 
     private const val TAG = "MoodBloomWear"
     private const val SIGNAL_PATH = "/signal"
+    private const val STILLHAVEN_PATH = "/stillhaven/start"
 
     /**
      * Send a mood tap signal to all connected phone nodes.
@@ -69,6 +70,32 @@ object SignalSender {
             }
             Log.i(TAG, "drainAndSend: sent $sent/${pending.size}")
             sent
+        }
+
+    /**
+     * Send a "start StillHaven grounding session on the desktop" request to the phone.
+     * Fire-and-forget — not queued offline. If the phone is unreachable the tap is silently
+     * dropped; the user can retry by tapping the button again.
+     * Returns true if the message was accepted by the local Data Layer for at least one node.
+     */
+    suspend fun sendStillhavenStart(context: Context): Boolean =
+        withContext(Dispatchers.IO) {
+            try {
+                val nodes = Tasks.await(Wearable.getNodeClient(context).connectedNodes)
+                if (nodes.isEmpty()) {
+                    Log.w(TAG, "sendStillhavenStart: no connected nodes")
+                    return@withContext false
+                }
+                val msgClient = Wearable.getMessageClient(context)
+                for (node in nodes) {
+                    Tasks.await(msgClient.sendMessage(node.id, STILLHAVEN_PATH, ByteArray(0)))
+                    Log.i(TAG, "StillHaven start → ${node.displayName} (${node.id})")
+                }
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, "sendStillhavenStart failed: ${e.message}")
+                false
+            }
         }
 
     // ── Internal ──────────────────────────────────────────────────────────────

--- a/src-tauri/gen/android/wear/src/main/res/layout/fragment_record.xml
+++ b/src-tauri/gen/android/wear/src/main/res/layout/fragment_record.xml
@@ -119,7 +119,7 @@
             android:paddingStart="4dp"
             android:paddingEnd="4dp" />
 
-        <!-- Shortcut row: Mood + Breathe -->
+        <!-- Shortcut row: Mood + Breathe + Still -->
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -138,7 +138,7 @@
                 android:paddingEnd="10dp"
                 android:paddingTop="5dp"
                 android:paddingBottom="5dp"
-                android:layout_marginEnd="8dp"
+                android:layout_marginEnd="6dp"
                 android:clickable="true"
                 android:focusable="true" />
 
@@ -149,6 +149,22 @@
                 android:text="🧘 Breathe"
                 android:textSize="11sp"
                 android:textColor="@color/wear_text_primary_alpha80"
+                android:background="@drawable/ic_record_btn"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:paddingTop="5dp"
+                android:paddingBottom="5dp"
+                android:layout_marginEnd="6dp"
+                android:clickable="true"
+                android:focusable="true" />
+
+            <TextView
+                android:id="@+id/groundShortcutBtn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="⊙ Still"
+                android:textSize="11sp"
+                android:textColor="@color/brand_primary_300"
                 android:background="@drawable/ic_record_btn"
                 android:paddingStart="10dp"
                 android:paddingEnd="10dp"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,10 @@ function MainApp() {
   useWearSignals({
     password: sessionPassword ?? '',
     enabled: isUnlocked && !!sessionPassword,
+    onStillhavenStart:
+      import.meta.env.VITE_FEATURE_STILL && stillhavenEnabled
+        ? () => setCurrentView('still')
+        : undefined,
   });
 
   // Peer-to-peer sync — initializes device identity and starts mDNS discovery.

--- a/src/hooks/useWearSignals.ts
+++ b/src/hooks/useWearSignals.ts
@@ -67,6 +67,8 @@ interface UseWearSignalsOptions {
   onSignal?: (signal: Signal) => void;
   /** Called after a voice memo is successfully stored */
   onVoiceMemo?: (memo: VoiceMemo) => void;
+  /** Called when the watch requests a StillHaven grounding session start */
+  onStillhavenStart?: () => void;
   /** Called on error (validation failure, encryption error, etc.) */
   onError?: (error: string) => void;
   /** If false, the listener is not attached (e.g., while locked) */
@@ -79,15 +81,18 @@ export function useWearSignals({
   password,
   onSignal,
   onVoiceMemo,
+  onStillhavenStart,
   onError,
   enabled = true,
 }: UseWearSignalsOptions) {
   const onSignalRef = useRef(onSignal);
   const onVoiceMemoRef = useRef(onVoiceMemo);
+  const onStillhavenStartRef = useRef(onStillhavenStart);
   const onErrorRef = useRef(onError);
 
   useEffect(() => { onSignalRef.current = onSignal; }, [onSignal]);
   useEffect(() => { onVoiceMemoRef.current = onVoiceMemo; }, [onVoiceMemo]);
+  useEffect(() => { onStillhavenStartRef.current = onStillhavenStart; }, [onStillhavenStart]);
   useEffect(() => { onErrorRef.current = onError; }, [onError]);
 
   // ── "wear://signal" event listener ─────────────────────────────────────────
@@ -97,8 +102,14 @@ export function useWearSignals({
 
     let unlisten: UnlistenFn | null = null;
     let unlistenMemo: UnlistenFn | null = null;
+    let unlistenStillhaven: UnlistenFn | null = null;
 
     (async () => {
+      // StillHaven start listener
+      unlistenStillhaven = await listen('wear://stillhaven_start', () => {
+        onStillhavenStartRef.current?.();
+      });
+
       // Signal listener
       unlisten = await listen<WearSignalEvent>('wear://signal', async (event) => {
         const { id, timestamp, type, source, payload } = event.payload;
@@ -166,6 +177,7 @@ export function useWearSignals({
     return () => {
       unlisten?.();
       unlistenMemo?.();
+      unlistenStillhaven?.();
     };
   }, [enabled, password]);
 


### PR DESCRIPTION
## Summary

- Watch gets a new **⊙ Still** shortcut button in the Record screen shortcut row (brand violet tint, styled to match Mood + Breathe chips)
- Tapping it sends a fire-and-forget `/stillhaven/start` MessageAPI message to the phone (not queued offline — if phone is unreachable, tap again)
- Phone bridge routes the new path through `WearListenerService` → `WearPlugin.bridgeStillhavenStart()` → emits `wear://stillhaven_start` Tauri event
- Desktop `useWearSignals` now accepts `onStillhavenStart` callback; `App.tsx` wires it to `setCurrentView('still')`, gated on `VITE_FEATURE_STILL` and `stillhavenEnabled`
- Watch shows "Starting on desktop…" status for 2 seconds, then resets — button is disabled during an active recording

## Signal path

```
Watch tap ⊙ Still
  → SignalSender.sendStillhavenStart()   /stillhaven/start MessageAPI
  → WearListenerService.handleStillhavenStart()
  → WearPlugin.bridgeStillhavenStart()   wear://stillhaven_start Tauri event
  → useWearSignals onStillhavenStart
  → setCurrentView('still')
```

## Test plan

- [ ] `npm test` passes (1166 tests)
- [ ] `npm run typecheck` clean
- [ ] Simulate: `invoke('plugin:wear|wearBridgeSignal', ...)` with path `/stillhaven/start` → app navigates to StillHaven view
- [ ] StillHaven disabled in settings → `onStillhavenStart` is `undefined`, event is a no-op
- [ ] Watch during recording → ⊙ Still tap does nothing (guard in `onGroundTap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)