### PR TITLE
feat(ci): VirusTotal release scanning + download verification surfaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -428,6 +428,16 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: node scripts/generate-checksums.cjs
 
+      # Submit installers to VirusTotal and publish per-asset report links.
+      # Transparency signal only (not a code signature); never blocks a release.
+      - name: Submit installers to VirusTotal
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
+        run: node scripts/submit-virustotal.cjs
+
       - name: Generate latest-release.json and attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <a href="#watch--phone-companion-beta"><img src="https://img.shields.io/badge/companion-Wear%20OS%20%7C%20Android-f97316?style=flat-square" alt="Companion"></a>
 <a href="https://tauri.app"><img src="https://img.shields.io/badge/built%20with-Tauri%202-ffd866?style=flat-square" alt="Built with Tauri"></a>
 <a href="#security--privacy"><img src="https://img.shields.io/badge/encryption-AES--256--GCM-ef4444?style=flat-square" alt="Encryption"></a>
+<a href="https://github.com/kenlacroix/moodhaven-journal/releases/latest/download/virustotal.txt"><img src="https://img.shields.io/badge/VirusTotal-scan%20reports-394eff?style=flat-square&logo=virustotal&logoColor=white" alt="VirusTotal scan reports"></a>
 </p>
 
 <p>MoodHaven Journal is a zero-knowledge journaling app designed to keep your thoughts safe.<br>Your entries are encrypted end-to-end, and your password never leaves your device.</p>
@@ -121,6 +122,20 @@ Grab the latest build from the [Releases](https://github.com/kenlacroix/moodhave
 | **Linux** | `MoodHaven_1.8.2_amd64.AppImage` | Any modern distro |
 | **Linux (Debian)** | `MoodHaven_1.8.2_amd64.deb` | Ubuntu 22.04+ |
 | **Web** | `npm run build:web` → serve `dist-web/` | Any modern browser |
+
+### Verifying Your Download
+
+MoodHaven is **not yet code-signed** (no commercial signing certificate). On Windows you may see a SmartScreen "unknown publisher" prompt, and on macOS Gatekeeper may warn the build is unverified — this is expected for an unsigned open-source app, not a sign of tampering. Until signing lands, every release ships three independent ways to verify the bytes you downloaded:
+
+- **SHA-256 checksums** — each release attaches `checksums.txt`. Compare your file:
+  - Windows (PowerShell): `Get-FileHash .\MoodHaven_*-setup.exe -Algorithm SHA256`
+  - macOS/Linux: `shasum -a 256 MoodHaven_*` (or `sha256sum`)
+- **Minisign signature** — each installer has a companion `.sig` signed with our release key. Verify with [minisign](https://jedisct1.github.io/minisign/):
+  ```bash
+  minisign -Vm MoodHaven_<version>_amd64.AppImage -P RWT1wIrjUnfXZuS/DdD4KiyMU31U/yOIhFUlwkWALb5cSc6Grzh5CE57
+  ```
+  (This is the same key the in-app updater verifies before installing an update.)
+- **VirusTotal** — each release attaches `virustotal.txt` linking a public multi-engine scan report for every installer. A clean report means no antivirus engine flags the build.
 
 ### First Launch
 

--- a/scripts/submit-virustotal.cjs
+++ b/scripts/submit-virustotal.cjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * submit-virustotal.js
+ *
+ * Runs in CI after checksums are generated, while all platform installers are
+ * still in artifacts/. Submits each desktop installer to VirusTotal so a public
+ * scan report exists, then writes virustotal.txt (asset name → report URL, keyed
+ * by SHA-256) and uploads it to the GitHub release.
+ *
+ * This is a transparency signal, NOT code signing: a clean VirusTotal report
+ * means no AV engine currently flags the build, but it does not remove the
+ * Windows SmartScreen "unknown publisher" prompt or the macOS Gatekeeper block.
+ * Those require a real signing certificate (tracked on the roadmap).
+ *
+ * The report URL is the permanent hash-based GUI link
+ * (https://www.virustotal.com/gui/file/<sha256>), so it stays valid even after
+ * the one-time analysis id expires.
+ *
+ * Usage (set in environment):
+ *   GH_TOKEN    — GitHub token with repo write access
+ *   TAG         — release tag, e.g. "v1.2.3"
+ *   VT_API_KEY  — VirusTotal API key (free public tier is fine for this
+ *                 non-commercial project: 4 lookups/min, 500/day)
+ *
+ * Non-fatal: a missing key, quota exhaustion, or VT outage logs a warning and
+ * exits 0 — it must never block a release.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const TAG = process.env.TAG;
+const VT_API_KEY = process.env.VT_API_KEY;
+
+if (!TAG) {
+  console.error('TAG environment variable is required');
+  process.exit(1);
+}
+if (!VT_API_KEY) {
+  console.warn('VT_API_KEY not set — skipping VirusTotal submission.');
+  process.exit(0);
+}
+
+const ARTIFACTS_DIR = path.join(process.cwd(), 'artifacts');
+const OUT_FILE = path.join(process.cwd(), 'virustotal.txt');
+
+// Desktop installers only — AABs are Play-managed and not AV-relevant.
+const ASSET_EXTENSIONS = ['.exe', '.msi', '.dmg', '.AppImage', '.deb', '.rpm'];
+
+// VT public API: 4 lookups/min. Space submissions ~16s apart to stay under it.
+const THROTTLE_MS = 16_000;
+// Files larger than this must use the dedicated large-file upload URL.
+const DIRECT_UPLOAD_LIMIT = 32 * 1024 * 1024;
+
+const VT_API = 'https://www.virustotal.com/api/v3';
+const VT_GUI_FILE = 'https://www.virustotal.com/gui/file';
+
+function findAssets(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findAssets(fullPath));
+    } else if (ASSET_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      results.push({ name: entry.name, path: fullPath });
+    }
+  }
+  return results;
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function submitFile({ name, path: filePath }) {
+  const size = fs.statSync(filePath).size;
+  let endpoint = `${VT_API}/files`;
+
+  if (size > DIRECT_UPLOAD_LIMIT) {
+    const res = await fetch(`${VT_API}/files/upload_url`, {
+      headers: { 'x-apikey': VT_API_KEY },
+    });
+    if (!res.ok) throw new Error(`upload_url request failed: ${res.status}`);
+    const body = await res.json();
+    endpoint = body.data;
+  }
+
+  const form = new FormData();
+  form.append('file', new Blob([fs.readFileSync(filePath)]), name);
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'x-apikey': VT_API_KEY },
+    body: form,
+  });
+  if (!res.ok) throw new Error(`submit failed: ${res.status} ${await res.text()}`);
+}
+
+(async () => {
+  const assets = findAssets(ARTIFACTS_DIR);
+  if (assets.length === 0) {
+    console.warn('No installers found in artifacts/ — nothing to submit.');
+    process.exit(0);
+  }
+
+  const lines = [];
+  for (let i = 0; i < assets.length; i++) {
+    const asset = assets[i];
+    const hash = sha256(asset.path);
+    const reportUrl = `${VT_GUI_FILE}/${hash}`;
+    try {
+      await submitFile(asset);
+      console.log(`Submitted ${asset.name} → ${reportUrl}`);
+    } catch (e) {
+      // Still record the hash link — VT may already know the file, and the link
+      // resolves once any scan of these bytes completes.
+      console.warn(`VT submit failed for ${asset.name}: ${e.message}`);
+    }
+    lines.push(`${asset.name}  ${reportUrl}`);
+    if (i < assets.length - 1) await sleep(THROTTLE_MS);
+  }
+
+  const header =
+    '# VirusTotal scan reports for this release (keyed by SHA-256).\n' +
+    '# Reports may take a few minutes to populate after publish.\n' +
+    '# A clean report means no AV engine flags the build; it is not a code signature.\n';
+  fs.writeFileSync(OUT_FILE, header + lines.join('\n') + '\n');
+  console.log(`\nWrote ${OUT_FILE}`);
+
+  try {
+    execSync(`gh release upload "${TAG}" "${OUT_FILE}" --clobber`, {
+      stdio: 'inherit',
+      env: { ...process.env },
+    });
+    console.log('Uploaded virustotal.txt to release.');
+  } catch (e) {
+    console.warn('Failed to upload virustotal.txt:', e.message);
+  }
+})().catch((e) => {
+  // Last-resort guard: never fail the release over VT.
+  console.warn('VirusTotal step error (non-fatal):', e.message);
+  process.exit(0);
+});

--- a/website/app/download/DownloadClient.tsx
+++ b/website/app/download/DownloadClient.tsx
@@ -200,6 +200,14 @@ export default function DownloadClient({ release }: { release: LatestRelease | n
             {primaryAsset?.checksumVerified !== false && (
               <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ SHA-256 verified</span>
             )}
+            <a
+              href={release?.releaseUrl ?? "https://github.com/kenlacroix/moodhaven-journal/releases/latest"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full hover:text-neutral-700 hover:bg-neutral-200 focus-visible:ring-1 focus-visible:ring-primary-700"
+            >
+              ✓ VirusTotal scanned
+            </a>
             <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ No account required</span>
             <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ MIT licensed</span>
           </div>
@@ -486,6 +494,59 @@ export default function DownloadClient({ release }: { release: LatestRelease | n
             )}
           </div>
         </section>
+
+        {/* Verify your download */}
+        <AnimatedReveal delay={0.25} className="mt-14">
+          <details className="group rounded-xl bg-neutral-50 ring-1 ring-neutral-200 p-5 text-left">
+            <summary className="cursor-pointer list-none flex items-center justify-between gap-2 text-sm font-semibold text-neutral-900 focus-visible:ring-2 focus-visible:ring-primary-700 rounded">
+              <span>Verify your download</span>
+              <span className="text-neutral-400 transition-transform duration-200 group-open:rotate-180" aria-hidden="true">⌄</span>
+            </summary>
+            <div className="mt-3 space-y-3 text-sm text-neutral-600 leading-relaxed">
+              <p>
+                MoodHaven isn&apos;t code-signed yet, so Windows SmartScreen may say
+                &quot;unknown publisher&quot; and macOS Gatekeeper may warn the build is
+                unverified. That&apos;s expected for an unsigned open-source app — not a sign
+                of tampering. Every release ships three independent ways to check the bytes
+                you downloaded:
+              </p>
+              <ul className="space-y-2 list-disc pl-5">
+                <li>
+                  <span className="font-medium text-neutral-800">SHA-256 checksums</span> —
+                  compare your file against{" "}
+                  <a
+                    href={release?.releaseUrl ?? "https://github.com/kenlacroix/moodhaven-journal/releases/latest"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary-700 underline hover:text-primary-900"
+                  >
+                    checksums.txt
+                  </a>{" "}
+                  (<code className="text-xs">shasum -a 256</code> /{" "}
+                  <code className="text-xs">Get-FileHash</code>).
+                </li>
+                <li>
+                  <span className="font-medium text-neutral-800">Minisign signature</span> —
+                  each installer has a <code className="text-xs">.sig</code> signed with our
+                  release key — the same key the in-app updater verifies before installing.
+                </li>
+                <li>
+                  <span className="font-medium text-neutral-800">VirusTotal</span> — every
+                  release attaches{" "}
+                  <a
+                    href={release?.releaseUrl ?? "https://github.com/kenlacroix/moodhaven-journal/releases/latest"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary-700 underline hover:text-primary-900"
+                  >
+                    virustotal.txt
+                  </a>{" "}
+                  linking a public multi-engine scan report for each installer.
+                </li>
+              </ul>
+            </div>
+          </details>
+        </AnimatedReveal>
 
         {/* Trust signals */}
         <AnimatedReveal delay={0.3} className="mt-14 text-center text-xs text-neutral-400 flex flex-wrap justify-center gap-3">


### PR DESCRIPTION
## What

Adds automated VirusTotal scanning of release builds and surfaces download verification to users on the README and website. Interim AV-transparency story while code signing stays cost-deferred (decided 2026-06-08).

## Changes

- **`scripts/submit-virustotal.cjs`** (new) — runs in the `update-manifest` CI job after checksums. Submits each desktop installer to VirusTotal, writes `virustotal.txt` (per-asset report links keyed by SHA-256), and attaches it to the release. Large-file (>32 MB) upload-URL aware, throttled to the free public tier (4/min), and **fully non-fatal** — a missing `VT_API_KEY`, quota miss, or VT outage logs a warning and never blocks a release.
- **`.github/workflows/build.yml`** — wires the step in after checksum generation with `continue-on-error: true`.
- **`README.md`** — "Verifying Your Download" section (SHA-256 + minisign + VirusTotal) with an honest unsigned-build / SmartScreen-Gatekeeper disclaimer, plus a VirusTotal badge.
- **`website/app/download/DownloadClient.tsx`** — a "Verify your download" details panel and a "VirusTotal scanned" trust chip.

## What gets scanned

All **desktop** installers: Windows `.exe`/`.msi`, macOS `.dmg` (x64 + aarch64), Linux `.AppImage`/`.deb`/`.rpm`. Android `.aab` bundles are intentionally skipped (Play-managed, not a useful VT target; revisit when an installable `.apk` ships).

## Honest framing

VirusTotal is a *reactive AV* signal, **not** code signing — a clean report means no engine flags the build, but it does not remove the Windows "unknown publisher" prompt or macOS Gatekeeper block. The report links are permanent hash-based GUI URLs (`/gui/file/<sha256>`) so they don't rot.

## Required before this is live

Add a `VT_API_KEY` repository secret (VirusTotal API key). Until then the step self-skips and the badge/chip links 404 until the first release built with the key.

## Testing

Submission path validated locally against the real API (key valid, file accepted, `virustotal.txt` generated correctly). Website typecheck, `node --check`, and YAML parse all pass. The `gh release upload` + >32 MB branches run only in CI.

## Notes

- Roadmap doc updates for this work ride with the e2e PR (#147), which owns that section of `active-plans/post-1.8.0-roadmap.md`.
- Diff is +236 lines, well under the 400-line PR cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)