### PR TITLE
feat(layout): mobile-responsive foundation — useIsMobile + viewport layout

### DIFF
--- a/src-tauri/src/commands/peer_sync_engine/conflict.rs
+++ b/src-tauri/src/commands/peer_sync_engine/conflict.rs
@@ -259,9 +259,13 @@ pub fn db_upsert_book(conn: &Connection, row: &SyncBookRow) -> Result<bool, Stri
             .map_err(|e| format!("insert book: {e}"))?;
             Ok(true)
         }
-        Some(ref local) if {
-            parse_peer_timestamp(local).map(|local_ts| remote_ts > local_ts).unwrap_or(false)
-        } => {
+        Some(ref local)
+            if {
+                parse_peer_timestamp(local)
+                    .map(|local_ts| remote_ts > local_ts)
+                    .unwrap_or(false)
+            } =>
+        {
             conn.execute(
                 "UPDATE books \
                  SET name = ?2, emoji = ?3, color = ?4, sort_order = ?5, \
@@ -475,10 +479,14 @@ pub fn db_upsert_entry(conn: &Connection, row: &JournalEntryRow) -> Result<bool,
             db_upsert_tags(conn, &row.id, &row.tags)?;
             Ok(true)
         }
-        Some(ref local) if {
-            // Parse local timestamp for comparison; fall back to "remote loses" on parse error.
-            parse_peer_timestamp(local).map(|local_ts| remote_ts > local_ts).unwrap_or(false)
-        } => {
+        Some(ref local)
+            if {
+                // Parse local timestamp for comparison; fall back to "remote loses" on parse error.
+                parse_peer_timestamp(local)
+                    .map(|local_ts| remote_ts > local_ts)
+                    .unwrap_or(false)
+            } =>
+        {
             // UPDATE — set updated_at explicitly so the trigger (WHEN NEW.updated_at = OLD.updated_at) doesn't fire
             conn.execute(
                 "UPDATE journal_entries \

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { LockScreen } from './pages/LockScreen';
 import { SetupScreen } from './pages/SetupScreen';
 import { MainLayout, MobileLayout, type ViewType } from './components/layout';
 import { usePlatform } from './hooks/usePlatform';
+import { useIsMobile } from './hooks/useIsMobile';
 import { TutorialWizard } from './components/tutorial';
 import { SyncDetailsModal } from './components/sync/SyncDetailsModal';
 import { useAppStore } from './stores/appStore';
@@ -82,6 +83,7 @@ function MainApp() {
   const [timelineRefresh, setTimelineRefresh] = useState(0);
 
   const { isAndroid, isBrowser } = usePlatform();
+  const isMobileViewport = useIsMobile();
 
   // Schedule reminder notifications (hook checks enabled state internally)
   useReminderScheduler();
@@ -269,8 +271,8 @@ function MainApp() {
     return <WellnessDisclaimerScreen onAccept={handleDisclaimerAccept} />;
   }
 
-  // Main app — MobileLayout on Android, MainLayout on desktop
-  const Layout = isAndroid ? MobileLayout : MainLayout;
+  // Main app — MobileLayout on Android or narrow viewports, MainLayout on desktop
+  const Layout = (isAndroid || isMobileViewport) ? MobileLayout : MainLayout;
   return (
     <ErrorBoundary>
       <Layout

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false
+  );
+
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  return isMobile;
+}
+
+export function useIsIOS(): boolean {
+  const [isIOS, setIsIOS] = useState(() => {
+    if (typeof navigator === 'undefined') return false;
+    // Primary: Tauri WebView on iOS sets a recognisable UA
+    if (/iPad|iPhone|iPod/.test(navigator.userAgent)) return true;
+    // Secondary: iPadOS in desktop mode reports as macOS, check pointer type
+    return navigator.maxTouchPoints > 1 && /Macintosh/.test(navigator.userAgent);
+  });
+
+  useEffect(() => {
+    // Attempt Tauri plugin-os if available (optional dep — not installed by default)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    import('@tauri-apps/plugin-os' as any)
+      .then((mod: { platform: () => Promise<string> }) => {
+        mod.platform()
+          .then((p) => setIsIOS(p === 'ios'))
+          .catch(() => {/* keep UA-based initial value */});
+      })
+      .catch(() => {/* plugin not present — UA value from useState is correct */});
+  }, []);
+
+  return isIOS;
+}


### PR DESCRIPTION
## Summary

- Adds `useIsMobile()` hook (breakpoint: 768px, updates on resize)
- Adds `useIsIOS()` hook (UA detection + iPadOS fallback; gracefully degrades if `@tauri-apps/plugin-os` not installed)
- Wires existing `MobileLayout` into `App.tsx` — desktop gets sidebar, mobile/viewport-narrow gets bottom tab bar
- `BottomTabBar`, `MobileLayout`, and `MobileHeader` were already fully implemented in the codebase; this PR connects them to the viewport detection

## Notes

- Existing desktop layout is unchanged at ≥768px
- Individual view responsiveness (WritingView, TimelineView, etc.) is follow-up work
- iOS-specific feature gates (hide peer sync UI, hide mic button) are separate follow-up

## Test plan

- [ ] Desktop at ≥768px: sidebar visible, bottom tab bar hidden
- [ ] Browser dev tools at <768px: bottom tab bar visible, sidebar hidden
- [ ] Tab navigation works on mobile layout
- [ ] No regression on desktop layout
- [ ] CI: typecheck, lint, tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)