### PR TITLE
fix(ci): include .deb/.rpm in artifacts so checksums.txt covers them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,8 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.exe
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.msi
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.rpm
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*.sig
           retention-days: 1
 


### PR DESCRIPTION
Completes the earlier checksums fix. `generate-checksums.cjs` already lists `.deb`/`.rpm` in `ASSET_EXTENSIONS`, but the checksum job only scans the workflow artifacts and the upload glob excluded deb/rpm — so the Linux packages never reached the checksum step. Adds `*.deb`/`*.rpm` to the artifact upload glob. Verified on the v1.8.2 build: checksums.txt currently lists dmg/msi/exe/AppImage/aab but not deb/rpm; this closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)