### PR TITLE
feat(setup): simplify onboarding to 3-step basic path with advanced toggle

### DIFF
--- a/src-tauri/src/commands/peer_sync_engine/conflict.rs
+++ b/src-tauri/src/commands/peer_sync_engine/conflict.rs
@@ -259,9 +259,13 @@ pub fn db_upsert_book(conn: &Connection, row: &SyncBookRow) -> Result<bool, Stri
             .map_err(|e| format!("insert book: {e}"))?;
             Ok(true)
         }
-        Some(ref local) if {
-            parse_peer_timestamp(local).map(|local_ts| remote_ts > local_ts).unwrap_or(false)
-        } => {
+        Some(ref local)
+            if {
+                parse_peer_timestamp(local)
+                    .map(|local_ts| remote_ts > local_ts)
+                    .unwrap_or(false)
+            } =>
+        {
             conn.execute(
                 "UPDATE books \
                  SET name = ?2, emoji = ?3, color = ?4, sort_order = ?5, \
@@ -475,10 +479,14 @@ pub fn db_upsert_entry(conn: &Connection, row: &JournalEntryRow) -> Result<bool,
             db_upsert_tags(conn, &row.id, &row.tags)?;
             Ok(true)
         }
-        Some(ref local) if {
-            // Parse local timestamp for comparison; fall back to "remote loses" on parse error.
-            parse_peer_timestamp(local).map(|local_ts| remote_ts > local_ts).unwrap_or(false)
-        } => {
+        Some(ref local)
+            if {
+                // Parse local timestamp for comparison; fall back to "remote loses" on parse error.
+                parse_peer_timestamp(local)
+                    .map(|local_ts| remote_ts > local_ts)
+                    .unwrap_or(false)
+            } =>
+        {
             // UPDATE — set updated_at explicitly so the trigger (WHEN NEW.updated_at = OLD.updated_at) doesn't fire
             conn.execute(
                 "UPDATE journal_entries \

--- a/src/components/setup/CompleteStep.tsx
+++ b/src/components/setup/CompleteStep.tsx
@@ -1,6 +1,8 @@
 interface CompleteStepProps {
   enableLanSync: boolean;
   isAdvanced?: boolean;
+  onStart?: () => Promise<void>;
+  isLoading?: boolean;
 }
 
 const BASIC_NUDGES = [
@@ -50,7 +52,7 @@ const BASIC_NUDGES = [
   },
 ];
 
-export function CompleteStep({ enableLanSync, isAdvanced = true }: CompleteStepProps) {
+export function CompleteStep({ enableLanSync, isAdvanced = true, onStart, isLoading = false }: CompleteStepProps) {
   return (
     <div className="text-center space-y-6">
       <div className="w-20 h-20 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center mx-auto">
@@ -115,10 +117,11 @@ export function CompleteStep({ enableLanSync, isAdvanced = true }: CompleteStepP
 
       <button
         type="button"
-        onClick={() => window.location.reload()}
+        onClick={onStart ? () => { void onStart(); } : () => window.location.reload()}
+        disabled={isLoading}
         className="btn-primary w-full py-3"
       >
-        Start Journaling
+        {isLoading ? 'Setting up…' : 'Start Journaling'}
       </button>
     </div>
   );

--- a/src/components/setup/CompleteStep.tsx
+++ b/src/components/setup/CompleteStep.tsx
@@ -1,8 +1,56 @@
 interface CompleteStepProps {
   enableLanSync: boolean;
+  isAdvanced?: boolean;
 }
 
-export function CompleteStep({ enableLanSync }: CompleteStepProps) {
+const BASIC_NUDGES = [
+  {
+    icon: (
+      <svg className="w-4 h-4 text-violet-600 dark:text-violet-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+      </svg>
+    ),
+    label: 'Add two-factor authentication',
+    hint: 'Settings → Privacy',
+    bg: 'bg-violet-50 dark:bg-violet-900/20',
+    iconBg: 'bg-violet-100 dark:bg-violet-900/40',
+  },
+  {
+    icon: (
+      <svg className="w-4 h-4 text-amber-600 dark:text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+      </svg>
+    ),
+    label: 'Create a recovery key',
+    hint: 'Settings → Privacy',
+    bg: 'bg-amber-50 dark:bg-amber-900/20',
+    iconBg: 'bg-amber-100 dark:bg-amber-900/40',
+  },
+  {
+    icon: (
+      <svg className="w-4 h-4 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8.288 15.038a5.25 5.25 0 017.424 0M5.106 11.856c3.807-3.808 9.98-3.808 13.788 0M1.924 8.674c5.565-5.565 14.587-5.565 20.152 0M12.53 18.22l-.53.53-.53-.53a.75.75 0 011.06 0z" />
+      </svg>
+    ),
+    label: 'Connect another device',
+    hint: 'Settings → Devices',
+    bg: 'bg-emerald-50 dark:bg-emerald-900/20',
+    iconBg: 'bg-emerald-100 dark:bg-emerald-900/40',
+  },
+  {
+    icon: (
+      <svg className="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+      </svg>
+    ),
+    label: 'Import a backup',
+    hint: 'Settings → Data',
+    bg: 'bg-blue-50 dark:bg-blue-900/20',
+    iconBg: 'bg-blue-100 dark:bg-blue-900/40',
+  },
+];
+
+export function CompleteStep({ enableLanSync, isAdvanced = true }: CompleteStepProps) {
   return (
     <div className="text-center space-y-6">
       <div className="w-20 h-20 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center mx-auto">
@@ -24,20 +72,46 @@ export function CompleteStep({ enableLanSync }: CompleteStepProps) {
         )}
       </div>
 
-      <div className="grid grid-cols-3 gap-4 py-4">
-        <div className="text-center">
-          <div className="text-2xl mb-1">5</div>
-          <div className="text-xs text-slate-500 dark:text-slate-400">Mood Levels</div>
+      {!isAdvanced && (
+        <div className="text-left space-y-2">
+          <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide text-center mb-3">
+            Explore when you're ready
+          </p>
+          {BASIC_NUDGES.map((nudge) => (
+            <div
+              key={nudge.label}
+              className={`flex items-center gap-3 p-3 ${nudge.bg} rounded-xl`}
+            >
+              <div className={`w-8 h-8 rounded-lg ${nudge.iconBg} flex items-center justify-center flex-shrink-0`}>
+                {nudge.icon}
+              </div>
+              <div className="text-left min-w-0">
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-200 leading-tight">
+                  {nudge.label}
+                </p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{nudge.hint}</p>
+              </div>
+            </div>
+          ))}
         </div>
-        <div className="text-center">
-          <div className="text-2xl mb-1">AES-256</div>
-          <div className="text-xs text-slate-500 dark:text-slate-400">Encryption</div>
+      )}
+
+      {isAdvanced && (
+        <div className="grid grid-cols-3 gap-4 py-4">
+          <div className="text-center">
+            <div className="text-2xl mb-1">5</div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">Mood Levels</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl mb-1">AES-256</div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">Encryption</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl mb-1">100%</div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">Private</div>
+          </div>
         </div>
-        <div className="text-center">
-          <div className="text-2xl mb-1">100%</div>
-          <div className="text-xs text-slate-500 dark:text-slate-400">Private</div>
-        </div>
-      </div>
+      )}
 
       <button
         type="button"

--- a/src/components/setup/PasswordStep.tsx
+++ b/src/components/setup/PasswordStep.tsx
@@ -7,6 +7,7 @@ interface PasswordStepProps {
   onConfirmPasswordChange: (val: string) => void;
   error: string | null;
   setupMode: 'fresh' | 'sync';
+  isLoading?: boolean;
 }
 
 function getPasswordStrength(password: string) {
@@ -26,6 +27,7 @@ export function PasswordStep({
   onConfirmPasswordChange,
   error,
   setupMode,
+  isLoading = false,
 }: PasswordStepProps) {
   const strength = getPasswordStrength(password);
 
@@ -127,10 +129,10 @@ export function PasswordStep({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!password || !confirmPassword}
+          disabled={!password || !confirmPassword || isLoading}
           className="btn-primary flex-1 py-3"
         >
-          Continue
+          {isLoading ? 'Setting up…' : 'Continue'}
         </button>
       </div>
     </div>

--- a/src/components/setup/PasswordStep.tsx
+++ b/src/components/setup/PasswordStep.tsx
@@ -7,7 +7,6 @@ interface PasswordStepProps {
   onConfirmPasswordChange: (val: string) => void;
   error: string | null;
   setupMode: 'fresh' | 'sync';
-  isLoading?: boolean;
 }
 
 function getPasswordStrength(password: string) {
@@ -27,7 +26,6 @@ export function PasswordStep({
   onConfirmPasswordChange,
   error,
   setupMode,
-  isLoading = false,
 }: PasswordStepProps) {
   const strength = getPasswordStrength(password);
 
@@ -129,10 +127,10 @@ export function PasswordStep({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!password || !confirmPassword || isLoading}
+          disabled={!password || !confirmPassword}
           className="btn-primary flex-1 py-3"
         >
-          {isLoading ? 'Setting up…' : 'Continue'}
+          Continue
         </button>
       </div>
     </div>

--- a/src/components/setup/WelcomeStep.tsx
+++ b/src/components/setup/WelcomeStep.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react';
+
 interface WelcomeStepProps {
-  onNext: () => void;
+  onNext: (advanced: boolean) => void;
 }
 
 export function WelcomeStep({ onNext }: WelcomeStepProps) {
+  const [advanced, setAdvanced] = useState(false);
+
   return (
     <div className="text-center space-y-6">
       {/* Bloom icon */}
@@ -69,9 +73,31 @@ export function WelcomeStep({ onNext }: WelcomeStepProps) {
         </ul>
       </div>
 
+      {/* Advanced setup toggle */}
+      <div className="flex items-center justify-between p-3 bg-slate-50 dark:bg-slate-700/40 rounded-xl text-left">
+        <div>
+          <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Advanced setup</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Configure 2FA, sync, cloud backup and more
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={advanced}
+          onClick={() => setAdvanced((v) => !v)}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 ${advanced ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-600'}`}
+        >
+          <span className="sr-only">Enable advanced setup</span>
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${advanced ? 'translate-x-6' : 'translate-x-1'}`}
+          />
+        </button>
+      </div>
+
       <button
         type="button"
-        onClick={onNext}
+        onClick={() => onNext(advanced)}
         className="btn-primary w-full py-3"
       >
         Create My Journal

--- a/src/pages/SetupScreen.tsx
+++ b/src/pages/SetupScreen.tsx
@@ -167,7 +167,7 @@ export function SetupScreen() {
     setError(null);
   };
 
-  const handlePasswordSubmit = useCallback(async () => {
+  const handlePasswordSubmit = useCallback(() => {
     if (!password) {
       setError('Please enter a password');
       return;
@@ -181,28 +181,27 @@ export function SetupScreen() {
       setError('Passwords do not match');
       return;
     }
-
-    if (!isAdvanced) {
-      // Basic path: initialize with safe defaults immediately, skip advanced steps
-      setIsLoading(true);
-      setError(null);
-      try {
-        const success = await initialize(password);
-        if (!success) {
-          setError('Failed to set up. Please try again.');
-          return;
-        }
-        await saveSettings();
-        goNext();
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setIsLoading(false);
-      }
-    } else {
-      goNext();
-    }
+    goNext();
   }, [password, confirmPassword]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Basic path: called from CompleteStep "Start Journaling" — initialize then let App.tsx transition
+  const handleBasicComplete = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const success = await initialize(password);
+      if (!success) {
+        setError('Failed to set up. Please try again.');
+        return;
+      }
+      await saveSettings();
+      // App.tsx watches isInitialized; once set to true it transitions away from SetupScreen
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [password, initialize, saveSettings]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleComplete = useCallback(async () => {
     setIsLoading(true);
@@ -314,14 +313,13 @@ export function SetupScreen() {
             {currentStep === 'password' && (
               <PasswordStep
                 onBack={goBack}
-                onSubmit={() => { void handlePasswordSubmit(); }}
+                onSubmit={handlePasswordSubmit}
                 password={password}
                 confirmPassword={confirmPassword}
                 onPasswordChange={setPassword}
                 onConfirmPasswordChange={setConfirmPassword}
                 error={error}
                 setupMode={setupMode}
-                isLoading={isLoading}
               />
             )}
 
@@ -407,7 +405,12 @@ export function SetupScreen() {
             )}
 
             {currentStep === 'complete' && (
-              <CompleteStep enableLanSync={enableLanSync} isAdvanced={isAdvanced} />
+              <CompleteStep
+                enableLanSync={enableLanSync}
+                isAdvanced={isAdvanced}
+                onStart={!isAdvanced ? handleBasicComplete : undefined}
+                isLoading={isLoading}
+              />
             )}
           </div>
         </div>

--- a/src/pages/SetupScreen.tsx
+++ b/src/pages/SetupScreen.tsx
@@ -4,9 +4,9 @@
  * Holds all shared wizard state and renders the appropriate step component.
  * Each step component owns only ephemeral UI state (hover, loading spinners).
  *
- * Steps:
- * Fresh path: welcome → source → password → recovery → security → storage → devices → import → complete
- * Sync path:  welcome → source → password → sync_from_peer → complete
+ * Basic path (default):  welcome → password → complete
+ * Fresh path (advanced): welcome → source → password → recovery → security → storage → devices → import → complete
+ * Sync path  (advanced): welcome → source → password → sync_from_peer → complete
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
@@ -39,6 +39,12 @@ interface StepConfig {
   subtitle: string;
 }
 
+const BASIC_STEPS: StepConfig[] = [
+  { id: 'welcome',  title: 'Welcome',  subtitle: 'Get started' },
+  { id: 'password', title: 'Password', subtitle: 'Protect your data' },
+  { id: 'complete', title: 'Ready',    subtitle: 'All set!' },
+];
+
 const FRESH_STEPS: StepConfig[] = [
   { id: 'welcome',       title: 'Welcome',        subtitle: 'Get started' },
   { id: 'source',        title: 'Setup',          subtitle: 'Choose path' },
@@ -61,6 +67,7 @@ const SYNC_STEPS: StepConfig[] = [
 
 export function SetupScreen() {
   const [currentStep, setCurrentStep] = useState<WizardStep>('welcome');
+  const [isAdvanced, setIsAdvanced] = useState(false);
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [storageType, setStorageType] = useState<StorageBackend>('local');
@@ -88,9 +95,14 @@ export function SetupScreen() {
   const trustedDevices = usePeerSyncStore((s) => s.trustedDevices);
   const { isBrowser } = usePlatform();
 
-  const STEPS = (setupMode === 'sync' ? SYNC_STEPS : FRESH_STEPS).filter(
-    (s) => !isBrowser || (s.id !== 'devices' && s.id !== 'sync_from_peer'),
-  );
+  const browserFilter = (s: StepConfig) =>
+    !isBrowser || (s.id !== 'devices' && s.id !== 'sync_from_peer');
+
+  const STEPS = (() => {
+    if (setupMode === 'sync') return SYNC_STEPS.filter(browserFilter);
+    if (isAdvanced) return FRESH_STEPS.filter(browserFilter);
+    return BASIC_STEPS;
+  })();
 
   // Start/stop discovery when entering the devices or sync_from_peer step
   useEffect(() => {
@@ -143,13 +155,19 @@ export function SetupScreen() {
     }
   };
 
+  const handleWelcomeNext = (advanced: boolean) => {
+    setIsAdvanced(advanced);
+    setCurrentStep(advanced ? 'source' : 'password');
+    setError(null);
+  };
+
   const handleChooseSource = (mode: 'fresh' | 'sync') => {
     setSetupMode(mode);
     setCurrentStep('password');
     setError(null);
   };
 
-  const handlePasswordSubmit = useCallback(() => {
+  const handlePasswordSubmit = useCallback(async () => {
     if (!password) {
       setError('Please enter a password');
       return;
@@ -163,7 +181,27 @@ export function SetupScreen() {
       setError('Passwords do not match');
       return;
     }
-    goNext();
+
+    if (!isAdvanced) {
+      // Basic path: initialize with safe defaults immediately, skip advanced steps
+      setIsLoading(true);
+      setError(null);
+      try {
+        const success = await initialize(password);
+        if (!success) {
+          setError('Failed to set up. Please try again.');
+          return;
+        }
+        await saveSettings();
+        goNext();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      goNext();
+    }
   }, [password, confirmPassword]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleComplete = useCallback(async () => {
@@ -182,6 +220,7 @@ export function SetupScreen() {
         settings: {
           ...s.settings,
           storage: {
+            ...s.settings.storage,
             type: storageType,
             webdav: {
               url: storageType === 'webdav' ? webdavUrl : '',
@@ -261,7 +300,7 @@ export function SetupScreen() {
 
           <div className="p-8">
             {currentStep === 'welcome' && (
-              <WelcomeStep onNext={() => setCurrentStep('source')} />
+              <WelcomeStep onNext={handleWelcomeNext} />
             )}
 
             {currentStep === 'source' && (
@@ -275,13 +314,14 @@ export function SetupScreen() {
             {currentStep === 'password' && (
               <PasswordStep
                 onBack={goBack}
-                onSubmit={handlePasswordSubmit}
+                onSubmit={() => { void handlePasswordSubmit(); }}
                 password={password}
                 confirmPassword={confirmPassword}
                 onPasswordChange={setPassword}
                 onConfirmPasswordChange={setConfirmPassword}
                 error={error}
                 setupMode={setupMode}
+                isLoading={isLoading}
               />
             )}
 
@@ -367,7 +407,7 @@ export function SetupScreen() {
             )}
 
             {currentStep === 'complete' && (
-              <CompleteStep enableLanSync={enableLanSync} />
+              <CompleteStep enableLanSync={enableLanSync} isAdvanced={isAdvanced} />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Default setup path reduced from 9 screens to 3: **welcome → password → complete**
- Added an accessible toggle on the welcome screen to opt into the full advanced wizard (all 9 existing steps preserved)
- Basic mode initializes with safe defaults (local storage, no LAN sync, no 2FA) and shows nudge cards on the completion screen pointing users to 2FA, recovery key, device pairing, and import
- Advanced path unchanged: source → password → recovery → security → storage → devices → import → complete

## Test plan

- [ ] Basic path: toggle off → Create My Journal → set password → verify "Setting up…" spinner → complete screen shows 4 nudge cards
- [ ] Advanced path: toggle on → dot count expands to 9 → full existing wizard flow works end-to-end
- [ ] Advanced → sync path: toggle on → choose "Restore from another device" → sync flow unchanged
- [ ] Back navigation works correctly in both paths (basic: password → welcome; advanced: preserves full step order)
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (1283 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)