### PR TITLE
fix(security): SQLC-004 orphaned moodhaven_enc.db startup recovery

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -58,7 +58,11 @@ pub fn read_db_state(db_path: &Path) -> DbStateFile {
 fn write_db_state(db_path: &Path, state: &DbStateFile) -> Result<(), String> {
     let path = db_state_path(db_path);
     let json = serde_json::to_string(state).map_err(|e| format!("serialize db_state: {e}"))?;
-    std::fs::write(&path, json).map_err(|e| format!("write db_state.json: {e}"))?;
+    // Atomic write: write to a tmp file then rename so a crash mid-write never leaves a
+    // partial JSON that causes the recovery path to misclassify the DB state.
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json).map_err(|e| format!("write db_state.json.tmp: {e}"))?;
+    std::fs::rename(&tmp, &path).map_err(|e| format!("rename db_state.json: {e}"))?;
     Ok(())
 }
 
@@ -85,20 +89,36 @@ impl Database {
     /// the connection is opened but no pragmas or migrations are run — the caller must
     /// call `apply_key()` after the user authenticates before the connection is usable.
     pub fn new(db_path: PathBuf) -> Result<Self, String> {
-        let state = read_db_state(&db_path);
+        let mut state = read_db_state(&db_path);
 
-        // Recovery: if db_state.json says encrypted=true and moodhaven_enc.db still exists,
-        // the previous migration was interrupted between db_state.json write and the rename.
-        // Complete the rename now to bring the file to a consistent encrypted state.
-        if state.encrypted {
-            let tmp_path = db_path.with_file_name("moodhaven_enc.db");
-            if tmp_path.exists() {
+        // Recovery: if moodhaven_enc.db exists, a previous encrypt_in_place was interrupted.
+        // Two sub-cases:
+        //   (a) db_state.json says encrypted=true  — crash after state write, before rename
+        //   (b) db_state.json missing/encrypted=false — crash before state write (SQLC-004)
+        // In case (b) the plaintext moodhaven.db is still present and would otherwise be
+        // opened normally, silently discarding the encrypted copy forever.
+        let tmp_path = db_path.with_file_name("moodhaven_enc.db");
+        if tmp_path.exists() {
+            if !state.encrypted {
+                log::warn!(
+                    "[sqlcipher] Found moodhaven_enc.db without db_state.json — \
+                     completing interrupted migration (SQLC-004 recovery)"
+                );
+                let _ = write_db_state(
+                    &db_path,
+                    &DbStateFile {
+                        encrypted: true,
+                        salt: None,
+                    },
+                );
+                state.encrypted = true;
+            } else {
                 log::info!("[sqlcipher] Completing interrupted migration on startup");
-                #[cfg(target_os = "windows")]
-                let _ = std::fs::remove_file(&db_path);
-                if let Err(e) = std::fs::rename(&tmp_path, &db_path) {
-                    log::error!("[sqlcipher] Startup recovery rename failed: {e}");
-                }
+            }
+            #[cfg(target_os = "windows")]
+            let _ = std::fs::remove_file(&db_path);
+            if let Err(e) = std::fs::rename(&tmp_path, &db_path) {
+                log::error!("[sqlcipher] Startup recovery rename failed: {e}");
             }
         }
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -268,7 +268,9 @@ impl Database {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                 }
                 match std::fs::rename(&self.path, &backup) {
-                    Err(e) => { last_err = format!("backup original db: {e}"); }
+                    Err(e) => {
+                        last_err = format!("backup original db: {e}");
+                    }
                     Ok(()) => match std::fs::rename(&tmp_path, &self.path) {
                         Ok(()) => {
                             let _ = std::fs::remove_file(&backup);
@@ -282,7 +284,11 @@ impl Database {
                     },
                 }
             }
-            if success { Ok(()) } else { Err(last_err) }
+            if success {
+                Ok(())
+            } else {
+                Err(last_err)
+            }
         };
 
         #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

- **SQLC-004**: If `encrypt_in_place` crashes after exporting `moodhaven_enc.db` but before writing `db_state.json`, every subsequent startup silently opens the original plaintext `moodhaven.db` — the encrypted copy is discarded forever. Fix unconditionally checks for `moodhaven_enc.db` at startup, independent of `db_state.json` state.
- **Atomic `write_db_state`**: All `db_state.json` writes now go through a `.tmp`→rename sequence, eliminating the partial-write failure mode that created the SQLC-004 window in the first place.

## Root cause

The previous recovery block in `Database::new()` was gated on `state.encrypted == true`. When `db_state.json` is absent (or stale), `read_db_state` returns `{encrypted: false}`, the gate is never entered, and `moodhaven_enc.db` is silently ignored.

## Fix

```
startup:
  moodhaven_enc.db present AND state.encrypted=false  →  SQLC-004 path
    write db_state.json atomically (encrypted=true, salt=None)
    set state.encrypted=true in memory
    rename moodhaven_enc.db → moodhaven.db
    continue as encrypted DB (skip migrations, await apply_key)

  moodhaven_enc.db present AND state.encrypted=true   →  existing path (a)
    rename moodhaven_enc.db → moodhaven.db

  moodhaven_enc.db absent                             →  no-op
```

## Test plan

- [ ] Fresh install (no DB files) — normal migration path unaffected
- [ ] Encrypted DB already in place — `apply_key` path unaffected
- [ ] Simulate SQLC-004: manually create `moodhaven_enc.db` (copy of encrypted DB), delete `db_state.json`, restart app — confirm WARN log fires and app opens in encrypted mode
- [ ] Simulate case (a): `moodhaven_enc.db` present, `db_state.json` says `encrypted=true` — confirm INFO log fires and rename completes
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)