### PR TITLE
feat(ui): extend mobile layout gates to iOS and narrow viewports (v1.8.0)

### DIFF
--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -10,6 +10,7 @@ import { useCalendar } from '../hooks/useCalendar';
 import { CalendarView } from '../components/calendar';
 import { DayTimelineView } from '../components/calendar/DayTimelineView';
 import { usePlatform } from '../hooks/usePlatform';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 interface CalendarPageProps {
   onSelectEntry?: (entryId: string) => void;
@@ -17,6 +18,8 @@ interface CalendarPageProps {
 
 export function CalendarPage({ onSelectEntry }: CalendarPageProps) {
   const { isAndroid } = usePlatform();
+  const isMobileViewport = useIsMobile();
+  const isMobile = isAndroid || isMobileViewport;
   const calendar = useCalendar();
   const [timelineVisible, setTimelineVisible] = useState(false);
 
@@ -58,7 +61,7 @@ export function CalendarPage({ onSelectEntry }: CalendarPageProps) {
   );
 
   // ── Mobile layout: full-screen grid, day view slides over from right ─────────
-  if (isAndroid) {
+  if (isMobile) {
     return (
       <div className="h-full relative overflow-hidden bg-white dark:bg-slate-900">
         {/* Calendar grid — always mounted, hidden behind overlay when day selected */}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { usePlatform } from '../hooks/usePlatform';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { useSettingsStore } from '../stores/settingsStore';
 import {
   getDataStats,
@@ -173,6 +174,8 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
   const setScrollToSection = useSettingsStore((s) => s.setScrollToSection);
 
   const { isAndroid } = usePlatform();
+  const isMobileViewport = useIsMobile();
+  const isMobile = isAndroid || isMobileViewport;
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [mobileScreen, setMobileScreen] = useState<'list' | 'detail'>('list');
   const [searchQuery, setSearchQuery] = useState('');
@@ -650,7 +653,7 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
     );
   }
 
-  if (isAndroid) {
+  if (isMobile) {
     const activeTabConfig = TABS.find(t => t.id === activeTab);
     return (
       <>

--- a/src/pages/TimelineView.tsx
+++ b/src/pages/TimelineView.tsx
@@ -20,6 +20,7 @@ import type { JournalEntry } from '../types/journal';
 import { MOOD_OPTIONS } from '../types/journal';
 import { useBooksStore } from '../stores/booksStore';
 import { usePlatform } from '../hooks/usePlatform';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { logger } from '../lib/services/logger';
 import { useVoiceMemoDrafts } from '../hooks/useVoiceMemoDrafts';
 import { VoiceMemoDraftCard } from '../components/voice-memo/VoiceMemoDraftCard';
@@ -99,6 +100,8 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
   const sessionPassword = useAppStore((s) => s.sessionPassword);
 
   const { isAndroid } = usePlatform();
+  const isMobileViewport = useIsMobile();
+  const isMobile = isAndroid || isMobileViewport;
   const activeBookId = useBooksStore((s) => s.activeBookId);
   const activeBooksLabel = useBooksStore((s) => {
     if (!s.activeBookId) return null;
@@ -380,9 +383,9 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
   }
 
   return (
-    <div className={isAndroid ? 'py-0' : 'max-w-2xl mx-auto px-6 py-8'}>
+    <div className={isMobile ? 'py-0' : 'max-w-2xl mx-auto px-6 py-8'}>
       {/* Header with entry count */}
-      <div className={isAndroid ? 'px-4 pt-4 mb-3' : 'mb-8'}>
+      <div className={isMobile ? 'px-4 pt-4 mb-3' : 'mb-8'}>
         <h1 className="text-2xl font-semibold text-slate-800 dark:text-slate-100">
           {activeBooksLabel ?? 'Journal'}
         </h1>
@@ -397,7 +400,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
 
       {/* Inline search */}
       {entries.length > 0 && (
-        <div className={`relative mb-4 ${isAndroid ? 'px-4' : ''}`}>
+        <div className={`relative mb-4 ${isMobile ? 'px-4' : ''}`}>
           <svg
             className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500 pointer-events-none"
             fill="none"
@@ -437,7 +440,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
 
       {/* Mood filter chips */}
       {entries.length > 0 && (
-        <div className={`flex gap-2 mb-4 ${isAndroid ? 'overflow-x-auto px-4 pb-1 flex-nowrap' : 'flex-wrap'}`}>
+        <div className={`flex gap-2 mb-4 ${isMobile ? 'overflow-x-auto px-4 pb-1 flex-nowrap' : 'flex-wrap'}`}>
           {/* All chip */}
           <button
             type="button"
@@ -487,7 +490,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
 
       {/* Date range filter chips */}
       {entries.length > 0 && (
-        <div className={`flex gap-2 mb-4 ${isAndroid ? 'overflow-x-auto px-4 pb-1 flex-nowrap' : 'flex-wrap'}`}>
+        <div className={`flex gap-2 mb-4 ${isMobile ? 'overflow-x-auto px-4 pb-1 flex-nowrap' : 'flex-wrap'}`}>
           {([
             ['all', 'All time'],
             ['week', 'This week'],
@@ -521,7 +524,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
         tags={allTags}
         activeTag={tagFilter}
         onSelect={setTagFilter}
-        isAndroid={isAndroid}
+        isAndroid={isMobile}
       />
 
       {/* Empty state - no entries at all */}
@@ -559,7 +562,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
 
       {/* Voice memo draft cards (Phase 5) */}
       {drafts.length > 0 && (
-        <div className={`mb-4 space-y-2 ${isAndroid ? 'px-4' : ''}`}>
+        <div className={`mb-4 space-y-2 ${isMobile ? 'px-4' : ''}`}>
           {drafts.map((draft) => (
             <VoiceMemoDraftCard
               key={draft.id}
@@ -573,11 +576,11 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
 
       {/* Pinned Entries section */}
       {pinnedEntries.length > 0 && (
-        <div className={isAndroid ? 'mb-4' : 'mb-8'}>
+        <div className={isMobile ? 'mb-4' : 'mb-8'}>
           <button
             type="button"
             onClick={() => setPinnedCollapsed((v) => !v)}
-            className={`flex items-center gap-2 mb-3 w-full text-left group ${isAndroid ? 'px-4' : ''}`}
+            className={`flex items-center gap-2 mb-3 w-full text-left group ${isMobile ? 'px-4' : ''}`}
           >
             <span className="text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wide">
               📌 Pinned
@@ -684,7 +687,7 @@ export function TimelineView({ onSelectEntry, onNewEntry, onSealEntry, refreshTr
       <VirtualEntryList
         groupedEntries={groupedEntries}
         mediaByEntry={mediaByEntry}
-        isAndroid={isAndroid}
+        isAndroid={isMobile}
         getDateHeader={getDateHeader}
         onSelectEntry={onSelectEntry}
         onDelete={handleDelete}

--- a/src/pages/WritingView.tsx
+++ b/src/pages/WritingView.tsx
@@ -48,6 +48,7 @@ import { MOOD_OPTIONS, PRIVACY_MODE_LABELS, PRIVACY_MODE_DESCRIPTIONS } from '..
 import type { JournalTemplate } from '../lib/utils/journalTemplates';
 import { formatTemplateContent } from '../lib/utils/journalTemplates';
 import { usePlatform } from '../hooks/usePlatform';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { logger } from '../lib/services/logger';
 import { useWearVoiceMemos } from '../hooks/useWearVoiceMemos';
 import type { VoiceMemo } from '../lib/services/voiceMemoService';
@@ -256,6 +257,8 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
   const distractionFree = useSettingsStore((s) => s.distractionFree);
   const writingAppearance = useSettingsStore((s) => s.settings.appearance.writing);
   const { isAndroid, isBrowser } = usePlatform();
+  const isMobileViewport = useIsMobile();
+  const isMobile = isAndroid || isMobileViewport;
   const setDistractionFree = useSettingsStore((s) => s.setDistractionFree);
   const hasSeenWritingDrawerHint = useSettingsStore((s) => s.settings.tutorial.hasSeenWritingDrawerHint);
   const setHasSeenWritingDrawerHint = useSettingsStore((s) => s.setHasSeenWritingDrawerHint);
@@ -768,7 +771,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
   // When the soft keyboard opens, visualViewport shrinks the container height and
   // keyboardVisible=true collapses the metadata section, so the editor stays visible
   // just above the keyboard.
-  if (isAndroid) {
+  if (isMobile) {
     const promptText = forYouPrompts[0]?.text ?? generalPrompts[0]?.text ?? null;
     return (
       <div


### PR DESCRIPTION
## Summary

- `CalendarPage`, `SettingsPage`, `TimelineView`, and `WritingView` previously switched to mobile layouts only when `isAndroid` was true
- This missed iOS (Tauri native) and browser viewport resizes below 768px
- Each view now computes `isMobile = isAndroid || useIsMobile()` so the mobile layout activates on all three targets
- Android-specific guards (keyboard avoidance, watch memo integration, streak toast, audio warmup) intentionally keep `isAndroid` — these are native-only behaviors not layout concerns

## Test plan

- [ ] Resize browser dev window to < 768px — CalendarPage, SettingsPage, TimelineView, WritingView should use mobile layouts
- [ ] Verify desktop layout restores above 768px
- [ ] On iOS Tauri build, all four views use mobile layout
- [ ] Android behavior unchanged
- [ ] `npm run typecheck` passes
- [ ] `npm test` — 1418 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)