### PR TITLE
fix(android): QA pass — callback leak, stream safety, brand strings

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/BiometricPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/BiometricPlugin.kt
@@ -22,7 +22,7 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 
 private const val TAG = "BiometricPlugin"
-private const val KEY_ALIAS = "MoodBloomBiometricKey"
+private const val KEY_ALIAS = "MoodHavenBiometricKey"
 private const val PREFS_NAME = "moodbloom_biometric"
 private const val PREF_ENCRYPTED_PW = "encrypted_password"
 private const val PREF_IV = "iv"
@@ -175,7 +175,7 @@ class BiometricPlugin(private val activity: Activity) : Plugin(activity) {
             try {
                 val cipher = buildDecryptCipher(iv)
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                    .setTitle("Unlock MoodBloom")
+                    .setTitle("Unlock MoodHaven")
                     .setSubtitle("Confirm your identity to access your journal")
                     .setNegativeButtonText("Use Password")
                     .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/WearPlugin.kt
@@ -70,6 +70,17 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
 
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+    private val channelCallback = object : ChannelClient.ChannelCallback() {
+        override fun onChannelOpened(channel: ChannelClient.Channel) {
+            if (channel.path != WearProtocol.CHANNEL_AUDIO) {
+                Log.w(TAG, "Plugin: unexpected channel path: ${channel.path}")
+                return
+            }
+            Log.i(TAG, "Plugin: audio channel opened from ${channel.nodeId}")
+            ioScope.launch { processAudioChannel(channel) }
+        }
+    }
+
     // Set singleton, drain any buffered events, and register foreground channel callback
     init {
         _instance = this
@@ -79,18 +90,14 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
         // When the app is in the foreground GMS routes ChannelAPI events to a registered
         // ChannelCallback rather than WearableListenerService.onChannelOpened().
         // Registering here ensures audio arrives regardless of app state.
-        val cb = object : ChannelClient.ChannelCallback() {
-            override fun onChannelOpened(channel: ChannelClient.Channel) {
-                if (channel.path != WearProtocol.CHANNEL_AUDIO) {
-                    Log.w(TAG, "Plugin: unexpected channel path: ${channel.path}")
-                    return
-                }
-                Log.i(TAG, "Plugin: audio channel opened from ${channel.nodeId}")
-                ioScope.launch { processAudioChannel(channel) }
-            }
-        }
-        Wearable.getChannelClient(activity).registerChannelCallback(cb)
+        Wearable.getChannelClient(activity).registerChannelCallback(channelCallback)
         Log.i(TAG, "ChannelClient foreground callback registered")
+    }
+
+    override fun onDestroy() {
+        Wearable.getChannelClient(activity).unregisterChannelCallback(channelCallback)
+        Log.i(TAG, "ChannelClient foreground callback unregistered")
+        super.onDestroy()
     }
 
     // ── Bridge from WearListenerService ──────────────────────────────────────
@@ -171,9 +178,7 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
     private suspend fun processAudioChannel(channel: ChannelClient.Channel) {
         val channelClient = Wearable.getChannelClient(activity)
         try {
-            val inputStream = channelClient.getInputStream(channel).await()
-            val allBytes = inputStream.readBytes()
-            inputStream.close()
+            val allBytes = channelClient.getInputStream(channel).await().use { it.readBytes() }
 
             val frame = AudioFrameParser.parse(allBytes) ?: return
             Log.i(TAG, "Plugin: audio received id=${frame.id} duration=${frame.durationMs}ms size=${frame.audioBytes.size}")
@@ -222,7 +227,7 @@ class WearPlugin(private val activity: Activity) : Plugin(activity) {
                 val id = json.optString("id").takeIf { it.isNotBlank() }
                 if (id == null) { Log.w(TAG, "Dropping buffered signal with missing id"); continue }
                 bridgeFromWatch(
-                    id = id!!,
+                    id = id,
                     timestamp = json.optString("timestamp", nowIso8601()),
                     type = json.optString("type", "unknown"),
                     source = json.optString("source", "watch"),

--- a/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
+++ b/src-tauri/gen/android/wear/src/main/java/com/moodbloom/wear/MoodComplicationService.kt
@@ -20,7 +20,7 @@ import androidx.wear.watchface.complications.datasource.SuspendingComplicationDa
  * LONG_TEXT:  last mood + time     e.g. "😊 Great · Today 09:14"
  *
  * Watch face users: long-press the watch face → Complications → choose a slot
- * → scroll to MoodBloom.
+ * → scroll to MoodHaven.
  */
 class MoodComplicationService : SuspendingComplicationDataSourceService() {
 
@@ -53,7 +53,7 @@ class MoodComplicationService : SuspendingComplicationDataSourceService() {
             // No history yet — prompt user to log
             when (request.complicationType) {
                 ComplicationType.SHORT_TEXT -> shortText("🌱", "Log mood")
-                ComplicationType.LONG_TEXT  -> longText("🌱 Log your mood", "MoodBloom")
+                ComplicationType.LONG_TEXT  -> longText("🌱 Log your mood", "MoodHaven")
                 else -> null
             }
         } else {
@@ -71,7 +71,7 @@ class MoodComplicationService : SuspendingComplicationDataSourceService() {
     private fun shortText(text: String, title: String): ShortTextComplicationData =
         ShortTextComplicationData.Builder(
             text  = PlainComplicationText.Builder(text).build(),
-            contentDescription = PlainComplicationText.Builder("MoodBloom: $title").build(),
+            contentDescription = PlainComplicationText.Builder("MoodHaven: $title").build(),
         )
             .setTitle(PlainComplicationText.Builder(title).build())
             .build()
@@ -79,7 +79,7 @@ class MoodComplicationService : SuspendingComplicationDataSourceService() {
     private fun longText(text: String, title: String): LongTextComplicationData =
         LongTextComplicationData.Builder(
             text  = PlainComplicationText.Builder(text).build(),
-            contentDescription = PlainComplicationText.Builder("MoodBloom: $text").build(),
+            contentDescription = PlainComplicationText.Builder("MoodHaven: $text").build(),
         )
             .setTitle(PlainComplicationText.Builder(title).build())
             .build()


### PR DESCRIPTION
## Summary

Code review QA pass on both Android companion apps. Three real bugs fixed across three files.

**WearPlugin.kt (phone companion)**
- `ChannelCallback` was registered in `init {}` as a local variable — no reference kept, so it could never be unregistered. Stored as `private val channelCallback` and added `onDestroy()` to call `unregisterChannelCallback`. Prevents potential double-processing of audio if the plugin is re-instantiated.
- `inputStream.readBytes()` followed by `inputStream.close()` — if `readBytes()` throws, the stream is never closed. Replaced with `inputStream.use { it.readBytes() }` for guaranteed close.
- Removed redundant `!!` on `id` (was already non-null via `.takeIf` guard on the line above).

**MoodComplicationService.kt (watch)**
- User-visible `contentDescription` strings and the setup comment still read "MoodBloom" — fixed to "MoodHaven". These surface to accessibility tools and the watch face complication picker.

**BiometricPlugin.kt (phone companion)**
- `KEY_ALIAS = "MoodBloomBiometricKey"` → `"MoodHavenBiometricKey"` — key alias is stored in Android Keystore; old alias will be orphaned. Users who had biometric enrolled will see a one-time re-enroll prompt (existing encrypted credential is cleared on key mismatch, same path as `clearEnrolledData()`).
- Biometric prompt title "Unlock MoodBloom" → "Unlock MoodHaven".

## Test plan
- [ ] Install on physical Android device; verify biometric unlock prompts "Unlock MoodHaven"
- [ ] Record a voice memo on watch; verify desktop receives it (ChannelAPI callback still fires)
- [ ] Check watch face complication picker shows "MoodHaven" in accessibility label

🤖 Generated with [Claude Code](https://claude.com/claude-code)