### PR TITLE
fix(ci): publish base64-decoded updater signatures (auto-update was broken)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,35 +202,49 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.sig
           retention-days: 1
 
-      # Upload the updater minisign signatures to the release.
-      # tauri-action uploads the installers but not their `.sig` companions, and
-      # the in-app updater (src-tauri/src/commands/updater.rs) fetches
-      # "<asset>.sig" for the AppImage / NSIS setup.exe it downloads and treats a
-      # missing signature as a hard error. Upload them here so auto-update from
-      # a signature-verifying build (1.8.1+) can succeed. macOS auto-update is a
-      # separate concern (Tauri signs the .app.tar.gz, not the .dmg the updater
-      # expects), tracked in the roadmap.
-      - name: Upload updater signatures to release
+      # Sign the installers and upload the updater minisign signatures.
+      # The in-app updater (src-tauri/src/commands/updater.rs) fetches
+      # "<asset>.sig" for the asset it downloads (AppImage / NSIS setup.exe / dmg)
+      # and treats a missing signature as a hard error. tauri-action signs the
+      # bundles during the build but then deletes the `.sig` companions (and the
+      # duplicate lowercase bundles) right after uploading the primary installers,
+      # so they never reach the release. Re-sign the installers that remain on
+      # disk with the same key and upload the signatures. The signature is over
+      # the exact installer bytes, so it verifies against the compiled-in pubkey.
+      - name: Sign installers and upload updater signatures
         if: github.event_name == 'push'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           shopt -s nullglob
           TAG="${{ github.ref_name }}"
           BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
           # Capitalised product-name globs match the installers tauri-action
-          # actually uploaded (avoids the lowercase mood-haven_* duplicate bundle).
-          sigs=( "$BUNDLE"/appimage/MoodHaven_*.AppImage.sig \
-                 "$BUNDLE"/nsis/MoodHaven_*-setup.exe.sig )
-          if [ ${#sigs[@]} -eq 0 ]; then
-            echo "No updater .sig files for ${{ matrix.target }} (expected on macOS); skipping."
+          # uploaded (skipping the lowercase mood-haven_* duplicate bundles).
+          installers=( "$BUNDLE"/appimage/MoodHaven_*.AppImage \
+                       "$BUNDLE"/nsis/MoodHaven_*-setup.exe \
+                       "$BUNDLE"/dmg/MoodHaven_*.dmg )
+          if [ ${#installers[@]} -eq 0 ]; then
+            echo "No updater installers found for ${{ matrix.target }}; skipping."
             exit 0
           fi
-          for sig in "${sigs[@]}"; do
-            echo "Uploading $(basename "$sig")"
-            gh release upload "$TAG" "$sig" --clobber
+          for f in "${installers[@]}"; do
+            echo "Signing $(basename "$f")"
+            npx --no-install @tauri-apps/cli signer sign "$f"
+            # `tauri signer sign` writes a base64-WRAPPED .sig. The in-app updater
+            # (verify_minisign) feeds the .sig straight into minisign-verify's
+            # Signature::decode, which expects the RAW minisign text — so it
+            # rejects the base64-wrapped form. Publish the base64-DECODED
+            # signature. openssl is used for a portable decode (BSD base64 on
+            # macOS has no `-d`). Locked by a regression test in updater.rs.
+            openssl base64 -d -A -in "$f.sig" -out "$f.sig.raw"
+            mv "$f.sig.raw" "$f.sig"
+            gh release upload "$TAG" "$f.sig" --clobber
+            echo "Uploaded $(basename "$f").sig"
           done
 
   # ── Android: Wear OS companion APK ─────────────────────────────────────────

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1092,4 +1092,33 @@ abc123  target.exe
         let result = load_pubkey();
         assert!(result.is_ok(), "compiled-in pubkey must decode: {result:?}");
     }
+
+    #[test]
+    fn release_signature_must_be_base64_decoded_form() {
+        // `tauri signer sign` writes a base64-WRAPPED .sig, but verify_minisign
+        // feeds the file straight into Signature::decode, which expects the RAW
+        // minisign text. The release must therefore publish the base64-DECODED
+        // signature (the CI build does this with `openssl base64 -d`). This locks
+        // that contract: had it shipped wrong, at-rest update verification would
+        // be inert exactly like the encryption-at-rest bug this campaign fixed.
+        let fx = MinisignFixture::generate();
+        let data = b"the released installer bytes";
+        let path = write_temp(data);
+
+        let raw_sig = fx.sign(data); // the decoded form CI must publish
+        let wrapped_sig = base64::engine::general_purpose::STANDARD.encode(raw_sig.as_bytes()); // tauri's on-disk .sig
+
+        let raw_ok = verify_minisign_with_key(&path, &raw_sig, &fx.pubkey_config_value());
+        let wrapped = verify_minisign_with_key(&path, &wrapped_sig, &fx.pubkey_config_value());
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            raw_ok.is_ok(),
+            "decoded (raw) signature must verify: {raw_ok:?}"
+        );
+        assert!(
+            wrapped.is_err(),
+            "base64-wrapped tauri .sig must NOT verify directly — CI must decode it before upload"
+        );
+    }
 }


### PR DESCRIPTION
## Why

While cutting v1.8.2 I found the in-app auto-update path is broken for any signature-verifying build (1.8.1+) — two compounding bugs:

1. **tauri-action deletes the `.sig` companions** right after uploading the primary installers, so they never reach the release (my first CI attempt, globbing for them on disk, found nothing).
2. **Signature encoding mismatch (the real one):** `tauri signer sign` writes a **base64-wrapped** `.sig`, but the updater's `verify_minisign` feeds the file straight into `minisign-verify`'s `Signature::decode`, which expects the **raw** minisign text. So even publishing tauri's `.sig` as-is makes every verifying update fail closed with *"Malformed signature file."* `load_pubkey` base64-decodes the key const, but `verify_minisign` never decoded the signature — the asymmetry was never caught because 1.8.0→1.8.1 skipped verification entirely.

Proven against the project's exact `minisign-verify` 0.2.5: the **decoded** form verifies; the **wrapped** form fails to decode.

## Fix

In each platform build job, after tauri-action: re-sign the installer that remains on disk (AppImage / NSIS `setup.exe` / `dmg`), **base64-decode** the signature (`openssl base64 -d` for cross-platform portability), and upload the raw minisign signature as `<asset>.sig`.

- Re-signing the same bytes with the same key yields a signature that verifies against the compiled-in pubkey.
- Makes auto-update work for the **already-shipped 1.8.1** updater — no binary change needed (its `verify_minisign` already expects the raw form).
- macOS `.dmg` is signed too, so the updater's signature check passes there as well (silent install on macOS remains notarization-gated — separate roadmap item).

## Regression test

`release_signature_must_be_base64_decoded_form` (updater.rs): asserts the decoded signature verifies and the base64-wrapped form is rejected. Had this shipped wrong, at-rest update verification would have been inert — exactly the class of bug (a security control that silently does nothing) this campaign exists to catch.

## Verification (local)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib updater::tests` (22 pass incl. the new test) ✅
- `tauri signer sign` → `openssl base64 -d` round-trip verified against `minisign-verify` 0.2.5 ✅
- build.yml YAML validated ✅

## After merge
Re-cut v1.8.2 so the rebuild attaches the correctly-encoded `.sig` files; verify present + decodable; then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)