### PR TITLE
fix(ci): upload updater minisign signatures to the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,37 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.sig
           retention-days: 1
 
+      # Upload the updater minisign signatures to the release.
+      # tauri-action uploads the installers but not their `.sig` companions, and
+      # the in-app updater (src-tauri/src/commands/updater.rs) fetches
+      # "<asset>.sig" for the AppImage / NSIS setup.exe it downloads and treats a
+      # missing signature as a hard error. Upload them here so auto-update from
+      # a signature-verifying build (1.8.1+) can succeed. macOS auto-update is a
+      # separate concern (Tauri signs the .app.tar.gz, not the .dmg the updater
+      # expects), tracked in the roadmap.
+      - name: Upload updater signatures to release
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          TAG="${{ github.ref_name }}"
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          # Capitalised product-name globs match the installers tauri-action
+          # actually uploaded (avoids the lowercase mood-haven_* duplicate bundle).
+          sigs=( "$BUNDLE"/appimage/MoodHaven_*.AppImage.sig \
+                 "$BUNDLE"/nsis/MoodHaven_*-setup.exe.sig )
+          if [ ${#sigs[@]} -eq 0 ]; then
+            echo "No updater .sig files for ${{ matrix.target }} (expected on macOS); skipping."
+            exit 0
+          fi
+          for sig in "${sigs[@]}"; do
+            echo "Uploading $(basename "$sig")"
+            gh release upload "$TAG" "$sig" --clobber
+          done
+
   # ── Android: Wear OS companion APK ─────────────────────────────────────────
   build-android:
     name: Build Android (Wear OS companion)


### PR DESCRIPTION
## Problem

The in-app updater (`src-tauri/src/commands/updater.rs`, since 1.8.1) fetches `<asset>.sig` for the AppImage / NSIS `setup.exe` it downloads and treats a **missing signature as a hard error** (`fetch_signature` runs up-front; abort before any download). But `tauri-action` only uploads the **installers** to the release, not their `.sig` companions — so a signature-verifying updater (1.8.1+) can never auto-update to a newer release: it gets *"No signature found for this release"* and fails closed.

This first surfaces on **1.8.1 → 1.8.2** (the first release a sig-checking updater would consume). The `.sig` files **are** generated during the signed build — they just never reach the release.

## Fix

Add a step to each platform build job that uploads the updater `.sig` files to the release directly from the build runner, where they exist on disk after the signed `tauri-action` build:
- Linux: `appimage/MoodHaven_*.AppImage.sig`
- Windows: `nsis/MoodHaven_*-setup.exe.sig`
- macOS: no-op (Tauri signs `.app.tar.gz`, not the `.dmg` the custom updater expects — a separate, pre-existing concern tracked in the roadmap).

Capitalised product-name globs match the installers tauri-action actually uploaded (avoids the lowercase `mood-haven_*` duplicate bundle). `nullglob` + a length guard make the macOS no-op safe under `set -euo pipefail`.

## After this merges
Re-cut v1.8.2 (delete the current unpublished draft + tag, re-push the tag) so the rebuild attaches the `.sig` files, then verify and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)