### PR TITLE
test(db): upgrade-migration E2E (plaintext→SQLCipher)

### DIFF
--- a/active-plans/post-1.8.0-roadmap.md
+++ b/active-plans/post-1.8.0-roadmap.md
@@ -57,17 +57,25 @@ cap, path-traversal guard) and verifies SHA-256 against `checksums.txt`, but:
 
 → Source: `research-upgrade-mechanism.md`
 
-### P0 — Test-automation gaps (cheap, lands in existing CI `cargo test`)
-- **Upgrade-migration E2E (highest-value gap):** no test proves an old-version profile opens
-  under the new binary with data intact and the plaintext→SQLCipher migration succeeding —
-  the single riskiest release-time path (data loss). Add a Rust integration fixture (seed a
-  plaintext N-1 DB → run N startup+`unlock_app` → assert encrypted + rows decrypt) in CI; add
-  the real-binary upgrade round-trip + crash-replay (SIGKILL mid-export) to the live-lab harness.
-- **Updater integrity unit tests (cheap):** `verify_sha256` / `fetch_checksum` have zero tests.
-  Add `#[test]`s: good hash passes, flipped byte fails, missing `checksums.txt` → unverified
-  (not failed), >200 MB rejected.
-- **Password-mismatch sync invariant (cheap):** documented "no corruption" but not asserted —
-  two temp DBs, different keys, run upsert, assert no crash/corruption.
+### P0 — Test-automation gaps (cheap, lands in existing CI `cargo test`) ✅ DONE
+**Status:** all three sub-items landed in the CI `cargo test` lane (207 lib tests green).
+- **Upgrade-migration E2E (highest-value gap):** ✅ DONE — `db::sqlcipher_key_tests`
+  `encrypt_in_place_migrates_plaintext_to_ciphertext_at_rest` seeds a pre-1.8.0 plaintext
+  profile, drives the real one-time `encrypt_in_place` migration, and asserts the on-disk
+  bytes are no longer a `SQLite format 3` header (the PT8 SQLCipher-inert regression guard),
+  rows survive, and unkeyed/wrong-key opens fail at rest;
+  `migrated_profile_reopens_and_decrypts_on_next_launch` proves the migrated profile reopens
+  unkeyed on the next launch and the first `apply_key` restores read access. The real-binary
+  upgrade round-trip + crash-replay (SIGKILL mid-export) remain a **live-lab** item.
+- **Updater integrity unit tests (cheap):** ✅ DONE (pre-existing) — `updater::tests` covers
+  `verify_sha256` (good/uppercase/tampered/wrong/empty-unverified/missing-file),
+  `parse_checksum_for_asset`, the version gate, `compute_severity`, and full minisign
+  authenticity incl. the base64-decoded-form release contract. (The >200 MB cap is enforced
+  inline in `download_and_install_update`, not a standalone fn — not unit-testable without
+  HTTP mocking; covered structurally.)
+- **Password-mismatch sync invariant (cheap):** ✅ DONE (pre-existing) — `conflict.rs`
+  `password_mismatch_blob_is_stored_verbatim_without_corruption` asserts the engine stores
+  foreign-key ciphertext byte-for-byte with no crash/corruption.
 
 → Source: `research-test-plan.md`
 
@@ -159,3 +167,113 @@ The three blog pcap exhibit placeholders depend on a live PT9/PT10 capture run.
 | `blog-final-technical.md` | Canonical technical blog post (10 rounds, `<details>` toggles, front-matter data block) | drafted |
 | `blog-final-nontechnical.md` | Derived non-technical blog post ("broke my own app ten times") | drafted |
 | `personal-site-security-post.md` | Personal-site version ("Red-Teaming My Own Encrypted Journaling App, Ten Rounds Deep") | drafted |
+
+---
+
+## 4. Product Roadmap Additions (Gemini external-review reconciliation, 2026-06-08)
+
+An external AI review (Google search AI) was run against the project and reconciled against the
+codebase as source of truth. **~70% of its SWOT was stale** — it modeled a pre-1.7 architecture
+and was wrong on storage (claimed IndexedDB/LocalStorage; desktop is **SQLite + SQLCipher** with
+per-entry AES-GCM), mobile ("PWA wrapper"; we have **native Tauri v2 iOS + Android** scaffolded),
+sync ("manual S3 buckets"; we have **WebDAV + Dropbox/GDrive OAuth PKCE**), recovery ("none";
+we ship a **24-char recovery key** + PIN + biometric), local AI ("impossible"; we ship **Ollama**),
+repo health ("no CONTRIBUTING / no CI crypto tests"; both exist — `CONTRIBUTING.md`, `pentest.yml`),
+and decryption ("monolithic DB load"; entries are **already per-row**, lazily decrypted).
+
+**Dropped outright:** CRDT (Yjs/Automerge) — overkill for single-user multi-device; LWW + field-merge
+is correct (reconsider only if real-time collab ever appears). On-device WebGPU/ONNX LLM — redundant
+with the existing Ollama path. Chunked decryption — already effectively done. React Native/Expo rewrite —
+directly contradicts the decided Tauri-v2-iOS approach (reuses all ~150 Rust commands).
+
+The four items below survived reconciliation as genuine, net-new value. Decided with owner 2026-06-08.
+
+### P1 — BYO-Cloud folder sync (the "storage blindness" fix) — PRIMARY sync story
+**Decision:** make **file-provider folder sync** the primary/default cloud-sync path; keep the existing
+OAuth Dropbox/GDrive code as a secondary "power user" option (it stays as-is, real credentials when
+convenient — no longer the headline).
+
+The insight the OAuth path missed: instead of registering an OAuth app and writing to a hidden
+app-folder, write the **same encrypted `.moodhaven` blob the export path already produces** into a
+**user-picked folder** that happens to live in iCloud Drive / Google Drive / Dropbox / OneDrive.
+The OS sync client handles propagation for free — no server, no OAuth registration, no per-provider
+API. Lower friction, fewer moving parts, and it works with *any* folder-syncing service the user
+already has.
+
+- **Desktop:** plain filesystem path chosen via `tauri-plugin-dialog` folder picker; persist the path
+  in settings; write/read `moodhaven-backup.moodhaven` there. Trivial — reuses `export_data`/`import_data`.
+- **Android:** Storage Access Framework — persisted tree URI (`takePersistableUriPermission`). **Verify**
+  whether `tauri-plugin-fs` + dialog expose a persistable tree URI on Android, or whether a small
+  native plugin is needed. Do not assume; spike first.
+- **iOS:** `UIDocumentPickerViewController` directory pick + **security-scoped bookmark** persisted
+  across launches; iCloud Drive folders are reachable this way. **Verify** Tauri dialog/fs coverage;
+  may need a thin Swift plugin for the bookmark.
+- **Conflict:** same LWW-by-`updated_at` merge as peer sync; `import_data` already dedups. Add an
+  on-foreground "newer backup detected — import?" check (manual in v1; auto-sync later).
+- **Sequencing:** lands cleanly inside the `ios-app-v2-0.md` Phase 1 work — see the BYO-Cloud sub-phase
+  added there. Benefits desktop + Android immediately, not just iOS.
+
+→ Cross-ref: `active-plans/ios-app-v2-0.md` Phase 1.
+
+### P1 — PDF Emergency Recovery Kit
+We already generate a 24-char key-escrow recovery key (`recoveryKeyService.ts`), but only as a
+one-time on-screen code — easy to lose, easy to skip. Package it as a printable/exportable **PDF
+emergency kit**: app name + date, the recovery-key groups in large monospace, a "what this is / how
+to use it / store it offline" section, and an explicit warning that it bypasses the password. High
+trust-per-hour; pairs naturally with the security-posture story.
+
+- Generate client-side (no key material leaves the device). Reuse the existing `make-pdf`/print path
+  or render to a printable HTML view → "Save as PDF".
+- **Add, do not replace** the on-screen code (keep both flows). Offer the PDF at recovery-key setup
+  *and* later via Settings → Privacy.
+- Never persist the generated PDF automatically — hand it to the user's save dialog only.
+
+### P2 — Media compression pipeline
+Confirmed gap: `media.rs` stores attachment **originals uncompressed** (only a 400×400 JPEG thumbnail
+is produced on read). Add a client-side **compress → WebP (or capped JPEG) before encrypt** step in
+the media ingest path so the encrypted DB/blobs stay lean. Minor for a text-first journal, but cheap
+insurance against multi-MB photo bloat.
+
+- Prefer Rust-side `image` crate (already a dep — used for thumbnails) to resize/recompress on
+  `save_media_attachment` *before* encryption, OR a WASM/Canvas pass in the frontend. Pick whichever
+  avoids decoding twice. Cap longest edge (~2048px) + quality target; keep an EXIF-strip for privacy.
+- Strip location/EXIF metadata during recompress (privacy win, fits the threat model).
+
+### P2 — PWA storage-persistence guard (web build only)
+The browser/PWA build can have its IndexedDB evicted under storage pressure. Cheap mitigation:
+call `navigator.storage.persist()` on first unlock in web mode, surface the granted/denied state,
+and add an "export a backup" nudge when persistence is denied. Desktop/native are unaffected (real
+filesystem) — this is strictly a web-target hardening.
+
+### P2/LOW — Peer-sync "big picture" gap cluster (track + close)
+Already-known peer-sync residuals, grouped here so they close as a set rather than drifting:
+- **Restore salt transfer** — full-DB restore streams the SQLCipher file but not the source's
+  `db_state.json` salt; a restored device can fail first-unlock key derivation until fixed
+  (architecture.md / peer-sync-security.md "known gap").
+- **Recovery-key promote re-verify** — the recovery-key promote path does not yet re-verify the
+  derived key against the stored hash.
+- **Per-device restore-arm scoping** — arm is one-shot + TTL + clear-on-lock, but not yet scoped to
+  a specific requesting device (deferred LOW in §2).
+
+→ These are the only legitimate "peer gaps" the external review gestured at; everything else it said
+about peers was already covered by the v1.8.0 consent-gate + auth work.
+
+---
+
+### Reconciliation summary — disposition table
+
+| Item | Source | Disposition | Where it lives |
+|---|---|---|---|
+| BYO-Cloud folder sync | Gemini (refined) | **BUILD — primary sync** | §4 P1 + `ios-app-v2-0.md` Ph1 |
+| OAuth Dropbox/GDrive | existing | Keep as secondary | `ios-app-v2-0.md` Ph1 (creds when convenient) |
+| PDF Recovery Kit | Gemini + owner | **BUILD** | §4 P1 |
+| Media compression | Gemini (confirmed gap) | **BUILD** | §4 P2 |
+| PWA persistence guard | Gemini (web only) | **BUILD** | §4 P2 |
+| Peer-sync gap cluster | existing residuals | **TRACK + close as set** | §4 P2/LOW |
+| Native mobile (iOS/Android) | existing | In progress | `ios-app-v2-0.md` |
+| CRDT sync | Gemini | **DROP** (LWW is correct) | — |
+| On-device WebGPU/ONNX LLM | Gemini | **DROP** (Ollama exists) | — |
+| Chunked decryption | Gemini | **DROP** (already per-row) | — |
+| React Native/Expo rewrite | Gemini | **DROP** (Tauri-v2 decided) | — |
+| CONTRIBUTING / CI crypto tests | Gemini | **DONE** (stale claim) | repo |
+| Local LLM "needed" | Gemini | **DONE** (Ollama) | `aiService.ts` |

--- a/active-plans/post-1.8.0-roadmap.md
+++ b/active-plans/post-1.8.0-roadmap.md
@@ -195,7 +195,14 @@ directly contradicts the decided Tauri-v2-iOS approach (reuses all ~150 Rust com
 
 The four items below survived reconciliation as genuine, net-new value. Decided with owner 2026-06-08.
 
-### P1 — BYO-Cloud folder sync (the "storage blindness" fix) — PRIMARY sync story
+### P1 — BYO-Cloud folder sync (the "storage blindness" fix) — PRIMARY sync story ✅ DESKTOP SHIPPED (PR #149)
+**Status:** **Desktop slice shipped** (PR #149). New `read_text_file` Rust command (shares
+`write_text_file`'s sensitive-path guard via `guard_user_file_path`); `'byocloud'` storage backend +
+`byocloud {folderPath, lastSyncAt}` settings/store/defaults; `byoCloudService` (pickSyncFolder /
+byoCloudUpload via `exportWithMedia` / byoCloudDownload via `encryptedImport`); SyncTab folder-picker +
+Back up / Restore UI; browser shim throws for `read_text_file`. Mobile (Android SAF tree-URI, iOS
+security-scoped bookmark) remains a **spike-first** item — not yet built.
+
 **Decision:** make **file-provider folder sync** the primary/default cloud-sync path; keep the existing
 OAuth Dropbox/GDrive code as a secondary "power user" option (it stays as-is, real credentials when
 convenient — no longer the headline).
@@ -207,8 +214,8 @@ The OS sync client handles propagation for free — no server, no OAuth registra
 API. Lower friction, fewer moving parts, and it works with *any* folder-syncing service the user
 already has.
 
-- **Desktop:** plain filesystem path chosen via `tauri-plugin-dialog` folder picker; persist the path
-  in settings; write/read `moodhaven-backup.moodhaven` there. Trivial — reuses `export_data`/`import_data`.
+- **Desktop:** ✅ DONE (PR #149) — filesystem path chosen via `tauri-plugin-dialog` folder picker;
+  path persisted in settings; write/read `moodhaven-backup.moodhaven` there. Reuses `export_data`/`import_data`.
 - **Android:** Storage Access Framework — persisted tree URI (`takePersistableUriPermission`). **Verify**
   whether `tauri-plugin-fs` + dialog expose a persistable tree URI on Android, or whether a small
   native plugin is needed. Do not assume; spike first.
@@ -271,7 +278,7 @@ about peers was already covered by the v1.8.0 consent-gate + auth work.
 
 | Item | Source | Disposition | Where it lives |
 |---|---|---|---|
-| BYO-Cloud folder sync | Gemini (refined) | **BUILD — primary sync** | §4 P1 + `ios-app-v2-0.md` Ph1 |
+| BYO-Cloud folder sync | Gemini (refined) | **DESKTOP SHIPPED (PR #149)** — mobile spike pending | §4 P1 + `ios-app-v2-0.md` Ph1 |
 | OAuth Dropbox/GDrive | existing | Keep as secondary | `ios-app-v2-0.md` Ph1 (creds when convenient) |
 | PDF Recovery Kit | Gemini + owner | **BUILD** | §4 P1 |
 | Media compression | Gemini (confirmed gap) | **BUILD** | §4 P2 |

--- a/active-plans/post-1.8.0-roadmap.md
+++ b/active-plans/post-1.8.0-roadmap.md
@@ -82,16 +82,23 @@ cap, path-traversal guard) and verifies SHA-256 against `checksums.txt`, but:
 ### P1 — Code-signing phases (cost-gated; removes "unknown publisher" / Gatekeeper blocks)
 Phased, in order. **Skip EV** — since March 2024 it no longer buys instant SmartScreen trust and
 requires a business entity.
-1. **Phase 0 ($0, ~1h):** keep minisign + checksums (done); add a "Verify your download" README/
-   site section + unsigned-build disclaimer; optional Linux GPG detached `.asc` sigs.
+1. **Phase 0 ($0, ~1h) ✅ DONE:** keep minisign + checksums (done); "Verify your download" section
+   added to README + website download page (`DownloadClient.tsx`) with the unsigned-build /
+   SmartScreen-Gatekeeper disclaimer, the minisign verify command + pubkey, and the VirusTotal link.
+   Optional Linux GPG detached `.asc` sigs not done (minisign covers authenticity). Decision
+   (2026-06-08): code signing deferred on cost; VirusTotal auto-submission is the interim AV story.
 2. **Phase 1 — Windows via Azure Trusted Signing (~$10/mo, highest ROI):** individual-eligible
    (self-employed US/CA), no USB token, Microsoft-trusted root, Tauri `signCommand` + `dotnet sign`.
    Removes "unknown publisher" instantly; SmartScreen reputation accrues organically with the same cert.
 3. **Phase 2 — macOS Developer ID + notarize + staple ($99/yr):** the only path past Gatekeeper
    ("damaged / can't be opened"); CI scaffolding (`APPLE_*` env block) is already stubbed in
    `build.yml` — uncomment + add secrets + real Team ID.
-4. **Phase 3 — reactive AV (as-needed):** VirusTotal each release; submit false positives to the
-   specific flagging vendors (Microsoft MSRC first). Signed binaries clear far faster.
+4. **Phase 3 — reactive AV (as-needed) ⏳ AUTOMATED:** the `build.yml` `update-manifest` job now
+   runs `scripts/submit-virustotal.cjs` (needs the `VT_API_KEY` repo secret) — submits each desktop
+   installer to VirusTotal post-build and attaches `virustotal.txt` (per-asset hash-based report
+   links) to the release. Non-fatal + throttled for the free public tier (4/min, 500/day;
+   non-commercial use only). Still manual when needed: submit false positives to the specific
+   flagging vendors (Microsoft MSRC first). Signed binaries clear far faster.
 
 → Source: `research-av-signing.md`
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1656,4 +1656,209 @@ mod sqlcipher_key_tests {
         drop(db);
         let _ = std::fs::remove_dir_all(&base);
     }
+
+    /// Build a deterministic 32-byte raw key (and its hex form) for migration tests.
+    fn test_key(seed: u8) -> [u8; 32] {
+        let mut k = [0u8; 32];
+        for (i, byte) in k.iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(seed).wrapping_add(seed);
+        }
+        k
+    }
+
+    // Upgrade-migration E2E (highest-value release gap): an N-1 install ships a PLAINTEXT
+    // moodhaven.db (db_state.json absent). The first unlock on the new binary derives the
+    // key and runs the one-time `encrypt_in_place` migration. This test drives that real
+    // migration path end-to-end and asserts the single thing the PT8 "SQLCipher-inert" bug
+    // got wrong for three minor versions: the on-disk file must be actual CIPHERTEXT
+    // afterwards, not a plaintext `SQLite format 3` DB — while every seeded row survives.
+    #[test]
+    fn encrypt_in_place_migrates_plaintext_to_ciphertext_at_rest() {
+        use super::{read_db_state, Database};
+
+        const SQLITE_MAGIC: &[u8] = b"SQLite format 3\0";
+
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let base = dir.join(format!("mh_migrate_e2e_{pid}"));
+        let _ = std::fs::remove_dir_all(&base);
+        let _ = std::fs::create_dir_all(&base);
+        let db_path = base.join("moodhaven.db");
+        let tmp_path = base.join("moodhaven_enc.db");
+
+        // 1. Seed a pre-1.8.0-style plaintext profile: full schema via Database::new (no
+        //    db_state.json → encrypted:false) with known journal rows the user must not lose.
+        {
+            let seed = Database::new(db_path.clone()).expect("seed plaintext DB");
+            {
+                let conn = seed.conn.lock().unwrap();
+                conn.execute_batch(
+                    "INSERT INTO journal_entries (id, encrypted_content, mood, created_at, updated_at)
+                     VALUES ('e1', 'blob-one', 5, datetime('now'), datetime('now')),
+                            ('e2', 'blob-two', 2, datetime('now'), datetime('now'));",
+                )
+                .unwrap();
+            }
+            assert!(!seed.is_encrypted(), "fresh seed must be plaintext");
+            drop(seed);
+        }
+
+        // 2. Sanity: the on-disk file really is a plaintext SQLite DB before migration.
+        let before = std::fs::read(&db_path).unwrap();
+        assert!(
+            before.starts_with(SQLITE_MAGIC),
+            "pre-migration file must be a plaintext `SQLite format 3` DB"
+        );
+
+        // 3. Boot the new binary and run the real one-time migration (what unlock_app calls).
+        let db = Database::new(db_path.clone()).expect("open plaintext DB on new binary");
+        assert!(!db.is_encrypted(), "still plaintext before first unlock");
+        let key = test_key(7);
+        let salt_b64 = "dGVzdC1zYWx0"; // base64("test-salt") — stored verbatim in db_state
+        db.encrypt_in_place(&key, salt_b64)
+            .expect("one-time migration must succeed");
+
+        // 4. db_state is now authoritative-encrypted, the interrupted-migration tmp is gone.
+        assert!(
+            db.is_encrypted(),
+            "db_state must report encrypted after migration"
+        );
+        let state = read_db_state(&db_path);
+        assert!(state.encrypted);
+        assert_eq!(
+            state.salt.as_deref(),
+            Some(salt_b64),
+            "salt must be persisted"
+        );
+        assert!(
+            !tmp_path.exists(),
+            "moodhaven_enc.db must be renamed away, not left behind"
+        );
+
+        // 5. THE regression guard: the on-disk file must no longer be a plaintext SQLite DB.
+        let after = std::fs::read(&db_path).unwrap();
+        assert!(
+            !after.starts_with(SQLITE_MAGIC),
+            "post-migration file must be ciphertext, not a plaintext `SQLite format 3` header \
+             (this is exactly the PT8 SQLCipher-inert bug)"
+        );
+
+        // 6. Data intact: the migrated connection serves every row through the keyed handle.
+        {
+            let conn = db.conn.lock().unwrap();
+            let n: i64 = conn
+                .query_row("SELECT count(*) FROM journal_entries", [], |r| r.get(0))
+                .expect("migrated DB must serve rows");
+            assert_eq!(n, 2, "both seeded rows must survive the migration");
+            let blob: String = conn
+                .query_row(
+                    "SELECT encrypted_content FROM journal_entries WHERE id = 'e1'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(blob, "blob-one");
+        }
+
+        // 7. At rest the bytes are unreadable without the key: an unkeyed open, and a
+        //    wrong-key open, must both fail; only the correct raw key decrypts.
+        {
+            let unkeyed = Connection::open(&db_path).unwrap();
+            assert!(
+                unkeyed
+                    .query_row("SELECT count(*) FROM journal_entries", [], |r| r
+                        .get::<_, i64>(0))
+                    .is_err(),
+                "unkeyed open of the encrypted file must not read journal data"
+            );
+        }
+        {
+            let wrong_hex = hex::encode(test_key(99));
+            let wrong = Connection::open(&db_path).unwrap();
+            wrong
+                .execute_batch(&format!("PRAGMA key = \"x'{wrong_hex}'\";"))
+                .unwrap();
+            assert!(
+                wrong
+                    .query_row("SELECT count(*) FROM journal_entries", [], |r| r
+                        .get::<_, i64>(0))
+                    .is_err(),
+                "wrong key must not decrypt the at-rest DB"
+            );
+        }
+
+        drop(db);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // Companion to the migration E2E: prove an already-migrated profile REOPENS cleanly on a
+    // subsequent launch. Database::new must open the encrypted file without keying it (the
+    // passive handle can't read journal data), and the first apply_key of the session must
+    // re-key it and restore full read access — the exact startup→unlock path every launch
+    // after the one-time migration takes.
+    #[test]
+    fn migrated_profile_reopens_and_decrypts_on_next_launch() {
+        use super::Database;
+
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let base = dir.join(format!("mh_migrate_reopen_{pid}"));
+        let _ = std::fs::remove_dir_all(&base);
+        let _ = std::fs::create_dir_all(&base);
+        let db_path = base.join("moodhaven.db");
+
+        let key = test_key(13);
+
+        // 1. Seed + migrate, exactly as the first-unlock path does, then close the app.
+        {
+            let seed = Database::new(db_path.clone()).expect("seed plaintext DB");
+            {
+                let conn = seed.conn.lock().unwrap();
+                conn.execute(
+                    "INSERT INTO journal_entries (id, encrypted_content, mood, created_at, updated_at)
+                     VALUES ('e1', 'persisted-blob', 3, datetime('now'), datetime('now'))",
+                    [],
+                )
+                .unwrap();
+            }
+            seed.encrypt_in_place(&key, "dGVzdC1zYWx0")
+                .expect("migration must succeed");
+            drop(seed); // app exit
+        }
+
+        // 2. Next launch: Database::new opens the encrypted file but does not key it, so the
+        //    passive connection cannot read journal data until the user unlocks.
+        let db = Database::new(db_path.clone()).expect("reopen encrypted DB on next launch");
+        assert!(
+            db.is_encrypted(),
+            "reopened profile must be recognised as encrypted"
+        );
+        {
+            let conn = db.conn.lock().unwrap();
+            assert!(
+                conn.query_row("SELECT count(*) FROM journal_entries", [], |r| r
+                    .get::<_, i64>(0))
+                    .is_err(),
+                "passive (unkeyed) connection must not serve journal data before unlock"
+            );
+        }
+
+        // 3. First unlock of the new session keys the connection and restores the row.
+        db.apply_key(&key)
+            .expect("unlock must re-key the reopened DB");
+        {
+            let conn = db.conn.lock().unwrap();
+            let blob: String = conn
+                .query_row(
+                    "SELECT encrypted_content FROM journal_entries WHERE id = 'e1'",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("unlocked reopened DB must serve the migrated row");
+            assert_eq!(blob, "persisted-blob");
+        }
+
+        drop(db);
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }


### PR DESCRIPTION
## What

Closes the highest-value **P0 test-automation gap** from `active-plans/post-1.8.0-roadmap.md`: there was no test proving a pre-1.8.0 plaintext profile migrates to SQLCipher with data intact — the single riskiest release-time path (data loss).

Adds two tests to `db::sqlcipher_key_tests`:

- **`encrypt_in_place_migrates_plaintext_to_ciphertext_at_rest`** — seeds a pre-1.8.0-style plaintext profile, drives the *real* one-time `encrypt_in_place` migration (what `unlock_app` invokes), and asserts:
  - db_state flips to `encrypted:true` with the salt persisted, tmp renamed away
  - **the on-disk bytes are no longer a `SQLite format 3` header** — the exact PT8 SQLCipher-inert regression guard
  - all seeded rows survive
  - unkeyed and wrong-key opens both fail at rest
- **`migrated_profile_reopens_and_decrypts_on_next_launch`** — a migrated profile reopens unkeyed on the next launch (passive handle can't read journal data) and the first `apply_key` re-keys and restores the row.

Also marks the P0 test-automation item **DONE** in the roadmap.

## Why the other two sub-items aren't here

They were already covered:
- **Updater integrity** — `updater::tests` already covers `verify_sha256`, `parse_checksum_for_asset`, version gate, `compute_severity`, and full minisign authenticity.
- **Password-mismatch sync invariant** — `conflict.rs::password_mismatch_blob_is_stored_verbatim_without_corruption` already asserts byte-for-byte storage with no corruption.

## Test

`cargo test --lib` → **207 passed, 0 failed**. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)