### PR TITLE
feat(ios): Phase 2+4 setup — iOS config, platform detection, feature gates

### DIFF
--- a/.claude/docs/build.md
+++ b/.claude/docs/build.md
@@ -31,6 +31,46 @@ npm install && npm run tauri build
 ```
 Output: .app bundle + .dmg
 
+## iOS (requires macOS + Xcode)
+
+### Prerequisites
+- macOS 13+ with Xcode 15+
+- Apple Developer account (free for Simulator; paid for device/TestFlight)
+- Rust iOS targets:
+```bash
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+```
+
+### First-time setup (run once per machine)
+```bash
+npm run tauri ios init
+# Generates: src-tauri/gen/apple/ (Xcode project)
+```
+
+After `ios init`, open the generated project in Xcode and:
+1. Set your team: Signing & Capabilities → Team → select your Apple Developer account
+   (replaces the `REPLACE_WITH_APPLE_TEAM_ID` placeholder in `tauri.conf.json`)
+2. Add capabilities in Xcode:
+   - Background Modes → Background fetch + Background processing (for deferred sync)
+   - Push Notifications (for reminders)
+3. Info.plist usage descriptions (add manually or via Xcode):
+   - `NSUserNotificationsUsageDescription` — "Receive journaling reminders"
+   - `NSFaceIDUsageDescription` — "Unlock MoodHaven with Face ID" (Phase 5)
+   - `NSMicrophoneUsageDescription` — "Record voice journal entries" (Phase 5 STT)
+
+### Build and run
+```bash
+npm run tauri ios dev       # hot-reload to Simulator or connected device
+npm run tauri ios build     # production .ipa
+```
+Output: `src-tauri/gen/apple/` (Xcode project + build artifacts)
+
+### Notes
+- `bundle.iOS.developmentTeam` in `tauri.conf.json` must match your Apple Team ID
+- STT (whisper.cpp sidecar) is **not available** on iOS — sidecar processes are blocked by the App Sandbox. The mic button is hidden on iOS via `usePlatform().isIOS`.
+- Peer sync (mDNS) is unreliable in iOS foreground — peer sync UI is hidden on iOS.
+- The writer breakout window is desktop-only — hidden on iOS.
+
 ## Troubleshooting
 | Issue | Solution |
 |-------|----------|

--- a/active-plans/auth-friction-reduction.md
+++ b/active-plans/auth-friction-reduction.md
@@ -1,0 +1,170 @@
+# Auth Friction Reduction
+
+**Status:** Item 2 (PIN unlock) done — PR #102 merged. Item 1 (desktop biometric) in progress.  
+**Target:** v1.8.x (desktop) | v2.1.0 (iOS, see `ios-app-v2-0.md` Phase 5)
+
+Reduces the unlock barrier without compromising the zero-knowledge encryption model. SSO (Google/Apple sign-in) was explicitly ruled out — it requires either a backend key escrow or abandoning the zero-knowledge guarantee. The items below deliver the same "frictionless" feel while keeping encryption intact.
+
+---
+
+## What's already done
+
+- **Auto-lock timeout** — configurable in Settings → Privacy → Auto-Lock. No work needed.
+- **Android biometric unlock** — `src/components/settings/tabs/PrivacyBiometric.tsx` exists and is wired for Android/Wear OS.
+
+---
+
+## Item 1 — Desktop Biometric Unlock (Windows Hello / Touch ID / polkit)
+
+### How it works with the encryption model
+
+The user's password is the encryption key. Biometric can't replace it — but it can *retrieve* it. The session bridge pattern already does this for the writer window (`store_session_password` / `retrieve_session_password`). The same idea applies here:
+
+```
+First unlock after launch:
+  User enters password → app unlocks → password stored in OS credential store
+                                         (encrypted by OS with biometric key)
+
+Subsequent unlocks (until reboot / force-quit):
+  User triggers biometric prompt → OS releases stored password → app unlocks normally
+```
+
+The password is never persisted to disk unprotected — it's stored in the OS keyring under biometric protection, cleared on lock.
+
+### Rust implementation
+
+Use `tauri-plugin-biometric` (official Tauri plugin, supports Windows Hello, macOS Touch ID, Linux polkit):
+
+```toml
+# src-tauri/Cargo.toml
+tauri-plugin-biometric = "2"
+```
+
+New Tauri commands in `src-tauri/src/commands/biometric.rs`:
+
+```rust
+biometric_is_available  // → { available: bool, reason: Option<String> }
+biometric_store_session // stores password in OS keyring under biometric key
+biometric_retrieve_session // triggers biometric prompt → returns password or error
+biometric_clear_session // called on lock / factory reset
+```
+
+Keyring storage key: `com.moodhaven.app / biometric_session`
+
+### Frontend
+
+`PrivacyBiometric.tsx` already exists but is Android-only. Extend it to render on desktop platforms too:
+
+```typescript
+// Show on: platform() === 'ios' || platform() === 'android' || isTauri (desktop)
+// Hide on: browser/web build
+```
+
+`LockScreen.tsx` (or equivalent) gets a "Use Biometrics" button that appears after `biometric_is_available` returns true and the user has opted in.
+
+### Settings opt-in
+
+Settings → Privacy → Biometric Unlock toggle (off by default, same as Android pattern). First enable prompts for password confirmation before activating — ensures the user knows their password before delegating to biometrics.
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src-tauri/Cargo.toml` | Add `tauri-plugin-biometric` |
+| `src-tauri/src/commands/biometric.rs` | New module (4 commands) |
+| `src-tauri/src/commands/mod.rs` | `pub mod biometric` |
+| `src-tauri/src/lib.rs` | Register 4 commands |
+| `src-tauri/capabilities/default.json` | Add biometric permissions |
+| `src/components/settings/tabs/PrivacyBiometric.tsx` | Extend to desktop platforms |
+| Lock screen component (wherever unlock lives) | Add biometric prompt path |
+
+### Acceptance criteria
+
+- [ ] First unlock: password required (biometric not yet available as primary)
+- [ ] After opt-in: subsequent unlocks via biometric prompt — no password entry
+- [ ] Lock → biometric unlock restores full session (same as password unlock)
+- [ ] Factory reset clears keyring entry
+- [ ] If biometric fails 3x, falls back to password entry
+- [ ] Web build: biometric option hidden entirely
+
+---
+
+## Item 2 — PIN Unlock ✅ DONE (PR #102)
+
+### How it works with the encryption model
+
+PIN unlocks a *key blob*, not the raw password. The flow:
+
+```
+Setup:
+  User enables PIN → enters their password to confirm
+  → app generates random 32-byte "PIN key" → encrypts it with AES-256-GCM(PBKDF2(PIN, salt))
+  → stores encrypted PIN key blob in settings table under key `pin_key_blob`
+  → also stores `pin_salt` (random, separate from password salt)
+
+Unlock via PIN:
+  User enters PIN → PBKDF2(PIN, pin_salt) → decrypt pin_key_blob → recover PIN key
+  → use PIN key to decrypt a stored wrapped copy of the session password
+  → unlock proceeds normally
+```
+
+The password itself is wrapped with the PIN key and stored as `pin_wrapped_password`. Changing the password invalidates the PIN (the wrapped copy is stale) and prompts to re-enter PIN to re-wrap.
+
+### Why PBKDF2 on a PIN?
+
+PINs have low entropy. Use aggressive PBKDF2 iterations (600k, same as master password) to resist offline brute force. A 6-digit PIN with 600k PBKDF2 iterations takes ~minutes per attempt on a modern GPU — not bulletproof but materially harder than a bare hash.
+
+**Rate limit:** Apply the same `PasswordRateLimiter` (5 failures → 30s lockout, persisted) already used for master password. Files: `src-tauri/src/commands/data_management.rs`.
+
+### PIN length
+
+4–6 digits (user-configurable, default 6). Numeric only. No biometric-equivalent convenience — PIN is specifically for users who want something shorter than a passphrase but can't use biometrics.
+
+### Rust
+
+New commands in `src-tauri/src/commands/pin_unlock.rs`:
+
+```rust
+pin_setup(password: String, pin: String)   // wraps password, stores blob
+pin_unlock(pin: String)                    // → decrypted password or rate-limit error
+pin_disable()                              // clears blob + salt
+pin_is_enabled()                           // → bool
+```
+
+Crypto all on Rust side: `pbkdf2` crate (already in tree), `aes-gcm` crate.
+
+### Frontend
+
+Settings → Privacy → PIN Unlock section (new, below Biometric). Lock screen shows PIN keypad when PIN is enabled. Falls back to full password on 5 failures (standard lock screen).
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/commands/pin_unlock.rs` | New module (4 commands) |
+| `src-tauri/src/commands/mod.rs` | `pub mod pin_unlock` |
+| `src-tauri/src/lib.rs` | Register 4 commands |
+| `src-tauri/capabilities/default.json` | Add pin_* permissions |
+| `src/lib/pinUnlockService.ts` | IPC wrappers |
+| `src/components/settings/tabs/PrivacyAutoLock.tsx` | PIN setup toggle + entry |
+| Lock screen | PIN keypad path |
+
+### Acceptance criteria
+
+- [ ] PIN setup requires current password confirmation
+- [ ] Correct PIN → unlocks app (same session as password unlock)
+- [ ] 5 wrong PINs → 30s lockout (same as password rate limiter)
+- [ ] After 5 lockout cycles, falls through to full password
+- [ ] Changing master password invalidates PIN and prompts to re-setup
+- [ ] Factory reset clears all PIN data
+- [ ] PIN disabled → lock screen shows only password entry
+
+---
+
+## Sequencing
+
+Both items are independent. Neither blocks the other.
+
+Suggested order: **Biometric first** — it's the higher-impact unlock improvement for desktop users and reuses the existing `PrivacyBiometric.tsx` structure. PIN is useful for users whose hardware doesn't support biometrics.
+
+Both can ship in a single v1.8.x PR if the scope is manageable, or separately.

--- a/active-plans/ios-app-v2-0.md
+++ b/active-plans/ios-app-v2-0.md
@@ -1,0 +1,428 @@
+# iOS App — v2.0 Plan
+
+**Status:** Phase 1 (cloud sync) in progress on `feat/cloud-sync-phase1` | Phase 2 config in progress on `feat/ios-phase2-setup`  
+**Target version:** v2.0.0  
+**Approach:** Tauri v2 iOS target (decided)
+
+---
+
+## Why Tauri v2 iOS (not native SwiftUI)
+
+- All ~150 Rust commands work immediately — encryption, SQLite, 2FA, time capsules, analytics, StillHaven
+- Same AES-256-GCM + PBKDF2 encryption model across all platforms
+- Same `.moodhaven` blob format — data portability between desktop and iOS is already solved
+- React UI already runs in a browser (WebView) via the web build — mobile-responsive is an evolution, not a rewrite
+- Single codebase to maintain
+- Tauri v2 iOS is production-ready as of v2.0 (September 2024)
+
+---
+
+## Prerequisites for the developer machine
+
+```bash
+# Rust iOS targets
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
+# Xcode (from App Store) — required for iOS builds
+# Apple Developer account — required for device deployment and TestFlight
+#   (Simulator builds work without a paid account)
+
+# Init the iOS Xcode project (run once)
+npm run tauri ios init
+```
+
+---
+
+## Work streams and sequencing
+
+The iOS app needs a cloud sync story before it's useful (LAN peer sync won't be the iOS primary path). Ship the sync improvements first, then the iOS shell, then the UI responsiveness work.
+
+```
+Phase 1: Cloud sync (Dropbox + Google Drive)   ← IN PROGRESS (feat/cloud-sync-phase1)
+Phase 2: Tauri iOS project setup               ← 1-2 days, mostly config
+Phase 3: Mobile-responsive React UI            ← IN PROGRESS (BottomTabBar + useIsMobile foundation)
+Phase 4: iOS-specific adaptations              ← feature scoping, flags, edge cases
+Phase 5: iOS-only additions (v2.1+)            ← HealthKit, Face ID, Widgets
+```
+
+---
+
+## Phase 1 — Cloud Sync: Dropbox + Google Drive
+
+### Context
+
+WebDAV is correct and should remain available. The gap: most users don't run a WebDAV server. Adding Dropbox and Google Drive gives users sync via services they already have, with zero infrastructure to manage. The encrypted blob format (`.moodhaven`) doesn't change — these providers are just new transport layers.
+
+### Architecture
+
+```
+User authenticates with Dropbox / Google Drive
+    ↓
+OAuth PKCE flow (browser → redirect to moodhaven:// custom URL scheme)
+    ↓
+Rust receives auth code, exchanges for access + refresh tokens
+    ↓
+Tokens stored encrypted in SQLite settings table (same as other secrets)
+    ↓
+Upload: current encrypted blob → /Apps/MoodHaven/moodhaven-backup.moodhaven
+Download: pull blob → decrypt and import (same path as WebDAV import)
+```
+
+### New Tauri command module: `src-tauri/src/commands/cloud_providers.rs`
+
+```rust
+// Commands to register in lib.rs:
+cloud_provider_auth_start    // opens browser to OAuth URL, returns state token
+cloud_provider_auth_complete // exchanges code for tokens, stores encrypted
+cloud_provider_sync_upload   // upload current encrypted export blob
+cloud_provider_sync_download // download and return blob for import
+cloud_provider_status        // { provider: "dropbox"|"gdrive"|null, connected: bool, lastSync: Option<String> }
+cloud_provider_disconnect    // clears stored tokens
+```
+
+### Custom URL scheme (OAuth redirect)
+
+Add to `tauri.conf.json`:
+```json
+{
+  "app": {
+    "security": {
+      "csp": "..."
+    }
+  },
+  "bundle": {
+    "iOS": {
+      "minimumSystemVersion": "16.0"
+    }
+  }
+}
+```
+
+Register `moodhaven://oauth` as a custom URL scheme in the iOS Info.plist (Tauri handles this via capabilities config).
+
+On desktop (macOS/Linux/Windows), use `tauri-plugin-deep-link` or a localhost redirect (Dropbox and Google both support `http://localhost:PORT/oauth` for desktop apps — simpler than a custom scheme on desktop).
+
+### Dropbox API
+
+- App type: "Scoped access," scope: `files.content.write` + `files.content.read`
+- Auth: OAuth 2.0 PKCE (`response_type=code`, `code_challenge_method=S256`)
+- Upload endpoint: `POST https://content.dropboxapi.com/2/files/upload`
+  - Header: `Dropbox-API-Arg: {"path": "/Apps/MoodHaven/moodhaven-backup.moodhaven", "mode": "overwrite"}`
+- Download endpoint: `POST https://content.dropboxapi.com/2/files/download`
+  - Header: `Dropbox-API-Arg: {"path": "/Apps/MoodHaven/moodhaven-backup.moodhaven"}`
+- Token refresh: `POST https://api.dropboxapi.com/oauth2/token` with `grant_type=refresh_token`
+
+### Google Drive API
+
+- Scope: `https://www.googleapis.com/auth/drive.appdata` (restricted to app folder, no access to user files — best for privacy)
+  - Or `https://www.googleapis.com/auth/drive.file` (files created by this app only)
+- Auth: OAuth 2.0 PKCE
+- Upload: multipart upload to `https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart`
+- Download: `GET https://www.googleapis.com/drive/v3/files/{fileId}?alt=media`
+- File management: create file on first sync, update on subsequent syncs (store file ID in settings)
+
+### Settings UI changes
+
+New sync provider picker in Settings → Sync tab (rename current "Cloud Sync" tab):
+
+```
+Sync Method
+  ○ None
+  ○ Dropbox        [Connect / Disconnect]  [Sync Now]
+  ○ Google Drive   [Connect / Disconnect]  [Sync Now]
+  ○ WebDAV         [URL / Username / Password fields]
+
+Last synced: <timestamp>
+```
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/commands/cloud_providers.rs` | New module |
+| `src-tauri/src/commands/mod.rs` | Declare `pub mod cloud_providers` |
+| `src-tauri/src/lib.rs` | Register 6 new commands |
+| `src-tauri/capabilities/default.json` | Add `core:default:allow-cloud-provider-*` |
+| `src/lib/services/cloudProvidersService.ts` | New IPC wrappers |
+| `src/components/settings/tabs/SyncTab.tsx` | Provider picker UI |
+| `src/types/settings.ts` | Add `syncProvider: 'none' | 'dropbox' | 'gdrive' | 'webdav'` |
+
+---
+
+## Phase 2 — Tauri iOS Project Setup
+
+### Done (on `feat/ios-phase2-setup`)
+
+- [x] `bundle.iOS` config added to `tauri.conf.json` (`minimumSystemVersion: "16.0"`, `developmentTeam` placeholder)
+- [x] `src-tauri/capabilities/ios.json` — iOS capability file with `platforms: ["iOS"]`; drops wear/window permissions not applicable to iOS
+- [x] `usePlatform.ts` — adds `isIOS`, `isMobile`; iOS detection via WKWebView UA + `__TAURI_INTERNALS__` guard
+- [x] `build.md` — iOS build section (prerequisites, `ios init` steps, Xcode capability config, Info.plist descriptions)
+
+### Requires macOS + Xcode (next steps on a Mac)
+
+```bash
+# Add Rust iOS targets
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
+# Generate the Xcode project (run once)
+npm run tauri ios init
+# → creates src-tauri/gen/apple/
+
+# Open in Xcode and:
+# 1. Set Team ID (replaces REPLACE_WITH_APPLE_TEAM_ID in tauri.conf.json)
+# 2. Add entitlements: Background Modes (fetch + processing), Push Notifications
+# 3. Add Info.plist keys:
+#    NSUserNotificationsUsageDescription = "Receive journaling reminders"
+#    NSFaceIDUsageDescription = "Unlock MoodHaven with Face ID" (Phase 5)
+#    NSMicrophoneUsageDescription = "Record voice journal entries" (Phase 5)
+
+# Build and run
+npm run tauri ios dev       # hot-reload to Simulator or connected device
+npm run tauri ios build     # production .ipa
+```
+
+### Expected first-build issues
+
+- `tauri-plugin-shell` sidecar spawning is blocked on iOS — STT mic button must be hidden via `usePlatform().isIOS` (Phase 4 work)
+- `wear:allow-*` permissions in `default.json` will be inert on iOS (wear plugin not loaded) — harmless
+- Minimum iOS version: 16.0+ covers ~95% of active iPhones as of 2026
+- Bundle ID conflict: if any package uses `com.moodhaven.app` as a reserved prefix, rename to `com.moodhaven.app.ios`
+
+---
+
+## Phase 3 — Mobile-Responsive React UI
+
+This is the largest work item. The current UI is sidebar-based with an 800px minimum width — it will not work on an iPhone screen.
+
+### Layout architecture
+
+**Current (desktop):**
+```
+<div class="flex h-screen">
+  <Sidebar />              // 240px wide, always visible
+  <main class="flex-1">
+    <ActiveView />
+  </main>
+</div>
+```
+
+**New (mobile-aware):**
+```
+<div class="flex flex-col h-screen">
+  <main class="flex-1 overflow-auto">
+    <ActiveView />
+  </main>
+  {isMobile && <BottomTabBar />}
+  {!isMobile && <Sidebar />}  // unchanged for desktop
+</div>
+```
+
+### `useIsMobile()` hook
+
+```typescript
+// src/hooks/useIsMobile.ts
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+  return isMobile;
+}
+```
+
+Tauri also exposes the platform: `import { platform } from '@tauri-apps/plugin-os'` returns `'ios'` on iOS — can use this for iOS-specific logic beyond just screen size.
+
+### BottomTabBar component (new)
+
+Five tabs: **Write** · **Timeline** · **Insights** · **Calendar** · **Settings**
+
+- Fixed to bottom, `safe-area-inset-bottom` padding for iPhone home bar
+- Active tab highlighted with mood accent color
+- Each tab icon from the existing `EditorIcons.tsx` set or new SVG atoms
+- File: `src/components/layout/BottomTabBar.tsx`
+
+### Views needing responsive work
+
+| View | Issue | Fix |
+|------|-------|-----|
+| `WritingView` | Sidebar-dependent width; toolbar wraps awkwardly | Full-width on mobile; toolbar scrolls horizontally or collapses to floating bar above keyboard |
+| `TimelineView` | Entry cards are already list-like — mostly fine | Touch target sizing (min 44px height); remove hover states |
+| `InsightsView` | AI cards are row-based flex — may overflow | Stack cards vertically on mobile |
+| `CalendarPage` | Calendar grid cells may be too small | Larger cells on mobile; swipe to change month |
+| `SettingsPage` | Tab strip at top may overflow | Tabs become a scrolling horizontal strip or a mobile-style section list |
+| `SidebarBooks` | Books modal — fine on desktop | Full-screen sheet on mobile |
+
+### Keyboard avoidance
+
+On iOS, the on-screen keyboard pushes content up. TipTap inside a `position: fixed` layout needs explicit keyboard avoidance handling:
+- Use `window.visualViewport` API to detect keyboard height
+- Push the editor container up when keyboard is shown
+- The iOS WKWebView handles some of this automatically if the body isn't fixed-height
+
+### Remove desktop-only minimum window size
+
+`tauri.conf.json` currently sets `"minWidth": 800, "minHeight": 600` — these are desktop-only constraints and don't affect iOS builds, but make sure mobile CSS doesn't rely on `min-width: 800px` media queries anywhere.
+
+### Tailwind responsive breakpoints
+
+MoodHaven already uses Tailwind. The convention for mobile-first responsive work:
+- Default styles: mobile
+- `md:` prefix: desktop (≥768px)
+- Replace any `flex` / `grid` that assumes wide viewport with `flex-col md:flex-row` etc.
+
+---
+
+## Phase 4 — iOS-Specific Adaptations
+
+### Feature scoping for iOS v1
+
+| Feature | iOS v1 | Notes |
+|---------|--------|-------|
+| Core journaling (read/write/mood/tags) | ✅ Full | Works via WKWebView |
+| Books, time capsules, search | ✅ Full | |
+| Calendar heatmap, insights, analytics | ✅ Full | SVG charts work in WKWebView |
+| AI insight cards | ✅ Full | Metadata-only, same Rust commands |
+| 2FA (TOTP) | ✅ Full | TOTP works; hardware key N/A on iOS |
+| WebDAV sync | ✅ Full | Rust HTTP client works on iOS |
+| Dropbox / Google Drive sync | ✅ Full | Phase 1 work; works on all platforms |
+| StillHaven bilateral audio | ✅ Full | Web Audio API works in WKWebView |
+| Peer LAN sync (mDNS + TCP) | ⚠️ Degraded | Discovery unreliable in foreground; **hide pairing UI on iOS**; show "Use cloud sync on iOS" message |
+| Speech-to-text (whisper.cpp sidecar) | ❌ Not in v1 | No sidecar processes on iOS; hide mic button; future: whisper-rs |
+| Voice memo draft pipeline | ❌ Not in v1 | Wear OS companion is Android-only; hide draft cards on iOS |
+| Hardware key (FIDO2) | ❌ N/A | iOS uses Face ID / Touch ID; show appropriate fallback |
+| Writer window (breakout window) | ❌ N/A | iOS has no multi-window journal writing; hide option |
+| Update checker (GitHub releases) | ❌ N/A | App Store handles updates; hide update panel |
+| Log folder access | ❌ N/A | iOS sandbox; hide "Open Log Folder" button |
+
+### Platform detection in the frontend
+
+Use `platform()` from `@tauri-apps/plugin-os` to gate iOS-only code:
+
+```typescript
+import { platform } from '@tauri-apps/plugin-os';
+const isIOS = platform() === 'ios';
+```
+
+Or extend the existing `usePlatform()` hook pattern to add `isIOS`.
+
+### Peer sync UI on iOS
+
+In `DevicesTab.tsx`, when `isIOS`:
+- Replace the full peer sync UI with an informational card:
+  > "Peer sync is available on the MoodHaven desktop app. On iOS, sync your journal using Dropbox or Google Drive."
+- Hide `DevicesNearby`, `PairingModal`, pairing controls
+
+### Hiding the mic button on iOS
+
+In `EditorToolbar.tsx`, conditionally render `<MicButton>` only when `!isIOS` and STT is available.
+
+### Tauri plugin iOS compatibility audit
+
+Before the iOS build, verify each plugin has an iOS implementation:
+
+| Plugin | iOS support? | Action |
+|--------|-------------|--------|
+| `tauri-plugin-fs` | ✅ Yes | No change |
+| `tauri-plugin-http` | ✅ Yes | No change |
+| `tauri-plugin-notification` | ✅ Yes | Add `NSUserNotificationUsageDescription` |
+| `tauri-plugin-log` | ✅ Yes | No change |
+| `tauri-plugin-shell` | ⚠️ Limited | Sidecar process spawning not available; guard STT commands |
+| `tauri-plugin-dialog` | ✅ Yes | iOS file picker uses UIDocumentPickerViewController |
+| `tauri-plugin-os` | ✅ Yes | Used for platform detection |
+
+---
+
+## Phase 5 — iOS-Only Additions (v2.1+)
+
+These are post-launch; don't block v2.0.
+
+**Face ID / Touch ID app lock:**
+- Replace the password-only unlock for returning users with biometric prompt
+- On success, retrieve the session from `retrieve_session_password` (the session bridge pattern already exists)
+- Uses `tauri-plugin-biometric` — plugin will already be in the tree from the v1.8 desktop biometric work (see `active-plans/auth-friction-reduction.md`); iOS just needs the platform wiring enabled
+
+**HealthKit integration:**
+- Replaces Oura Ring for iOS users (most iPhone users don't have Oura; most do have HealthKit data)
+- Pull: sleep score, HRV average, resting HR, step count — same fields as Oura
+- Store in `oura_health_context` table (rename table or add `source` column)
+- Requires a custom Swift Tauri plugin (`tauri-plugin-healthkit`)
+- Would feed existing Oura health context badge and AI prompts
+
+**iOS Widgets:**
+- Lock screen widget: quick mood tap (1–5)
+- Home screen widget: current streak + last entry date
+- Requires a Swift widget extension — separate from the Tauri app but reads shared data
+
+**whisper-rs for local STT:**
+- `whisper-rs` crate (Rust bindings to whisper.cpp as a library) compiles whisper.cpp directly into the Rust binary — no sidecar process needed
+- Models are still downloaded and cached locally
+- Increases binary size significantly (~50MB+ for the library)
+- Adds the full L1→L2→L3 STT pipeline back on iOS
+
+---
+
+## Data flow: iOS ↔ Desktop sync (via Dropbox/Google Drive)
+
+```
+iPhone (MoodHaven iOS)
+    │
+    │  User taps "Sync Now" (or auto-sync on foreground)
+    │
+    ↓
+cloud_provider_sync_upload
+    │  export_data() → encrypted .moodhaven blob
+    │  PUT to Dropbox/Google Drive
+    │
+    ↓
+[ Dropbox / Google Drive ]
+    │
+    ↓
+cloud_provider_sync_download (on desktop)
+    │  GET from Dropbox/Google Drive → encrypted blob
+    │  import_data() → merge into local SQLite
+    │
+Desktop (MoodHaven desktop app)
+```
+
+Conflict resolution: same LWW (last-write-wins by `updated_at`) as peer sync. The `import_data` command already handles deduplication.
+
+**Note:** This is manual sync in v2.0 (user-triggered). Auto-sync on app foreground is Phase 5.
+
+---
+
+## iOS App Store notes
+
+- Bundle ID: e.g. `com.moodhaven.app.ios` (or `com.kennethlacroix.moodhaven`)
+- Category: Productivity or Health & Fitness
+- Privacy labels: no data collected (all local + user-controlled sync)
+- Age rating: 4+ (no objectionable content; StillHaven disclaimer handles the wellness framing)
+- Export compliance: uses AES-256 encryption → must declare but is not restricted (encryption is for data protection, not communication security)
+- TestFlight for beta distribution before App Store submission
+
+---
+
+## Rough effort estimates
+
+| Work stream | Estimated effort |
+|-------------|-----------------|
+| Phase 1: Dropbox + Google Drive sync | 2–3 weeks |
+| Phase 2: Tauri iOS project setup | 1–3 days |
+| Phase 3: Mobile-responsive React UI | 3–5 weeks |
+| Phase 4: iOS-specific adaptations (feature gates, plugin audit) | 1 week |
+| **Total to v2.0 ship** | **7–10 weeks** |
+
+The mobile UI work is the long pole. Phase 1 (cloud sync) benefits all platforms immediately and can ship as v1.7 before iOS is ready.
+
+---
+
+## Suggested version sequencing
+
+| Version | Content |
+|---------|---------|
+| v1.7.0 | SQLCipher + peer key (security fixes) + Dropbox/Google Drive sync |
+| v1.8.0 | Mobile-responsive UI (also improves the existing web build) + desktop biometric unlock + PIN unlock (see `active-plans/auth-friction-reduction.md`) |
+| v2.0.0 | iOS app launch (TestFlight → App Store) |
+| v2.1.0 | Face ID / Touch ID (iOS), HealthKit — biometric plugin already landed in v1.8 |
+| v2.2.0 | whisper-rs STT on iOS |

--- a/active-plans/security-at-rest-fixes.md
+++ b/active-plans/security-at-rest-fixes.md
@@ -1,0 +1,193 @@
+# Security: At-Rest Data Protection Fixes
+
+**From:** Pentest 2 findings (T7, T8, T9, T10)
+**Blog post:** `.claude/plans/blog-post-pentest-draft.md`
+**Status (2026-06-05):** PR 1 complete (CI green, targeting v1.7.0). PR 2 not started — blocks release gate.
+
+Two PRs, one logical group. PR 1 is done. PR 2 (peer_key.bin) is the remaining work before
+cutting the security release tag.
+
+---
+
+## PR 1 — SQLCipher Migration (`security-sqlcipher`)
+
+**Closes:** T7 (DB readable at rest), T8 (password hash exposed), T9 (lockout bypass moot)
+
+### What changes
+
+`src-tauri/Cargo.toml` — swap the rusqlite dependency:
+```toml
+# Before
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# After
+rusqlite = { version = "0.31", features = ["bundled-sqlcipher-vendored-openssl"] }
+```
+`bundled-sqlcipher-vendored-openssl` compiles SQLCipher and OpenSSL from source — no system deps,
+works on all three platforms without extra CI steps.
+
+`src-tauri/src/db/mod.rs` — three changes:
+
+**1. Key pragma on open.** After `Connection::open()`, set the key before any queries:
+```rust
+conn.execute_batch(&format!(
+    "PRAGMA key = '{}';",
+    hex::encode(derived_key_bytes)
+))?;
+```
+The key is 32 bytes derived from the user's password via the same PBKDF2 already in use.
+Use hex-encoding (64 chars) rather than raw bytes — SQLCipher's PRAGMA key treats the value
+as a passphrase and applies its own KDF on top; using `PRAGMA hexkey` bypasses that second
+KDF and gives deterministic behaviour.
+
+**2. Migration detect-and-rekey.** Existing users have an unencrypted DB. Detect this on open:
+```rust
+// Try encrypted open first; if it fails, the DB is unencrypted (existing install)
+fn open_database(path: &Path, key: Option<&[u8]>) -> Result<Connection, rusqlite::Error> {
+    let conn = Connection::open(path)?;
+    if let Some(k) = key {
+        conn.execute_batch(&format!("PRAGMA hexkey = '{}';", hex::encode(k)))?;
+        // Probe: if this fails, DB is unencrypted or wrong key
+        conn.execute_batch("SELECT count(*) FROM sqlite_master;")?;
+    }
+    Ok(conn)
+}
+```
+When migration is needed (unencrypted DB + valid password on hand), call `sqlcipher_export`:
+```sql
+ATTACH DATABASE 'moodhaven_enc.db' AS encrypted KEY 'hexkey:...';
+SELECT sqlcipher_export('encrypted');
+DETACH DATABASE encrypted;
+```
+Then swap files and delete the plaintext original.
+
+**3. Pre-password state.** On first launch there is no password yet. The DB at this point
+contains only the schema — no journal entries, no password hash. Leave it unencrypted until
+the user completes the first-run wizard and sets a password. At that point, call
+`sqlcipher_export` to encrypt it and set a `db_encrypted = true` flag in a sidecar JSON file
+(not in the DB itself — we need to read this flag before opening the DB).
+
+### Key derivation
+
+Reuse the existing PBKDF2 parameters already proven in the frontend (`crypto.ts`):
+- PBKDF2-HMAC-SHA256
+- 600,000 iterations
+- Salt: read the `password_salt` from the settings table **before** encrypting, then
+  store the same salt in the sidecar JSON so it's available before the DB can be opened
+
+Do this on the Rust side with the `pbkdf2` crate (already in the tree for TOTP).
+
+### Unlock flow change
+
+Currently `unlock_app` just sets a boolean in memory. With SQLCipher it needs to also:
+1. Derive the DB key from the supplied password
+2. Re-open (or re-key) the connection with that key
+3. If the key is wrong, return an error before setting `isUnlocked`
+
+The `Database` struct needs to hold the derived key in memory for the session,
+used for any new connections (writer window, etc.).
+
+### Migration path for existing users
+
+```
+Launch after update
+    │
+    ├── sidecar JSON exists + db_encrypted = true → normal encrypted open
+    │
+    ├── sidecar JSON missing or db_encrypted = false
+    │       ├── password_hash exists in DB → open unencrypted, prompt user to
+    │       │   re-enter password to trigger migration, show one-time banner
+    │       └── no password_hash → first-run wizard, encrypt on password set
+```
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src-tauri/Cargo.toml` | Swap rusqlite feature flag |
+| `src-tauri/src/db/mod.rs` | Key pragma, detect-and-rekey, migration |
+| `src-tauri/src/commands/data_management.rs` | Pass key to unlock_app; re-open DB |
+| `src-tauri/src/lib.rs` | Database state carries optional key bytes |
+| `src/components/settings/tabs/PrivacyDataManagement.tsx` | One-time migration banner (if needed) |
+
+### Acceptance criteria
+
+> **Status (2026-06-05): PR #97 (`worktree-security-sqlcipher`) — all CI green. Merged into v1.7.0.**
+
+- [x] Fresh install: DB created encrypted from first password set
+- [x] Existing install: detect-and-rekey via `db_state.json` sidecar + `encrypt_in_place()` — migration banner path wired
+- [ ] `sqlite3 moodhaven.db .tables` on the migrated file returns `Error: file is not a database` — runtime-only, verify post-merge QA
+- [x] Wrong password: `unlock_app` returns error, app stays on lock screen
+- [ ] Export/import still works (encrypted backup → decrypt in memory → re-encrypt for export) — needs QA run post-merge
+- [x] All 1245 tests pass (CI: Frontend ×2, Rust ×3, Lint, Secret Scan — all green)
+- [x] `cargo check` clean on Linux, Windows, macOS (CI confirmed)
+
+---
+
+## PR 2 — Encrypt peer_key.bin (`security-peer-key`)
+
+**Status:** In progress — PR #103 (`worktree-security-peer-key`, commit `bf3b8d0`). CI running. Blocking gate: plan requires both PRs before cutting the security release tag.
+
+**Closes:** T10 (Ed25519 private key readable at rest)
+
+### The constraint
+
+Peer discovery starts before the user unlocks. The current code loads `peer_key.bin` at startup
+to register the mDNS service. If we encrypt it with the password-derived key, it can't be loaded
+until after unlock.
+
+**Decision: delay peer discovery start until after unlock.**
+
+This is already architecturally sound — there's no value in broadcasting your device on the LAN
+before the app is unlocked. Move `peer_discovery_start` from auto-start in `lib.rs` to be called
+by `unlock_app`. The sync server (TCP listener) can also wait until unlock.
+
+### What changes
+
+**Encryption:** Use the OS credential store rather than the password-derived key:
+- Windows: Windows Data Protection API (`DPAPI` / `CryptProtectData`) — encrypts with the
+  OS user's login credentials, transparent to the user, survives reboots
+- macOS: Keychain via `security` framework
+- Linux: Secret Service via `libsecret` or fallback to file-based with `chmod 0600`
+
+Rust crate: `keyring = "2"` — already handles all three platforms.
+
+Store the 32-byte Ed25519 seed in the keyring under service name `com.moodhaven.app`,
+username `peer_key`. Keep `peer_key.bin` as a fallback for systems where keyring is
+unavailable (e.g., headless Linux), but apply `chmod 0600` on all platforms via the
+`rustix` or `fs` crate.
+
+**Migration:** On first launch after update, read `peer_key.bin` if it exists, store in
+keyring, then delete `peer_key.bin`. If keyring unavailable, leave as file with `0600`.
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src-tauri/Cargo.toml` | Add `keyring` crate |
+| `src-tauri/src/commands/peer_identity.rs` | Read/write via keyring; fallback to file |
+| `src-tauri/src/lib.rs` | Move peer discovery start to post-unlock |
+| `src-tauri/src/commands/data_management.rs` | Call `peer_discovery_start` from `unlock_app` |
+
+### Acceptance criteria
+
+- [ ] `peer_key.bin` no longer exists on disk after migration (keyring path)
+- [ ] Device identity is stable across app restarts
+- [ ] Peer discovery does not start until after successful unlock
+- [ ] Fallback: on headless Linux without Secret Service, file is created with `0600`
+- [ ] All 1245 tests pass
+
+---
+
+## Order of work
+
+1. ✅ PR 1 done — SQLCipher merged (v1.7.0), closes T7/T8/T9
+2. PR 2 next — no shared files with PR 1, can be built independently
+3. Both must be done before cutting the security release tag — **PR 2 is the current blocker**
+4. Blog post ships after both PRs land
+
+## Not doing (out of scope for these PRs)
+
+- Lockout file hardening — rendered moot by SQLCipher; log as a follow-up if desired
+- UDP discovery plaintext — architectural, separate discussion
+- HELLO handshake plaintext — same, separate discussion

--- a/src-tauri/capabilities/ios.json
+++ b/src-tauri/capabilities/ios.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "ios",
+  "description": "iOS-specific capabilities — applies only to the iOS target",
+  "platforms": ["iOS"],
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "log:default",
+    {
+      "identifier": "http:allow-fetch",
+      "allow": [{ "url": "https://**" }, { "url": "http://**" }]
+    },
+    "http:allow-fetch-cancel",
+    "http:allow-fetch-read-body",
+    "http:allow-fetch-send",
+    "notification:default",
+    "dialog:default",
+    "fs:default",
+    "allow-all-app-commands"
+  ]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,6 +56,10 @@
     "macOS": {
       "minimumSystemVersion": "10.15"
     },
+    "iOS": {
+      "minimumSystemVersion": "16.0",
+      "developmentTeam": "REPLACE_WITH_APPLE_TEAM_ID"
+    },
     "linux": {
       "appimage": {
         "bundleMediaFramework": true

--- a/src/components/editor/EditorToolbar.test.tsx
+++ b/src/components/editor/EditorToolbar.test.tsx
@@ -1,0 +1,68 @@
+vi.mock('../../hooks/usePlatform', () => ({ usePlatform: vi.fn() }));
+
+import { render, screen } from '@testing-library/react';
+import { CollapsibleToolbar } from './EditorToolbar';
+import { usePlatform } from '../../hooks/usePlatform';
+import type { Editor } from '@tiptap/react';
+
+const mockUsePlatform = vi.mocked(usePlatform);
+
+const mockEditor = {
+  on: vi.fn(),
+  off: vi.fn(),
+} as unknown as Editor;
+
+const baseProps = {
+  editor: mockEditor,
+  onFormat: vi.fn(),
+  getFormatState: () => ({}),
+  expanded: true,
+  onToggle: vi.fn(),
+  onLinkClick: vi.fn(),
+  onEmojiClick: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CollapsibleToolbar — iOS STT gate', () => {
+  it('renders the mic button when isIOS is false and onMicClick is provided', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(
+      <CollapsibleToolbar
+        {...baseProps}
+        sttReady
+        sttState="idle"
+        onMicClick={vi.fn()}
+      />
+    );
+    expect(screen.getByTitle('Start dictation')).toBeInTheDocument();
+  });
+
+  it('does not render the mic button when isIOS is true, even with onMicClick provided', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(
+      <CollapsibleToolbar
+        {...baseProps}
+        sttReady
+        sttState="idle"
+        onMicClick={vi.fn()}
+      />
+    );
+    expect(screen.queryByTitle('Start dictation')).not.toBeInTheDocument();
+  });
+
+  it('does not render the mic button when onMicClick is not provided, regardless of platform', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(<CollapsibleToolbar {...baseProps} />);
+    expect(screen.queryByTitle('Start dictation')).not.toBeInTheDocument();
+  });
+
+  it('renders standard formatting buttons on iOS', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<CollapsibleToolbar {...baseProps} onMicClick={vi.fn()} />);
+    expect(screen.getByTitle('Bold (Ctrl+B)')).toBeInTheDocument();
+    expect(screen.getByTitle('Italic (Ctrl+I)')).toBeInTheDocument();
+  });
+});

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { type Editor } from '@tiptap/react';
 import { type STTState } from '../../hooks/useSpeechToText';
+import { usePlatform } from '../../hooks/usePlatform';
 import {
   TBBoldIcon,
   TBItalicIcon,
@@ -51,6 +52,7 @@ export function CollapsibleToolbar({
   quickCapture = false,
   onToggleQuickCapture,
 }: CollapsibleToolbarProps) {
+  const { isIOS } = usePlatform();
   const [formatState, setFormatState] = useState<Record<string, boolean>>({});
 
   // Track format state on selection/transaction changes
@@ -175,8 +177,8 @@ export function CollapsibleToolbar({
             onClick={onEmojiClick}
           />
 
-          {/* Speech-to-text: quick capture toggle + mic button */}
-          {onMicClick && (
+          {/* Speech-to-text: quick capture toggle + mic button — sidecar unavailable on iOS */}
+          {onMicClick && !isIOS && (
             <>
               <TBDivider />
               {onToggleQuickCapture && (

--- a/src/components/layout/FocusMenu.test.tsx
+++ b/src/components/layout/FocusMenu.test.tsx
@@ -1,0 +1,54 @@
+vi.mock('../../hooks/usePlatform', () => ({ usePlatform: vi.fn() }));
+vi.mock('../../stores/settingsStore', () => ({ useSettingsStore: vi.fn() }));
+vi.mock('../../lib/services/windowUtils', () => ({ toggleFullscreen: vi.fn().mockResolvedValue(undefined) }));
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FocusMenu } from './FocusMenu';
+import { usePlatform } from '../../hooks/usePlatform';
+import { useSettingsStore } from '../../stores/settingsStore';
+
+const mockUsePlatform = vi.mocked(usePlatform);
+const mockUseSettingsStore = vi.mocked(useSettingsStore);
+
+function setupStoreMock() {
+  (mockUseSettingsStore as ReturnType<typeof vi.fn>).mockImplementation(
+    (sel: (s: { distractionFree: boolean; setDistractionFree: () => void }) => unknown) =>
+      sel({ distractionFree: false, setDistractionFree: vi.fn() })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupStoreMock();
+});
+
+describe('FocusMenu — iOS breakout gate', () => {
+  it('shows the Breakout writer button when isIOS is false', async () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(<FocusMenu onOpenBreakout={vi.fn()} />);
+
+    await userEvent.click(screen.getByTitle('Focus & window options'));
+
+    expect(screen.getByText('Breakout writer')).toBeInTheDocument();
+  });
+
+  it('does not show the Breakout writer button when isIOS is true', async () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<FocusMenu onOpenBreakout={vi.fn()} />);
+
+    await userEvent.click(screen.getByTitle('Focus & window options'));
+
+    expect(screen.queryByText('Breakout writer')).not.toBeInTheDocument();
+  });
+
+  it('still shows Focus mode and Fullscreen on iOS', async () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<FocusMenu onOpenBreakout={vi.fn()} />);
+
+    await userEvent.click(screen.getByTitle('Focus & window options'));
+
+    expect(screen.getByText('Focus mode')).toBeInTheDocument();
+    expect(screen.getByText('Fullscreen')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/FocusMenu.tsx
+++ b/src/components/layout/FocusMenu.tsx
@@ -16,12 +16,14 @@ import { useRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { toggleFullscreen } from '../../lib/services/windowUtils';
+import { usePlatform } from '../../hooks/usePlatform';
 
 interface FocusMenuProps {
   onOpenBreakout: () => void;
 }
 
 export function FocusMenu({ onOpenBreakout }: FocusMenuProps) {
+  const { isIOS } = usePlatform();
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
 
@@ -144,20 +146,22 @@ export function FocusMenu({ onOpenBreakout }: FocusMenuProps) {
             Fullscreen
           </button>
 
-          {/* Divider */}
-          <div className="my-1 border-t border-slate-100 dark:border-slate-700" />
-
-          {/* Breakout writer */}
-          <button
-            type="button"
-            onClick={handleBreakout}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
-          >
-            <svg className="w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-            </svg>
-            Breakout writer
-          </button>
+          {/* Breakout writer — desktop only (no separate windows on iOS) */}
+          {!isIOS && (
+            <>
+              <div className="my-1 border-t border-slate-100 dark:border-slate-700" />
+              <button
+                type="button"
+                onClick={handleBreakout}
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
+              >
+                <svg className="w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                </svg>
+                Breakout writer
+              </button>
+            </>
+          )}
         </div>,
         document.body
       )}

--- a/src/components/peer-sync/DevicesTab.test.tsx
+++ b/src/components/peer-sync/DevicesTab.test.tsx
@@ -1,0 +1,78 @@
+vi.mock('../../hooks/usePlatform', () => ({ usePlatform: vi.fn() }));
+vi.mock('../../stores/peerSyncStore', () => ({ usePeerSyncStore: vi.fn() }));
+vi.mock('../../stores/settingsStore', () => ({ useSettingsStore: vi.fn() }));
+vi.mock('../../lib/services/peerDiscoveryService', () => ({
+  startDiscovery: vi.fn(),
+  stopDiscovery: vi.fn(),
+}));
+vi.mock('./PairingModal', () => ({ PairingModal: () => null }));
+vi.mock('./TrustedDevicesList', () => ({ TrustedDevicesList: () => null }));
+vi.mock('./DevicesThisDevice', () => ({ ThisDeviceCard: () => null }));
+vi.mock('./DevicesNearby', () => ({ NearbyPeerRow: () => null, EmptyNearby: () => null }));
+vi.mock('./DeviceIconSet', () => ({ ScanningDots: () => null }));
+vi.mock('./DevicesSyncOptions', () => ({ DevicesSyncOptions: () => null }));
+vi.mock('../../lib/services/logger', () => ({ logger: { error: vi.fn() } }));
+
+import { render, screen } from '@testing-library/react';
+import { DevicesTab } from './DevicesTab';
+import { usePlatform } from '../../hooks/usePlatform';
+import { usePeerSyncStore } from '../../stores/peerSyncStore';
+import { useSettingsStore } from '../../stores/settingsStore';
+
+const mockUsePlatform = vi.mocked(usePlatform);
+const mockUsePeerSyncStore = vi.mocked(usePeerSyncStore);
+const mockUseSettingsStore = vi.mocked(useSettingsStore);
+
+const storeState = {
+  settings: { sync: { peerSyncLanOnly: false, peerSyncIntervalSecs: 30 } },
+  setPeerSyncLanOnly: vi.fn(),
+  setPeerSyncIntervalSecs: vi.fn(),
+  saveSettings: vi.fn(),
+};
+
+function setupMocks() {
+  mockUsePeerSyncStore.mockReturnValue({
+    identity: null,
+    identityLoading: false,
+    isDiscovering: false,
+    nearbyPeers: [],
+    setDiscovering: vi.fn(),
+    clearPeers: vi.fn(),
+  } as ReturnType<typeof usePeerSyncStore>);
+  // Selector-based store mock
+  (mockUseSettingsStore as ReturnType<typeof vi.fn>).mockImplementation(
+    (sel: (s: typeof storeState) => unknown) => sel(storeState)
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupMocks();
+});
+
+describe('DevicesTab — iOS gate', () => {
+  it('shows iOS placeholder when isIOS is true', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<DevicesTab />);
+    expect(screen.getByText('Peer sync is not available on iOS')).toBeInTheDocument();
+    expect(screen.getByText(/Use Dropbox or Google Drive/)).toBeInTheDocument();
+  });
+
+  it('does not render the Local Sync toggle on iOS', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<DevicesTab />);
+    expect(screen.queryByText('Local Sync')).not.toBeInTheDocument();
+  });
+
+  it('shows browser placeholder when isBrowser is true', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: true, isDesktop: false });
+    render(<DevicesTab />);
+    expect(screen.getByText('LAN Sync requires the desktop app')).toBeInTheDocument();
+  });
+
+  it('renders the Local Sync toggle on desktop (not iOS, not browser)', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(<DevicesTab />);
+    expect(screen.getByText('Local Sync')).toBeInTheDocument();
+  });
+});

--- a/src/components/peer-sync/DevicesTab.tsx
+++ b/src/components/peer-sync/DevicesTab.tsx
@@ -24,7 +24,7 @@ import type { DiscoveredPeer } from '../../types/peerSync';
 import { logger } from '../../lib/services/logger';
 
 export function DevicesTab() {
-  const { isBrowser } = usePlatform();
+  const { isBrowser, isIOS } = usePlatform();
   const { identity, identityLoading, isDiscovering, nearbyPeers, setDiscovering, clearPeers } =
     usePeerSyncStore();
 
@@ -54,6 +54,28 @@ export function DevicesTab() {
       setTogglingDiscovery(false);
     }
   }, [isDiscovering, setDiscovering, clearPeers]);
+
+  if (isIOS) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-4 text-center px-4">
+        <div className="w-14 h-14 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center">
+          <svg className="w-7 h-7 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
+          </svg>
+        </div>
+        <div>
+          <p className="font-medium text-slate-800 dark:text-slate-100">Peer sync is not available on iOS</p>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 max-w-xs">
+            LAN peer sync uses mDNS and native TCP — unreliable in the iOS foreground.
+            Use Dropbox or Google Drive to sync your journal on iPhone.
+          </p>
+        </div>
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Sync your journal in Settings → Cloud Sync
+        </p>
+      </div>
+    );
+  }
 
   if (isBrowser) {
     return (

--- a/src/components/settings/tabs/AboutTab.test.tsx
+++ b/src/components/settings/tabs/AboutTab.test.tsx
@@ -1,0 +1,80 @@
+vi.mock('../../../hooks/usePlatform', () => ({ usePlatform: vi.fn() }));
+vi.mock('../../updater/UpdatePanel', () => ({ UpdatePanel: () => <div>UpdatePanel</div> }));
+vi.mock('../../../lib/services/logger', () => ({ logger: { error: vi.fn() } }));
+
+import { render, screen } from '@testing-library/react';
+import { AboutTab } from './AboutTab';
+import { usePlatform } from '../../../hooks/usePlatform';
+import type { AppSettings } from '../../../types/settings';
+import type { UseUpdateCheckReturn } from '../../../hooks/useUpdateCheck';
+
+const mockUsePlatform = vi.mocked(usePlatform);
+
+const mockSettings = {
+  version: 4,
+  logLevel: 'warn',
+  moduleLogLevels: {},
+} as unknown as AppSettings;
+
+const mockUpdateHook = {
+  checking: false,
+  updateAvailable: false,
+  latestVersion: null,
+  downloadUrl: null,
+  releaseNotes: null,
+  checkForUpdate: vi.fn(),
+  downloading: false,
+  downloadProgress: 0,
+  downloadAndInstall: vi.fn(),
+} as unknown as UseUpdateCheckReturn;
+
+const baseProps = {
+  settings: mockSettings,
+  updateHook: mockUpdateHook,
+  appVersion: '1.6.0',
+  logPath: '/tmp/moodhaven.log',
+  handleLogLevelChange: vi.fn(),
+  setModuleLogLevel: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AboutTab — iOS platform gates', () => {
+  it('renders UpdatePanel on desktop (not iOS)', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.getByText('UpdatePanel')).toBeInTheDocument();
+  });
+
+  it('does not render UpdatePanel on iOS', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.queryByText('UpdatePanel')).not.toBeInTheDocument();
+  });
+
+  it('renders the Log Level select on desktop', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.getByLabelText('Log level')).toBeInTheDocument();
+  });
+
+  it('does not render the Log Level select on iOS', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.queryByLabelText('Log level')).not.toBeInTheDocument();
+  });
+
+  it('does not render the Log Level select in browser mode', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: true, isDesktop: false });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.queryByLabelText('Log level')).not.toBeInTheDocument();
+  });
+
+  it('renders the app version on all platforms', () => {
+    mockUsePlatform.mockReturnValue({ isIOS: true, isAndroid: false, isMobile: true, isBrowser: false, isDesktop: false });
+    render(<AboutTab {...baseProps} />);
+    expect(screen.getByText('v1.6.0')).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/tabs/AboutTab.tsx
+++ b/src/components/settings/tabs/AboutTab.tsx
@@ -27,18 +27,20 @@ export function AboutTab({
   handleLogLevelChange,
   setModuleLogLevel,
 }: AboutTabProps) {
-  const { isBrowser } = usePlatform();
+  const { isBrowser, isIOS } = usePlatform();
   const [moduleOverridesOpen, setModuleOverridesOpen] = useState(false);
   return (
     <div id="panel-about" role="tabpanel" className="space-y-6">
 
-      {/* Updates section */}
-      <SettingSection
-        title="Updates"
-        description="Keep MoodHaven Journal up to date"
-      >
-        <UpdatePanel hook={updateHook} currentVersion={appVersion} />
-      </SettingSection>
+      {/* Updates section — App Store handles updates on iOS */}
+      {!isIOS && (
+        <SettingSection
+          title="Updates"
+          description="Keep MoodHaven Journal up to date"
+        >
+          <UpdatePanel hook={updateHook} currentVersion={appVersion} />
+        </SettingSection>
+      )}
 
       <SettingSection
         title="About MoodHaven Journal"
@@ -66,7 +68,7 @@ export function AboutTab({
             </p>
           </div>
 
-          {!isBrowser && (
+          {!isBrowser && !isIOS && (
             <>
               <div className="py-3 border-b border-slate-100 dark:border-slate-700 space-y-2">
                 <div className="flex items-center justify-between">

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,22 +1,24 @@
 /**
- * usePlatform — detect whether the app is running on Android or desktop.
+ * usePlatform — detect whether the app is running on iOS, Android, or desktop.
  *
  * Strategy: Tauri exposes `window.__TAURI_INTERNALS__` on all platforms.
- * On Android the user-agent contains "Android". This is reliable inside a
- * Tauri WebView because we control the UA string.
- *
- * Result is stable for the lifetime of the app — computed once at module load.
+ * Platform is inferred from the WebView user-agent — reliable inside Tauri
+ * because we control the UA string. Result is stable for the app lifetime.
  */
 
-const IS_ANDROID = typeof navigator !== 'undefined' &&
-  /android/i.test(navigator.userAgent);
+const _hasTauri = typeof window !== 'undefined' && !!window.__TAURI_INTERNALS__;
+const _ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
 
-const IS_BROWSER = typeof window !== 'undefined' && !window.__TAURI_INTERNALS__;
+const IS_IOS = _hasTauri && /iPhone|iPad|iPod/i.test(_ua);
+const IS_ANDROID = _hasTauri && !IS_IOS && /android/i.test(_ua);
+const IS_BROWSER = !_hasTauri;
 
 export function usePlatform() {
   return {
+    isIOS: IS_IOS,
     isAndroid: IS_ANDROID,
+    isMobile: IS_IOS || IS_ANDROID,
     isBrowser: IS_BROWSER,
-    isDesktop: !IS_ANDROID && !IS_BROWSER,
+    isDesktop: !IS_IOS && !IS_ANDROID && !IS_BROWSER,
   };
 }

--- a/src/pages/CalendarPage.test.tsx
+++ b/src/pages/CalendarPage.test.tsx
@@ -69,7 +69,7 @@ function setupCalendarMock(initial: Partial<ReturnType<typeof useCalendar>> = {}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockUsePlatform.mockReturnValue({ isAndroid: false, isBrowser: false, isDesktop: true });
+  mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: false, isMobile: false, isBrowser: false, isDesktop: true });
   setupCalendarMock();
 });
 
@@ -107,14 +107,14 @@ describe('CalendarPage', () => {
   });
 
   it('renders mobile layout on Android', () => {
-    mockUsePlatform.mockReturnValue({ isAndroid: true, isBrowser: false, isDesktop: false });
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: true, isMobile: true, isBrowser: false, isDesktop: false });
     setupCalendarMock();
     render(<CalendarPage />);
     expect(screen.getByText('Tap a day to see its entries')).toBeInTheDocument();
   });
 
   it('shows back button in mobile layout after selecting a date', () => {
-    mockUsePlatform.mockReturnValue({ isAndroid: true, isBrowser: false, isDesktop: false });
+    mockUsePlatform.mockReturnValue({ isIOS: false, isAndroid: true, isMobile: true, isBrowser: false, isDesktop: false });
     setupCalendarMock();
     render(<CalendarPage />);
     fireEvent.click(screen.getByText('Select date'));


### PR DESCRIPTION
## Summary

- **Phase 2 — Tauri iOS project setup**: `tauri.conf.json` iOS bundle config (min iOS 16.0), `src-tauri/capabilities/ios.json` capability file scoped to iOS, `usePlatform()` hook extended with `isIOS` / `isMobile` / `isDesktop`, iOS build guide in `docs/build.md`
- **Phase 4 — Feature gates**: Four desktop-only features conditionally hidden on iOS via `usePlatform().isIOS`
  - `DevicesTab`: peer sync UI replaced with an informational card directing users to cloud sync
  - `EditorToolbar`: STT mic button hidden (whisper.cpp sidecar unavailable on iOS)
  - `FocusMenu`: Breakout writer button hidden (no multi-window on iOS)
  - `AboutTab`: Update panel + log level/folder section hidden (App Store owns updates; sandboxed log access)
- **Test coverage**: 17 new tests across 4 test files covering all 6 new `isIOS` code branches

## Target

Merges into `feat/cloud-sync-phase1` (cloud sync ships first per the iOS sequencing plan).
The `usePlatform` gates in this PR are inert on desktop — they evaluate to `false` and render no differently from before.

## Test plan

- [x] `npm test` — 1300/1300 passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files)
- [x] All 4 component tests verify: iOS path hides feature, non-iOS path shows it, standard controls unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)