### PR TITLE
feat(website): major homepage overhaul + auto-versioning from GitHub

### DIFF
--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { ShieldCheck, Download, Smartphone, Coins, Code2, Users, Lock, FileCode2, Brain, Wifi, Terminal, Waves } from "lucide-react";
+import { ShieldCheck, Download, Smartphone, Coins, Code2, Users, Lock, FileCode2, Brain, Wifi, Terminal, Waves, BarChart2, Tag, Calendar, BookOpen, Clock } from "lucide-react";
 import AnimatedReveal from "@/components/AnimatedReveal";
 import Link from "next/link";
 
@@ -83,6 +83,34 @@ const TECHNICAL = [
     q: "How do I install on Linux?",
     a: "Download the .AppImage from the Downloads page. Make it executable (chmod +x) and run it directly — no installation required. A .deb package is also available for Ubuntu-based distributions.",
     links: [{ label: "Downloads page", href: "/download" }],
+  },
+];
+
+const MOOD_TRACKING = [
+  {
+    icon: BarChart2,
+    q: "How does the mood tracker work?",
+    a: "You select a mood level (1–5) for each journal entry — from Very Low to Excellent. The app uses these to build a mood calendar heatmap, streak stats, and day-of-week pattern charts. No AI required — all analytics run locally.",
+  },
+  {
+    icon: Tag,
+    q: "What is activity tagging?",
+    a: "Activity tagging lets you link journal entries to activities — Exercise, Social, Reading, Meditation, Cooking, and more. 15 activities are predefined; you can add up to 50 custom ones. After a few weeks, the Insights view shows which activities correlate with your better or worse moods.",
+  },
+  {
+    icon: Calendar,
+    q: "What does the mood calendar show?",
+    a: "The calendar view shows a monthly heatmap: each day is colored by your average mood for that day. Green for excellent, yellow for neutral, orange/red for low. It lets you spot patterns across weeks and months without reading through individual entries.",
+  },
+  {
+    icon: BookOpen,
+    q: 'What is "On This Day"?',
+    a: "On This Day shows you entries written on this same date in previous years. It's a built-in way to see how far you've come or revisit a moment from a year ago — without having to search.",
+  },
+  {
+    icon: Clock,
+    q: "What is the Time Capsule?",
+    a: "The Time Capsule lets you seal any entry until a future date. The entry is hidden from your timeline and search results until the date arrives. Useful for letters to your future self, anniversary memories, or anything you want to revisit later.",
   },
 ];
 
@@ -196,6 +224,28 @@ export default function FAQPage() {
                         ))}
                       </div>
                     )}
+                  </div>
+                </details>
+              );
+            })}
+          </div>
+        </AnimatedReveal>
+
+        {/* Mood & Activity Tracking questions */}
+        <AnimatedReveal delay={0.11}>
+          <p className="text-xs font-semibold text-neutral-400 uppercase tracking-widest mb-5 mt-12">Mood &amp; Activity Tracking</p>
+          <div className="divide-y divide-neutral-100 rounded-xl ring-1 ring-neutral-200 overflow-hidden">
+            {MOOD_TRACKING.map((item) => {
+              const Icon = item.icon;
+              return (
+                <details key={item.q} className="group bg-white/90">
+                  <summary className="flex items-center gap-3 px-5 py-4 cursor-pointer select-none list-none hover:bg-primary-50 transition-colors focus-visible:ring-2 focus-visible:ring-primary-700 focus-visible:outline-none">
+                    <Icon className="w-4 h-4 text-primary-600 flex-shrink-0" aria-hidden="true" />
+                    <span className="flex-1 text-sm font-medium text-neutral-900">{item.q}</span>
+                    <span className="text-neutral-400 group-open:rotate-180 transition-transform duration-200 text-xs" aria-hidden="true">▾</span>
+                  </summary>
+                  <div className="px-5 pb-5 pt-1 pl-12 text-sm text-neutral-600 leading-relaxed">
+                    <p>{item.a}</p>
                   </div>
                 </details>
               );

--- a/website/app/features/page.tsx
+++ b/website/app/features/page.tsx
@@ -1,0 +1,360 @@
+import type { Metadata } from "next";
+import {
+  Type,
+  BookOpen,
+  Pin,
+  LayoutTemplate,
+  Paintbrush,
+  Save,
+  Smile,
+  Tag,
+  CalendarDays,
+  TrendingUp,
+  Activity,
+  History,
+  ShieldCheck,
+  KeyRound,
+  Hash,
+  Lock,
+  Fingerprint,
+  Grid,
+  EyeOff,
+  Timer,
+  Wifi,
+  Cloud,
+  FileDown,
+  FileJson,
+  Sparkles,
+  MessageSquare,
+  RefreshCw,
+  UserCheck,
+  Monitor,
+  Globe,
+  Watch,
+  Mic,
+  Waves,
+} from "lucide-react";
+import AnimatedReveal from "@/components/AnimatedReveal";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Features — MoodHaven Journal",
+  description:
+    "Everything MoodHaven Journal does — writing tools, mood tracking, activity tagging, privacy features, peer sync, AI insights, and more. Free forever.",
+  alternates: { canonical: "https://www.moodhaven.app/features" },
+  openGraph: {
+    title: "Features — MoodHaven Journal",
+    description:
+      "Everything MoodHaven Journal does — writing tools, mood tracking, activity tagging, privacy features, peer sync, AI insights, and more. Free forever.",
+    url: "https://www.moodhaven.app/features",
+    type: "website",
+  },
+};
+
+interface FeatureItem {
+  icon: React.ElementType;
+  name: string;
+  description: string;
+}
+
+interface FeatureCategory {
+  heading: string;
+  items: FeatureItem[];
+}
+
+const CATEGORIES: FeatureCategory[] = [
+  {
+    heading: "Writing",
+    items: [
+      {
+        icon: Type,
+        name: "Rich text editor",
+        description: "TipTap-powered editor with headings, lists, bold, italic, inline code, links, and slash commands.",
+      },
+      {
+        icon: BookOpen,
+        name: "Multiple journals (Books)",
+        description: "Organize entries into named books, each with its own emoji and color.",
+      },
+      {
+        icon: Pin,
+        name: "Entry pinning and status badges",
+        description: "Pin important entries and mark them as Thinking, Complete, or Revisit.",
+      },
+      {
+        icon: LayoutTemplate,
+        name: "Templates",
+        description: "Pick from built-in templates to start an entry with structure already in place.",
+      },
+      {
+        icon: Paintbrush,
+        name: "Writing appearance",
+        description: "Adjust font, size, line height, tint color, and accessibility options per session.",
+      },
+      {
+        icon: Save,
+        name: "Auto-save",
+        description: "Encrypts and writes to disk as you type — no manual save, no lost words.",
+      },
+    ],
+  },
+  {
+    heading: "Mood & Tracking",
+    items: [
+      {
+        icon: Smile,
+        name: "5-level mood selector",
+        description: "One tap per entry, always visible. Ranges from Very Low to Excellent.",
+      },
+      {
+        icon: Tag,
+        name: "Activity tagging",
+        description: "Tag Exercise, Social, Reading, Meditation, Cooking, and 10 more predefined activities. Add up to 50 custom ones.",
+      },
+      {
+        icon: CalendarDays,
+        name: "Mood calendar heatmap",
+        description: "Monthly calendar colored by daily average mood — spot patterns across weeks at a glance.",
+      },
+      {
+        icon: TrendingUp,
+        name: "Mood statistics",
+        description: "Streaks, day-of-week patterns, and trend charts — all computed locally without any AI.",
+      },
+      {
+        icon: Activity,
+        name: "Activity-mood correlation",
+        description: "The Insights view shows which activities correlate with your best and worst moods.",
+      },
+      {
+        icon: History,
+        name: "On This Day",
+        description: "Resurface entries written on this same date in past years, automatically.",
+      },
+    ],
+  },
+  {
+    heading: "Privacy & Security",
+    items: [
+      {
+        icon: ShieldCheck,
+        name: "AES-256-GCM encryption",
+        description: "Keys are derived from your password and never stored. The backend only ever sees ciphertext.",
+      },
+      {
+        icon: KeyRound,
+        name: "Zero-knowledge design",
+        description: "Even if the database file were extracted, its contents are unreadable without your password.",
+      },
+      {
+        icon: Hash,
+        name: "PBKDF2 key derivation",
+        description: "600,000 iterations with a per-entry random salt — compromising one key exposes nothing else.",
+      },
+      {
+        icon: Lock,
+        name: "2FA",
+        description: "TOTP authenticator app support plus FIDO2 hardware key (YubiKey) as a second factor.",
+      },
+      {
+        icon: Fingerprint,
+        name: "Biometric unlock",
+        description: "OS keyring integration — Touch ID, Windows Hello, and Linux keyring for fast re-unlock.",
+      },
+      {
+        icon: Grid,
+        name: "PIN unlock",
+        description: "Set a fast 4–6 digit PIN as an alternative to typing your full password on the lock screen.",
+      },
+      {
+        icon: EyeOff,
+        name: "Privacy modes",
+        description: "Per-entry modes: Open, Mindful (hidden preview), or Private (fully blurred in the timeline).",
+      },
+      {
+        icon: Timer,
+        name: "Time Capsule",
+        description: "Seal entries until a future date. Anniversary auto-reveals surface past entries on their date each year.",
+      },
+    ],
+  },
+  {
+    heading: "Sync & Data",
+    items: [
+      {
+        icon: Wifi,
+        name: "Peer sync over LAN",
+        description: "Ed25519 device identity, QR/PIN pairing, AES-256-GCM encrypted transport — no cloud relay required.",
+      },
+      {
+        icon: Cloud,
+        name: "WebDAV backup",
+        description: "Encrypted export to your own WebDAV server. The server only ever receives ciphertext.",
+      },
+      {
+        icon: FileDown,
+        name: "Selective export",
+        description: "Filter by tag, mood range, or date range before exporting — export exactly what you want.",
+      },
+      {
+        icon: FileJson,
+        name: "JSON and encrypted export",
+        description: "Export as a portable .moodhaven encrypted backup or as plaintext JSON for your own tools.",
+      },
+    ],
+  },
+  {
+    heading: "AI — opt-in, metadata only",
+    items: [
+      {
+        icon: MessageSquare,
+        name: "Contextual writing prompts",
+        description: "Prompts based on mood patterns and entry frequency — your actual text is never analyzed.",
+      },
+      {
+        icon: Sparkles,
+        name: "Weekly reflection summaries",
+        description: "Generated from mood metadata, not from the content of your entries.",
+      },
+      {
+        icon: UserCheck,
+        name: "Disabled by default",
+        description: "All AI features require explicit opt-in. Nothing is sent anywhere without your consent.",
+      },
+      {
+        icon: RefreshCw,
+        name: "BYOK",
+        description: "Bring your own OpenAI key, or point it at a local Ollama model — no subscription needed.",
+      },
+    ],
+  },
+  {
+    heading: "Platform",
+    items: [
+      {
+        icon: Monitor,
+        name: "Native desktop",
+        description: "Windows, macOS, and Linux via Tauri v2. Full feature set, native OS integration.",
+      },
+      {
+        icon: Globe,
+        name: "Browser / PWA",
+        description: "Full-featured at journal.moodhaven.app using an IndexedDB backend. No install required.",
+      },
+      {
+        icon: Watch,
+        name: "Wear OS companion",
+        description: "Capture voice memos from your wrist. Desktop receives, transcribes, and queues them as drafts.",
+      },
+      {
+        icon: Mic,
+        name: "Voice memos",
+        description: "Offline transcription via a whisper.cpp sidecar — no cloud speech API, no audio leaves your device.",
+      },
+    ],
+  },
+  {
+    heading: "Wellness",
+    items: [
+      {
+        icon: Waves,
+        name: "StillHaven",
+        description: "Bilateral audio stimulation companion. Pre/post activation tracking and session history. Opt-in via Settings → Health.",
+      },
+    ],
+  },
+];
+
+export default function FeaturesPage() {
+  return (
+    <main id="main-content" className="bg-[var(--background)] px-4 pt-12 pb-20">
+      <div className="max-w-4xl mx-auto">
+
+        <AnimatedReveal>
+          <p className="text-center text-xs font-semibold text-neutral-400 uppercase tracking-widest mb-3">
+            What&apos;s included
+          </p>
+          <h1 className="text-3xl md:text-4xl font-bold text-neutral-900 text-center mb-2">
+            Features
+          </h1>
+          <p className="text-center text-neutral-500 text-base mb-10 max-w-lg mx-auto">
+            Everything MoodHaven Journal ships with — writing tools, mood tracking, privacy features, and more.
+          </p>
+        </AnimatedReveal>
+
+        {/* Free-forever callout */}
+        <AnimatedReveal delay={0.05}>
+          <div className="mb-12 rounded-xl bg-primary-50 ring-1 ring-primary-100 px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-primary-900">Free forever. No Pro tier.</p>
+              <p className="text-xs text-primary-700 mt-0.5">
+                Every feature on this page ships to everyone. MIT licensed, no subscription, no upsell.
+              </p>
+            </div>
+            <Link
+              href="/faq#free"
+              className="shrink-0 text-xs font-semibold text-primary-700 hover:underline whitespace-nowrap"
+            >
+              Why free? →
+            </Link>
+          </div>
+        </AnimatedReveal>
+
+        {/* Feature categories */}
+        <div className="space-y-14">
+          {CATEGORIES.map((category, catIdx) => (
+            <AnimatedReveal key={category.heading} delay={catIdx * 0.04}>
+              <section>
+                <p className="text-xs font-semibold text-neutral-400 uppercase tracking-widest mb-5">
+                  {category.heading}
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {category.items.map((item, i) => {
+                    const Icon = item.icon;
+                    return (
+                      <AnimatedReveal key={item.name} delay={catIdx * 0.04 + i * 0.05}>
+                        <div className="bg-white/90 rounded-xl p-5 ring-1 ring-neutral-100 flex items-start gap-3 h-full">
+                          <div className="w-8 h-8 rounded-lg bg-primary-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                            <Icon className="w-4 h-4 text-primary-600" aria-hidden="true" />
+                          </div>
+                          <div>
+                            <p className="text-sm font-semibold text-neutral-900 mb-0.5">{item.name}</p>
+                            <p className="text-sm text-neutral-500 leading-relaxed">{item.description}</p>
+                          </div>
+                        </div>
+                      </AnimatedReveal>
+                    );
+                  })}
+                </div>
+              </section>
+            </AnimatedReveal>
+          ))}
+        </div>
+
+        {/* Bottom CTA */}
+        <AnimatedReveal delay={0.15}>
+          <div className="mt-16 text-center">
+            <p className="text-sm text-neutral-500 mb-4">Ready to try it?</p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link
+                href="/download"
+                className="rounded-full bg-primary-700 text-white px-6 py-2.5 text-sm font-semibold hover:bg-primary-800 transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-700/60"
+              >
+                Download for Desktop
+              </Link>
+              <a
+                href="https://journal.moodhaven.app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full border border-neutral-300 bg-white text-neutral-900 px-6 py-2.5 text-sm font-semibold hover:bg-neutral-50 transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300"
+              >
+                Try in Browser
+              </a>
+            </div>
+          </div>
+        </AnimatedReveal>
+
+      </div>
+    </main>
+  );
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,6 +1,10 @@
 // app/page.tsx
 import type { Metadata } from "next";
+import { getLatestRelease } from "@/lib/getLatestRelease";
 import HomeClient from "@/components/HomeClient";
+
+// Fetch the latest release on every request — GitHub is the source of truth.
+export const runtime = "edge";
 
 export const metadata: Metadata = {
   title: "MoodHaven Journal — Privacy-First Journaling App",
@@ -18,6 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Home() {
-  return <HomeClient />;
+export default async function Home() {
+  const release = await getLatestRelease();
+  return <HomeClient latestRelease={release} />;
 }

--- a/website/components/AppPreview.tsx
+++ b/website/components/AppPreview.tsx
@@ -19,6 +19,14 @@ const CALLOUTS = [
     label: "Multiple journals",
     description: "Named books with emoji and color. Work, personal, therapy — separate.",
   },
+  {
+    label: "Activity tagging",
+    description: "Tag what you were doing — Exercise, Social, Reading — then see mood patterns in the Insights view.",
+  },
+  {
+    label: "Mood calendar",
+    description: "Monthly heatmap colored by daily mood. Spot patterns at a glance across weeks and months.",
+  },
 ];
 
 export default function AppPreview() {
@@ -30,7 +38,7 @@ export default function AppPreview() {
             See it in action
           </p>
           <h2 className="text-center text-2xl md:text-3xl font-bold text-neutral-900 mb-4">
-            A writing space that respects you
+            A writing space built for reflection
           </h2>
           <p className="text-center text-neutral-500 text-base mb-12 max-w-md mx-auto">
             Clean, focused, and private by default. Your words stay on your device.

--- a/website/components/ComparisonTable.tsx
+++ b/website/components/ComparisonTable.tsx
@@ -1,0 +1,93 @@
+import AnimatedReveal from "./AnimatedReveal";
+
+const ROWS = [
+  {
+    feature: "Requires a cloud account",
+    moodhaven: { value: "No — local only", positive: true },
+    cloud: { value: "Yes — Google/Dropbox/iCloud required", positive: false },
+  },
+  {
+    feature: "Open source & auditable",
+    moodhaven: { value: "MIT licensed", positive: true },
+    cloud: { value: "Rarely", positive: false },
+  },
+  {
+    feature: "Peer sync without relay",
+    moodhaven: { value: "Yes — LAN direct", positive: true },
+    cloud: { value: "No — cloud relay only", positive: false },
+  },
+  {
+    feature: "Works fully offline",
+    moodhaven: { value: "Yes", positive: true },
+    cloud: { value: "Sometimes", positive: false },
+  },
+  {
+    feature: "End-to-end encryption",
+    moodhaven: { value: "Yes — keys in memory, never stored", positive: true },
+    cloud: { value: "Varies", positive: false },
+  },
+  {
+    feature: "Zero telemetry",
+    moodhaven: { value: "Yes", positive: true },
+    cloud: { value: "Often collects usage data", positive: false },
+  },
+  {
+    feature: "Paid tier for AI features",
+    moodhaven: { value: "Never — always free", positive: true },
+    cloud: { value: "Usually $10–20/year", positive: false },
+  },
+];
+
+export default function ComparisonTable() {
+  return (
+    <section className="bg-[var(--background)] px-4 py-20">
+      <div className="max-w-5xl mx-auto">
+        <AnimatedReveal>
+          <p className="text-center text-xs font-semibold text-neutral-400 uppercase tracking-widest mb-3">
+            How we compare
+          </p>
+          <h2 className="text-center text-2xl md:text-3xl font-bold text-neutral-900 mb-12">
+            MoodHaven vs cloud-based journals
+          </h2>
+        </AnimatedReveal>
+        <AnimatedReveal delay={0.1}>
+          <div className="bg-white/90 rounded-xl ring-1 ring-neutral-200 overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-neutral-100">
+                    <th className="text-left px-5 py-3.5 font-semibold text-neutral-500 w-1/2">Feature</th>
+                    <th className="text-left px-5 py-3.5 font-semibold text-primary-700">MoodHaven</th>
+                    <th className="text-left px-5 py-3.5 font-semibold text-neutral-500">Cloud journals</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ROWS.map((row, i) => (
+                    <tr
+                      key={row.feature}
+                      className={i % 2 === 0 ? "bg-neutral-50/50" : "bg-white"}
+                    >
+                      <td className="px-5 py-3.5 text-neutral-700 font-medium">{row.feature}</td>
+                      <td className="px-5 py-3.5">
+                        <span className="inline-flex items-center gap-1.5 text-emerald-700 font-medium">
+                          <span className="text-emerald-500" aria-hidden="true">✓</span>
+                          {row.moodhaven.value}
+                        </span>
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <span className="inline-flex items-center gap-1.5 text-neutral-500">
+                          <span className="text-neutral-400" aria-hidden="true">✗</span>
+                          {row.cloud.value}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </AnimatedReveal>
+      </div>
+    </section>
+  );
+}

--- a/website/components/FeaturesGrid.tsx
+++ b/website/components/FeaturesGrid.tsx
@@ -1,4 +1,4 @@
-import { HardDrive, ShieldCheck, Brain, BookOpen, Wifi, Monitor } from "lucide-react";
+import { HardDrive, ShieldCheck, Brain, BookOpen, Wifi, Monitor, Tag, Clock, Mic } from "lucide-react";
 import AnimatedReveal from "./AnimatedReveal";
 
 const FEATURES = [
@@ -37,6 +37,24 @@ const FEATURES = [
     name: "Every platform",
     description:
       "Native desktop on Windows, macOS, Linux. Browser PWA at journal.moodhaven.app. Wear OS for voice captures from your wrist.",
+  },
+  {
+    icon: Tag,
+    name: "Activity tagging",
+    description:
+      "Tag entries with activities — Exercise, Reading, Social, Meditation and more. See which activities correlate with your best and worst moods in the Insights view.",
+  },
+  {
+    icon: Clock,
+    name: "Time Capsule",
+    description:
+      "Seal any entry until a future date. Revisit a letter to your future self when the date arrives — or let anniversary entries surface each year automatically.",
+  },
+  {
+    icon: Mic,
+    name: "Voice memos from your wrist",
+    description:
+      "Record a voice reflection on Wear OS. Whisper.cpp transcribes it locally on your desktop — no cloud STT, no audio ever leaves your devices.",
   },
 ];
 

--- a/website/components/HomeClient.tsx
+++ b/website/components/HomeClient.tsx
@@ -10,8 +10,15 @@ import AppPreview from "./AppPreview";
 import PrivacyProof from "./PrivacyProof";
 import FeatureTabs from "./FeatureTabs";
 import NewsletterSignup from "./NewsletterSignup";
+import HowItWorks from "./HowItWorks";
+import ComparisonTable from "./ComparisonTable";
+import type { LatestRelease } from "@/lib/getLatestRelease";
 
-export default function HomeClient() {
+interface HomeClientProps {
+  latestRelease?: LatestRelease | null;
+}
+
+export default function HomeClient({ latestRelease }: HomeClientProps) {
   return (
     <div className="w-full">
       {/* Hero Section */}
@@ -24,14 +31,16 @@ export default function HomeClient() {
           <div className="flex flex-col lg:flex-row items-center gap-12">
             {/* Copy block */}
             <AnimatedReveal className="flex-1 text-center lg:text-left">
-              {/* Announcement chip */}
+              {/* Announcement chip — version pulled live from GitHub releases */}
               <a
                 href="/changelog"
                 className="inline-flex items-center gap-2 bg-white/10 border border-white/20 rounded-full px-3.5 py-1.5 mb-6 text-xs font-medium text-primary-100 hover:bg-white/20 transition-colors duration-200"
               >
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-cta animate-pulse" aria-hidden="true" />
-                v1.1.0 — StillHaven ships
-                <span className="text-white font-semibold">See what&apos;s new →</span>
+                {latestRelease?.version
+                  ? `${latestRelease.version} — See what's new`
+                  : "See what's new"}
+                <span className="text-white font-semibold">→</span>
               </a>
 
               <h1 className="text-3xl md:text-5xl font-bold tracking-tight">
@@ -47,10 +56,10 @@ export default function HomeClient() {
                     href="https://journal.moodhaven.app"
                     className="w-full sm:w-auto text-center rounded-full bg-accent-cta text-neutral-900 px-6 py-3.5 text-sm font-semibold shadow transition-all duration-200 ease-out hover:bg-accent-cta/90 hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cta/60"
                   >
-                    Open in Browser <span aria-hidden="true">→</span>
+                    Try it live — no install <span aria-hidden="true">→</span>
                   </a>
                   <p className="text-xs text-primary-300 max-w-[160px] text-center lg:text-left">
-                    Start writing in 10 seconds, nothing to install.
+                    Open in your browser. No account, no download.
                   </p>
                 </div>
                 <div className="flex flex-col items-center lg:items-start gap-1.5">
@@ -66,23 +75,9 @@ export default function HomeClient() {
                 </div>
               </div>
 
-              {/* Trust strip */}
-              <div className="mt-6 flex flex-wrap justify-center lg:justify-start gap-2">
-                {[
-                  "v1.1.0",
-                  "702 tests",
-                  "MIT licensed",
-                  "Built in public",
-                ].map((label) => (
-                  <span
-                    key={label}
-                    className="inline-flex items-center gap-1.5 bg-white/10 border border-white/15 rounded-full px-3 py-1 text-xs text-primary-200"
-                  >
-                    <span className="w-1 h-1 rounded-full bg-primary-400" aria-hidden="true" />
-                    {label}
-                  </span>
-                ))}
-              </div>
+              <p className="text-xs text-primary-300 mt-2 text-center lg:text-left">
+                No Pro tier. No subscription. No paid features. Everything ships to everyone.
+              </p>
             </AnimatedReveal>
 
             {/* App screenshot — side-by-side on lg+, stacked below copy on smaller screens */}
@@ -112,9 +107,11 @@ export default function HomeClient() {
 
       <AppPreview />
       <PrivacyCallout />
+      <HowItWorks />
       <FeaturesGrid />
       <FeatureTabs />
       <PrivacyProof />
+      <ComparisonTable />
       <NewsletterSignup />
       <CommunityCallout />
     </div>

--- a/website/components/HowItWorks.tsx
+++ b/website/components/HowItWorks.tsx
@@ -1,0 +1,47 @@
+import AnimatedReveal from "./AnimatedReveal";
+
+const STEPS = [
+  {
+    number: "01",
+    heading: "Download or open in browser",
+    body: "Native desktop app on Windows, macOS, and Linux. Or open journal.moodhaven.app in any modern browser — no installation, no account form.",
+  },
+  {
+    number: "02",
+    heading: "Set a password — that's your key",
+    body: "Your password is never stored or sent anywhere. It derives the encryption key in memory. No reset button. No support ticket. Only you can unlock your journal.",
+  },
+  {
+    number: "03",
+    heading: "Start writing. Nothing else required.",
+    body: "No cloud setup. No storage picker. No email confirmation. Your first entry encrypts to disk in under a second. That's the whole onboarding.",
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <section className="bg-[var(--background)] px-4 py-20">
+      <div className="max-w-5xl mx-auto">
+        <AnimatedReveal>
+          <p className="text-center text-xs font-semibold text-neutral-400 uppercase tracking-widest mb-3">
+            How it works
+          </p>
+          <h2 className="text-center text-2xl md:text-3xl font-bold text-neutral-900 mb-12">
+            Up and writing in three steps
+          </h2>
+        </AnimatedReveal>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {STEPS.map((step, i) => (
+            <AnimatedReveal key={step.number} delay={i * 0.15}>
+              <div className="bg-white/90 rounded-xl p-6 space-y-3 ring-1 ring-neutral-100">
+                <p className="text-4xl font-bold text-primary-200">{step.number}</p>
+                <h3 className="text-base font-semibold text-neutral-900">{step.heading}</h3>
+                <p className="text-sm text-neutral-600 leading-relaxed">{step.body}</p>
+              </div>
+            </AnimatedReveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/NavBar.tsx
+++ b/website/components/NavBar.tsx
@@ -9,6 +9,7 @@ import { Menu, X } from 'lucide-react';
 
 const navLinks = [
   { name: 'Home', href: '/' },
+  { name: 'Features', href: '/features' },
   { name: 'Download', href: '/download' },
   { name: 'Platforms', href: '/platforms' },
   { name: 'Blog', href: '/blog' },

--- a/website/content/posts/activity-tagging-and-mood-correlation.mdx
+++ b/website/content/posts/activity-tagging-and-mood-correlation.mdx
@@ -1,0 +1,51 @@
+---
+title: "Activity Tagging: Seeing What Actually Affects Your Mood"
+publishDate: "2026-06-10"
+excerpt: "Tracking activities alongside mood turns a journal into a feedback loop. After a few weeks you can see — not guess — which habits are helping and which aren't."
+---
+
+Most mood trackers tell you how you felt but not why.
+
+You logged a 2 out of 5 on Tuesday. You have no idea if it was the bad sleep, the difficult meeting, the fact that you skipped lunch, or just a slow day. The number sits there, accurate and useless. Without context, patterns do not emerge. Without patterns, you cannot change anything.
+
+Activity tagging is MoodHaven's answer to the "why."
+
+## How it works
+
+When you finish writing an entry, you can tag it with activities. MoodHaven ships with 15 predefined categories: Exercise, Social, Work, Reading, Creative, Meditation, Good Sleep, Poor Sleep, Nature, Family, Cooking, Music, Learning, Travel, and Gaming. You can also create up to 50 custom activities for anything those categories do not cover.
+
+Tagging takes a few seconds. You tap the activity pills at the bottom of the entry before closing it. That is the entire input.
+
+Over time, those tags accumulate alongside your mood scores. After a few weeks, the Insights view shows a correlation chart: for each activity, the average mood on days you tagged it versus days you did not. If you tagged Exercise 20 times and your average mood on those days was 3.8 versus a baseline of 3.1, that is information worth knowing.
+
+## Correlation, not causation
+
+It is worth being precise about what this chart does and does not show.
+
+Correlation means the two things tend to appear together. It does not mean one caused the other. Seeing that Exercise correlates with mood +0.7 in your data does not prove exercise made you feel better. You might exercise more on days you already feel good. The direction of the relationship is not something a simple average can resolve.
+
+But correlation from your own data over your own months is more useful than a generic wellness tip from a lifestyle blog. "Exercise improves mood" is advice you have heard. "In your journal, over the last 60 days, the 18 entries tagged Exercise averaged a full point higher than the 40 entries without it" is specific to you. You can work with that.
+
+The chart is honest about being a correlation chart, not a causal one. What you do with the information is yours to decide.
+
+## Privacy
+
+Activity tags are stored locally in the same SQLite database as everything else. They sit in a join table that links entry IDs to activity IDs. Nothing about your activity patterns is sent anywhere.
+
+The correlation chart is computed on your device, from your local data, every time you open Insights. There is no server, no analytics pipeline, no aggregation across users. The computation is simple SQL, and you can read it in `activities.rs` if you want to understand exactly how the averages are calculated.
+
+## What actually changes after a month of tagging
+
+The patterns that emerge tend to surprise people.
+
+You might expect Exercise to be your strongest positive correlate and find that Social edges it out. You might discover Poor Sleep is far more damaging to your mood than you had given it credit for. Or you might see that Gaming, which you had mentally filed as unproductive, does not correlate with worse days at all.
+
+These are not insights a generic app can give you. They come from your data, tagged by you, specific to how your life actually works.
+
+After 4 to 6 weeks of consistent tagging, most people have enough data for something resembling a pattern. It does not require perfect consistency. Missing a few days does not invalidate the rest. The chart fills in as you go.
+
+## No tier, no paywall
+
+Activity tagging and the correlation chart ship to everyone. There is no insights tier, no subscription required to see your own patterns. MoodHaven is free and MIT licensed, and that includes the features that took the most time to build.
+
+[Download the desktop app](/download) for Windows, macOS, or Linux, or [read the source on GitHub](https://github.com/kenlacroix/moodhaven-journal).

--- a/website/content/posts/what-we-actually-send-to-ai.mdx
+++ b/website/content/posts/what-we-actually-send-to-ai.mdx
@@ -1,0 +1,59 @@
+---
+title: "What We Actually Send to the AI (and What We Don't)"
+publishDate: "2026-06-08"
+excerpt: "MoodHaven's AI features work from metadata — mood scores, patterns, frequency. Your journal text never leaves your device. Here's exactly what goes out and what stays in."
+---
+
+Most apps that say "AI-powered" have a quiet asterisk attached. The asterisk usually reads something like: we send your content to OpenAI, but we call it "anonymized" or "encrypted in transit." A few are honest about it. Most are not.
+
+I want to be direct about what MoodHaven does, because vagueness on this specific question is how trust erodes.
+
+## What the AI sees
+
+When you enable AI features in MoodHaven, the model receives a structured metadata object. It looks like this:
+
+```
+{
+  recentMoodAverage: 3.2,
+  moodTrend: "improving",
+  dominantEmotions: ["grateful", "anxious", "reflective"],
+  entryFrequency: "daily",
+  preferredTime: "evening"
+}
+```
+
+That is the entirety of what goes out. Five fields. All of them derived locally from your mood scores, timestamps, and entry patterns. None of them are your words.
+
+`recentMoodAverage` is the arithmetic mean of your last several mood ratings, which are integers from 1 to 5. `moodTrend` is calculated by comparing recent average to older average. `dominantEmotions` are categories extracted on your device from writing patterns, not from the text itself. `entryFrequency` is how often you write. `preferredTime` is when you most often open the app.
+
+There are no text fields in this object. There is no `entryContent`, no `recentEntries`, no `journalExcerpt`. The structure physically cannot carry your writing.
+
+## What the AI never sees
+
+The content of any journal entry you have written. Not a sentence, not a phrase, not a word. This is not a soft commitment that might change in a future version. The code that assembles the AI request object has no access to decrypted entry content. Entry content is AES-256-GCM ciphertext at rest, and the only place it is decrypted is in the editor on your device.
+
+## AI is off by default, and it stays off until you act
+
+When you first install MoodHaven, AI features are disabled. You have to go into Settings, find the AI section, read what it does, and explicitly turn it on. There is no nudge flow, no onboarding step that quietly suggests enabling it, no banner that appears after a week. It is off. You turn it on if you want it.
+
+When you do enable it, you also have to provide an API key. MoodHaven does not have its own AI backend. The request goes through your account.
+
+## BYOK: your key, your account
+
+If you use your own OpenAI API key, the metadata object described above is sent to OpenAI under your credentials, not ours. That means it appears in your OpenAI usage dashboard. It counts against your billing. And it is subject to OpenAI's data handling policies for API calls, which are different from their consumer product policies.
+
+This is worth understanding clearly. When you use BYOK, MoodHaven is a client library that calls OpenAI on your behalf. We are not a middleman holding your key on a server somewhere. The key lives in encrypted storage on your device and is passed directly in the request.
+
+## Ollama: zero data leaves your machine
+
+If you run a local Ollama instance, none of this goes anywhere. The request goes from MoodHaven to a process running on your own computer. No network traffic exits your machine. This is the most private AI configuration and the one I use personally.
+
+Setup requires installing Ollama and pulling a model, which takes some technical comfort but is not difficult. The MoodHaven settings panel has a field for the Ollama endpoint, and once it is pointed at your local instance, AI features work identically.
+
+## You can read the code
+
+I am not asking you to take my word for any of this. The AI request is assembled in `useInsights.ts`. The object that gets passed to the API call is in `aiService.ts`. There is no code path in either file that reads or attaches decrypted entry content to an outbound request.
+
+If you find one, open an issue. That would be a bug, and I would treat it as a serious one.
+
+MoodHaven is free and open source. [Read the source on GitHub](https://github.com/kenlacroix/moodhaven-journal) or [download the desktop app](/download).

--- a/website/content/posts/why-local-first-matters.mdx
+++ b/website/content/posts/why-local-first-matters.mdx
@@ -1,0 +1,49 @@
+---
+title: "Why Local-First Is the Right Architecture for a Private Journal"
+publishDate: "2026-06-09"
+excerpt: "Cloud-first apps trade your data for convenience. Local-first flips that — you get the convenience, and your data never leaves until you decide it should."
+---
+
+Most journaling apps store your entries on their servers.
+
+Some are upfront about it. Others describe themselves as "encrypted" or "private" while still routing your data through infrastructure they control. A few, like OwnJournal, encrypt your data before sending it to Google Drive or Dropbox, which is better than nothing, but still means a cloud account is required for the app to function. The cloud is still in the loop.
+
+Local-first means something more specific: your device is the source of truth. The database lives on your disk. The app works fully offline, forever. Sync is something you opt into, on your terms, to destinations you choose.
+
+## Why this architecture matters for a journal
+
+Journaling is different from most software categories. You write things in a journal you would not say out loud. Fears about your health, frustrations with people you love, doubts about your choices, things you are not ready to share with anyone. A journal is only useful if you trust it completely.
+
+A journal stored on someone else's server is, by definition, a journal you share with that company. Their engineers could access it if they had reason to. A court order could compel them to produce it. A data breach could expose it. You accepted those terms when you signed up, buried in a document you did not read.
+
+The argument usually made in response to this is: "but we encrypt it." Encryption in transit protects your data from eavesdroppers on the network. Encryption at rest means the stored bytes are scrambled. Neither of those things prevents the company from decrypting your data using a key they hold, if they need to. Zero-knowledge systems do better, but they are rare, and "zero-knowledge" is a claim that is easy to make and hard to verify.
+
+Local-first sidesteps the question entirely. If the database never leaves your device, there is nothing for the company to hand over, breach, or misuse.
+
+## How MoodHaven implements this
+
+Every journal entry in MoodHaven is encrypted on your device before it touches disk. The encryption key is derived from your password using PBKDF2 with 600,000 iterations. The key is never stored. The encrypted content is saved to a local SQLite database. When you look at the raw database file, you see ciphertext.
+
+The save path in the Rust backend, `journal.rs`, makes no network calls. You can read it. There is no HTTP client in the entry creation function. Your writing goes from the editor to your disk, encrypted, with no stops in between.
+
+Peer sync, if you use it, works over your local network. Two devices on the same Wi-Fi can sync with each other directly, using an encrypted TCP connection with forward secrecy. There is no relay server. When both devices are away from the network, sync does not happen. Your data does not travel through any infrastructure that is not yours.
+
+WebDAV backup is available for people who want an off-device copy. You point it at a server you control, MinIO, a Nextcloud instance, a NAS, whatever you run. MoodHaven encrypts the backup before uploading it. The server sees ciphertext.
+
+## The tradeoff, named honestly
+
+You do not get "tap a button and your journal appears on your new phone in 30 seconds" out of the box.
+
+Peer sync requires both devices to be on the same network at the same time. If you get a new laptop and want your journal on it, you need to be home, on the same Wi-Fi as your old laptop, and run through the pairing flow. WebDAV backup requires you to have a server. None of this is difficult, but it is more friction than signing into an app with a Google account.
+
+This is a real tradeoff and I think it is worth naming directly rather than hiding in a footnote.
+
+But consider what you are trading for that convenience in a cloud-first app. You are trading the most personal writing you will ever do. For a Spotify playlist or a grocery list, that math probably works out fine. For a journal, I think the math runs the other way. A slightly slower new-device setup is a reasonable price for a system where no one else holds a copy of your thoughts.
+
+## Local-first is not a niche position
+
+1Password stores your vault locally and syncs only encrypted blobs. Obsidian treats your notes as files on your filesystem and makes cloud sync optional. Bitwarden, in its self-hosted form, gives you a server you run yourself. These are widely used, respected tools that made the same architectural choice MoodHaven makes.
+
+Local-first is not a limitation imposed by technical constraints. It is a design decision, made deliberately, in favor of the user's privacy over the developer's convenience. The cloud-first approach is easier to build and easier to monetize. Local-first requires more engineering and a different relationship with the people who use the software.
+
+MoodHaven is free and open source. The database is on your disk, the encryption key is in your head, and the code is on [GitHub](https://github.com/kenlacroix/moodhaven-journal) if you want to read it. [Download the desktop app](/download) for Windows, macOS, or Linux.

--- a/website/lib/getLatestRelease.ts
+++ b/website/lib/getLatestRelease.ts
@@ -13,14 +13,57 @@ export interface LatestRelease {
   assets: ReleaseAsset[];
 }
 
-const RELEASE_JSON_URL =
-  "https://github.com/kenlacroix/moodhaven-journal/releases/latest/download/latest-release.json";
+const GITHUB_REPO = "kenlacroix/moodhaven-journal";
+const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+// Fallback: pre-published JSON artifact (CI-generated, present on older releases)
+const RELEASE_JSON_FALLBACK = `https://github.com/${GITHUB_REPO}/releases/latest/download/latest-release.json`;
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function parseGitHubApiResponse(data: unknown): LatestRelease | null {
+  if (!data || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+
+  const version = typeof d.tag_name === "string" ? d.tag_name : null;
+  const releaseUrl = typeof d.html_url === "string" ? d.html_url : null;
+  const publishedAt = typeof d.published_at === "string" ? d.published_at : null;
+
+  if (!version || !releaseUrl || !publishedAt) return null;
+  if (!releaseUrl.startsWith("https://github.com/")) return null;
+
+  const assets: ReleaseAsset[] = [];
+  if (Array.isArray(d.assets)) {
+    for (const asset of d.assets) {
+      if (!asset || typeof asset !== "object") continue;
+      const a = asset as Record<string, unknown>;
+      const name = typeof a.name === "string" ? a.name : "";
+      const downloadUrl =
+        typeof a.browser_download_url === "string" ? a.browser_download_url : "";
+      const size = typeof a.size === "number" ? a.size : 0;
+
+      if (!name || !downloadUrl.startsWith("https://github.com/")) continue;
+      assets.push({ name, downloadUrl, sizeLabel: formatBytes(size) });
+    }
+  }
+
+  if (assets.length === 0) return null;
+  return { version, releaseUrl, publishedAt, assets };
+}
 
 function isValidRelease(data: unknown): data is LatestRelease {
   if (!data || typeof data !== "object") return false;
   const d = data as Record<string, unknown>;
   if (typeof d.version !== "string" || !d.version) return false;
-  if (typeof d.releaseUrl !== "string" || !d.releaseUrl.startsWith("https://github.com/")) return false;
+  if (
+    typeof d.releaseUrl !== "string" ||
+    !d.releaseUrl.startsWith("https://github.com/")
+  )
+    return false;
   if (typeof d.publishedAt !== "string") return false;
   if (!Array.isArray(d.assets)) return false;
   for (const asset of d.assets) {
@@ -34,9 +77,25 @@ function isValidRelease(data: unknown): data is LatestRelease {
   return true;
 }
 
-export async function getLatestRelease(): Promise<LatestRelease | null> {
+async function fetchFromGitHubAPI(): Promise<LatestRelease | null> {
   try {
-    const res = await fetch(RELEASE_JSON_URL, {
+    const res = await fetch(GITHUB_API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) return null;
+    const data: unknown = await res.json();
+    return parseGitHubApiResponse(data);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFromReleaseJSON(): Promise<LatestRelease | null> {
+  try {
+    const res = await fetch(RELEASE_JSON_FALLBACK, {
       redirect: "follow",
       headers: { "Cache-Control": "no-store" },
     });
@@ -48,4 +107,21 @@ export async function getLatestRelease(): Promise<LatestRelease | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Fetch the latest release. GitHub API is the source of truth — no CI step
+ * required. Falls back to the pre-published release JSON if the API is
+ * unavailable or rate-limited.
+ */
+export async function getLatestRelease(): Promise<LatestRelease | null> {
+  const fromAPI = await fetchFromGitHubAPI();
+  if (fromAPI) return fromAPI;
+  return fetchFromReleaseJSON();
+}
+
+/** Return only the version string, for lightweight use in the hero chip. */
+export async function getLatestVersion(): Promise<string | null> {
+  const release = await getLatestRelease();
+  return release?.version ?? null;
 }


### PR DESCRIPTION
## Summary

- **Auto-versioning**: `getLatestRelease()` now fetches from GitHub Releases API (primary) with fallback to CDN JSON. Homepage uses `export const runtime = "edge"` — version chip updates on every deploy; no CI step required. Just publish a GitHub release.
- **Homepage redesign**: New `HowItWorks` (3-step) and `ComparisonTable` (MoodHaven vs cloud journals) sections added. Hero announcement chip shows live version. Browser CTA renamed to "Try it live — no install". Trust strip removed. "No Pro tier" copy added inline.
- **FeaturesGrid**: Expanded 6→9 features (Activity tagging, Time Capsule, Voice memos from wrist added).
- **AppPreview**: Updated heading + 2 new callout cards (activity tagging, mood calendar).
- **/features page**: New full feature listing with 7 categories and 33 individual features. "Free forever. No Pro tier." banner at top.
- **FAQ**: New "Mood & Activity Tracking" section — 5 Q&As covering mood tracker, activity tagging, mood calendar, On This Day, Time Capsule.
- **NavBar**: Features link added between Home and Download.
- **Blog**: 3 new posts — activity tagging & mood correlation, what we send to AI, why local-first matters.

## Test plan

- [ ] `npm run build` in `website/` passes (✓ confirmed: 32/32 pages, no TS errors)
- [ ] Homepage loads and version chip shows current tag from GitHub (requires Cloudflare Pages deploy)
- [ ] `/features` page renders all 7 categories with icons
- [ ] `/faq` shows new "Mood & Activity Tracking" accordion section
- [ ] NavBar shows Features link on desktop and mobile
- [ ] 3 new blog posts visible at `/blog`
- [ ] Fallback: if GitHub API down, `latest-release.json` CDN artifact is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)