### PR TITLE
feat(sync): BYO-Cloud folder sync (desktop)

### DIFF
--- a/active-plans/ios-app-v2-0.md
+++ b/active-plans/ios-app-v2-0.md
@@ -38,7 +38,7 @@ npm run tauri ios init
 The iOS app needs a cloud sync story before it's useful (LAN peer sync won't be the iOS primary path). Ship the sync improvements first, then the iOS shell, then the UI responsiveness work.
 
 ```
-Phase 1: Cloud sync (Dropbox + Google Drive)   ← IN PROGRESS (feat/cloud-sync-phase1)
+Phase 1: Cloud sync — 1a BYO-Cloud folder sync (PRIMARY) + 1b OAuth (secondary, coded)
 Phase 2: Tauri iOS project setup               ← 1-2 days, mostly config
 Phase 3: Mobile-responsive React UI            ← IN PROGRESS (BottomTabBar + useIsMobile foundation)
 Phase 4: iOS-specific adaptations              ← feature scoping, flags, edge cases
@@ -47,11 +47,48 @@ Phase 5: iOS-only additions (v2.1+)            ← HealthKit, Face ID, Widgets
 
 ---
 
-## Phase 1 — Cloud Sync: Dropbox + Google Drive
+## Phase 1 — Cloud Sync
+
+> **Direction change (2026-06-08, owner-decided):** **BYO-Cloud folder sync is now the PRIMARY/default
+> sync story.** The OAuth Dropbox/GDrive work below stays as a secondary "power user" option (code is
+> done; wire real credentials when convenient — no longer the headline). Rationale + full reconciliation:
+> `active-plans/post-1.8.0-roadmap.md` §4. The external review correctly flagged that OAuth app-folder
+> sync is higher-friction than necessary.
+
+### Phase 1a — BYO-Cloud folder sync (PRIMARY)
+
+Instead of registering an OAuth app and writing to a hidden app-folder, write the **same encrypted
+`.moodhaven` blob `export_data` already produces** into a **user-picked folder** that happens to sit
+inside iCloud Drive / Google Drive / Dropbox / OneDrive. The OS sync client propagates it for free —
+no server, no OAuth registration, no per-provider API, works with any folder-syncing service the user
+already has.
+
+```
+export_data(password) → encrypted .moodhaven blob
+    ↓  write to user-chosen synced folder
+[ iCloud Drive / Google Drive / Dropbox / OneDrive folder ]  (OS handles propagation)
+    ↓  other device reads from the same folder
+import_data(blob, password) → LWW merge into local SQLite
+```
+
+| Platform | Folder access mechanism | Verify before building |
+|----------|------------------------|------------------------|
+| Desktop | `tauri-plugin-dialog` folder picker → plain path persisted in settings | — (trivial) |
+| Android | Storage Access Framework: persisted tree URI (`takePersistableUriPermission`) | Does `tauri-plugin-fs`+dialog expose a persistable tree URI, or is a thin native plugin needed? **Spike first.** |
+| iOS | `UIDocumentPickerViewController` directory pick + **security-scoped bookmark** persisted across launches | Tauri dialog/fs coverage of security-scoped bookmarks; may need a small Swift plugin. **Spike first.** |
+
+- **Conflict:** same LWW-by-`updated_at` as peer sync; `import_data` already dedups. Add an
+  on-foreground "newer backup detected — import?" check (manual in v1; auto-sync later).
+- **New commands (indicative):** `folder_sync_set_target` (store path/URI/bookmark),
+  `folder_sync_upload`, `folder_sync_download`, `folder_sync_status`, `folder_sync_clear`.
+- Do **not** assume plugin support for persistent mobile folder permissions — spike the Android SAF
+  tree-URI and iOS security-scoped bookmark paths before committing the mobile UI.
+
+### Phase 1b — OAuth Dropbox + Google Drive (SECONDARY, already coded)
 
 ### Context
 
-WebDAV is correct and should remain available. The gap: most users don't run a WebDAV server. Adding Dropbox and Google Drive gives users sync via services they already have, with zero infrastructure to manage. The encrypted blob format (`.moodhaven`) doesn't change — these providers are just new transport layers.
+WebDAV is correct and should remain available. Adding Dropbox and Google Drive gives users sync via services they already have. The encrypted blob format (`.moodhaven`) doesn't change — these providers are just new transport layers. **Now secondary** to folder sync (above); the code in `cloud_providers.rs` is complete but credentials are compile-time placeholders — wire real app credentials when convenient.
 
 ### Architecture
 

--- a/src-tauri/src/commands/data_management.rs
+++ b/src-tauri/src/commands/data_management.rs
@@ -834,20 +834,13 @@ pub async fn import_data(app: AppHandle, data: String) -> Result<i32, String> {
     Ok(imported_count)
 }
 
-/// Write text to a file and verify it was written correctly.
-/// Used instead of the FS plugin which has scope restrictions on user-selected paths.
-/// Rejects paths that traverse into sensitive system or shell-config locations.
-#[tauri::command]
-pub async fn write_text_file(
-    path: String,
-    contents: String,
-    lock: State<'_, AppLockState>,
-) -> Result<u64, String> {
-    require_unlocked(&lock)?;
-    let file_path = std::path::Path::new(&path);
+/// Canonicalize a user-selected path and reject any that traverse into sensitive
+/// system or shell-config locations. Shared by `write_text_file` and `read_text_file`
+/// so both honor the identical guard. For not-yet-existing files the parent is
+/// canonicalized and the filename re-joined.
+fn guard_user_file_path(path: &str) -> Result<std::path::PathBuf, String> {
+    let file_path = std::path::Path::new(path);
 
-    // Resolve to an absolute, canonical path (resolves `..` components).
-    // If the file doesn't exist yet, canonicalize the parent instead.
     let canonical = if file_path.exists() {
         file_path
             .canonicalize()
@@ -861,8 +854,8 @@ pub async fn write_text_file(
         return Err("Invalid path".to_string());
     };
 
-    // Block writes to sensitive system and shell-config paths using component-based
-    // matching so that ".ssh" in a directory name elsewhere does not false-match.
+    // Block sensitive system and shell-config paths using component-based matching so
+    // that ".ssh" in a directory name elsewhere does not false-match.
     // Lowercased for case-insensitive matching on Windows.
     let blocked_by_component = canonical.components().any(|c| {
         let name = c.as_os_str().to_str().unwrap_or("").to_lowercase();
@@ -904,11 +897,25 @@ pub async fn write_text_file(
 
     if blocked_by_component || blocked_by_prefix || blocked_by_filename {
         return Err(format!(
-            "Writing to '{}' is not permitted",
+            "Access to '{}' is not permitted",
             canonical.display()
         ));
     }
 
+    Ok(canonical)
+}
+
+/// Write text to a file and verify it was written correctly.
+/// Used instead of the FS plugin which has scope restrictions on user-selected paths.
+/// Rejects paths that traverse into sensitive system or shell-config locations.
+#[tauri::command]
+pub async fn write_text_file(
+    path: String,
+    contents: String,
+    lock: State<'_, AppLockState>,
+) -> Result<u64, String> {
+    require_unlocked(&lock)?;
+    let canonical = guard_user_file_path(&path)?;
     let file_path = canonical.as_path();
 
     // Ensure parent directory exists
@@ -936,6 +943,19 @@ pub async fn write_text_file(
     }
 
     Ok(written_size)
+}
+
+/// Read a UTF-8 text file from a user-selected path. Honors the same path guard as
+/// `write_text_file`. Used by BYO-Cloud folder sync to read back the encrypted backup
+/// blob from a user-picked sync folder (one the OS keeps mirrored to iCloud/Drive/etc.).
+#[tauri::command]
+pub async fn read_text_file(path: String, lock: State<'_, AppLockState>) -> Result<String, String> {
+    require_unlocked(&lock)?;
+    let canonical = guard_user_file_path(&path)?;
+    if !canonical.exists() {
+        return Err(format!("File does not exist: {}", canonical.display()));
+    }
+    fs::read_to_string(&canonical).map_err(|e| format!("Failed to read file: {}", e))
 }
 
 /// Get database statistics for export info

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -671,6 +671,7 @@ pub fn run() {
             commands::import_data,
             commands::get_data_stats,
             commands::write_text_file,
+            commands::read_text_file,
             commands::exit_app,
             commands::get_log_path,
             commands::open_log_folder,

--- a/src/components/settings/tabs/SyncTab.tsx
+++ b/src/components/settings/tabs/SyncTab.tsx
@@ -10,6 +10,11 @@ import {
   syncUpload,
   syncDownload,
 } from '../../../lib/services/cloudProvidersService';
+import {
+  pickSyncFolder,
+  byoCloudUpload,
+  byoCloudDownload,
+} from '../../../lib/services/byoCloudService';
 import { getSessionPassword } from '../../../lib/services/journalService';
 
 interface SyncTabProps {
@@ -19,14 +24,19 @@ interface SyncTabProps {
   setWebDAVConfig: (patch: Partial<AppSettings['storage']['webdav']>) => void;
   setSyncMode: (v: 'manual' | 'on-open' | 'on-save') => void;
   setSyncIntervalMinutes: (v: number) => void;
+  setByoCloudFolder: (folderPath: string | null) => void;
+  setByoCloudLastSync: (date: string) => void;
 }
 
 export function SyncTab({
   settings,
+  saveSettings,
   setStorageType,
   setWebDAVConfig,
   setSyncMode,
   setSyncIntervalMinutes,
+  setByoCloudFolder,
+  setByoCloudLastSync,
 }: SyncTabProps) {
   const [isConnecting, setIsConnecting] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -110,6 +120,56 @@ export function SyncTab({
     [],
   );
 
+  const byoFolder = settings.storage.byocloud?.folderPath ?? null;
+  const byoLastSync = settings.storage.byocloud?.lastSyncAt ?? null;
+
+  const handlePickFolder = useCallback(async () => {
+    setSyncMessage(null);
+    try {
+      const folder = await pickSyncFolder();
+      if (!folder) return; // cancelled
+      setByoCloudFolder(folder);
+      await saveSettings();
+    } catch (e) {
+      setSyncMessage({ text: e instanceof Error ? e.message : 'Could not select folder', error: true });
+    }
+  }, [setByoCloudFolder, saveSettings]);
+
+  const handleByoSync = useCallback(
+    async (direction: 'upload' | 'download') => {
+      if (!byoFolder) {
+        setSyncMessage({ text: 'Choose a sync folder first', error: true });
+        return;
+      }
+      const password = getSessionPassword();
+      if (!password) {
+        setSyncMessage({ text: 'Session not unlocked', error: true });
+        return;
+      }
+      setIsSyncing(true);
+      setSyncMessage(null);
+      const result =
+        direction === 'upload'
+          ? await byoCloudUpload(password, byoFolder)
+          : await byoCloudDownload(password, byoFolder);
+      setIsSyncing(false);
+      if (result.success) {
+        setByoCloudLastSync(new Date().toISOString());
+        void saveSettings();
+        setSyncMessage({
+          text:
+            direction === 'upload'
+              ? 'Backup written to sync folder'
+              : `Imported${result.entriesCount !== undefined ? ` — ${result.entriesCount} entries` : ''}`,
+          error: false,
+        });
+      } else {
+        setSyncMessage({ text: result.error ?? 'Sync failed', error: true });
+      }
+    },
+    [byoFolder, setByoCloudLastSync, saveSettings],
+  );
+
   const providerLabel = settings.storage.type === 'dropbox' ? 'Dropbox' : 'Google Drive';
   const cloudProviderKey = settings.storage.type === 'dropbox' || settings.storage.type === 'gdrive'
     ? settings.storage.type
@@ -130,6 +190,7 @@ export function SyncTab({
           value={settings.storage.type}
           options={[
             { value: 'local', label: 'Local only' },
+            { value: 'byocloud', label: 'Sync folder (iCloud/Drive/Dropbox)' },
             { value: 'dropbox', label: 'Dropbox' },
             { value: 'gdrive', label: 'Google Drive' },
             { value: 'webdav', label: 'WebDAV' },
@@ -141,6 +202,71 @@ export function SyncTab({
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Your journal is stored locally only. Connect a sync provider to back up across devices.
           </p>
+        )}
+
+        {settings.storage.type === 'byocloud' && (
+          <div className="space-y-3">
+            {/* Folder status */}
+            <div className="flex items-center justify-between p-3 bg-slate-50 dark:bg-slate-800/50 rounded-xl gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Sync folder</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">
+                  {byoFolder ?? 'No folder selected'}
+                </p>
+                {byoLastSync && (
+                  <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                    Last synced {new Date(byoLastSync).toLocaleString()}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => void handlePickFolder()}
+                className="shrink-0 px-3 py-1.5 text-sm font-medium text-violet-600 dark:text-violet-400 bg-violet-100 dark:bg-violet-900/30 rounded-lg hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors"
+              >
+                {byoFolder ? 'Change…' : 'Choose folder…'}
+              </button>
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={isSyncing || !byoFolder}
+                onClick={() => { clearMessage(); void handleByoSync('upload'); }}
+                className="px-3 py-1.5 text-sm font-medium text-violet-600 dark:text-violet-400 bg-violet-100 dark:bg-violet-900/30 rounded-lg hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors disabled:opacity-50"
+              >
+                {isSyncing ? 'Syncing…' : 'Back up now'}
+              </button>
+              <button
+                type="button"
+                disabled={isSyncing || !byoFolder}
+                onClick={() => { clearMessage(); void handleByoSync('download'); }}
+                className="px-3 py-1.5 text-sm font-medium text-violet-600 dark:text-violet-400 bg-violet-100 dark:bg-violet-900/30 rounded-lg hover:bg-violet-200 dark:hover:bg-violet-900/50 transition-colors disabled:opacity-50"
+              >
+                {isSyncing ? 'Syncing…' : 'Restore from folder'}
+              </button>
+            </div>
+
+            {/* Inline status message */}
+            {syncMessage && (
+              <p
+                className={`text-xs ${
+                  syncMessage.error
+                    ? 'text-rose-500 dark:text-rose-400'
+                    : 'text-emerald-600 dark:text-emerald-400'
+                }`}
+              >
+                {syncMessage.text}
+              </p>
+            )}
+
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Pick a folder inside a service that already syncs to the cloud (iCloud Drive, Google
+              Drive, Dropbox, OneDrive). Your backup is encrypted on this device before it's written —
+              the cloud provider only ever sees ciphertext.
+            </p>
+          </div>
         )}
 
         {(settings.storage.type === 'dropbox' || settings.storage.type === 'gdrive') && (

--- a/src/lib/backend/browser-invoke.ts
+++ b/src/lib/backend/browser-invoke.ts
@@ -450,6 +450,9 @@ async function dispatch(command: string, p: Params): Promise<any> {
       URL.revokeObjectURL(url);
       return;
     }
+    case 'read_text_file':
+      // BYO-Cloud folder sync reads arbitrary OS paths — not reachable from the browser sandbox.
+      throw new Error('Folder sync requires the desktop app');
 
     // -----------------------------------------------------------------------
     // 2FA — browser provides TOTP via WebCrypto; stubs for hardware key

--- a/src/lib/services/byoCloudService.ts
+++ b/src/lib/services/byoCloudService.ts
@@ -1,0 +1,79 @@
+/**
+ * BYO-Cloud Folder Sync
+ *
+ * Writes the same encrypted `.moodhaven` backup blob the export path produces into a
+ * user-picked folder that the OS keeps mirrored to iCloud Drive / Google Drive / Dropbox /
+ * OneDrive. No server, no OAuth, no per-provider API — the OS sync client handles
+ * propagation. Upload = export → write file; download = read file → import.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
+import { exportWithMedia, encryptedImport } from './dataManagementService';
+
+const BACKUP_FILENAME = 'moodhaven-backup.moodhaven';
+
+export interface ByoCloudResult {
+  success: boolean;
+  error?: string;
+  entriesCount?: number;
+}
+
+/** Join a folder path and filename using the folder's native separator. */
+function backupPathIn(folderPath: string): string {
+  const sep = folderPath.includes('\\') ? '\\' : '/';
+  const base = folderPath.endsWith(sep) ? folderPath.slice(0, -sep.length) : folderPath;
+  return `${base}${sep}${BACKUP_FILENAME}`;
+}
+
+/**
+ * Prompt the user to pick a sync folder. Returns the chosen absolute path, or null
+ * if the user cancelled.
+ */
+export async function pickSyncFolder(): Promise<string | null> {
+  const selected = await open({
+    directory: true,
+    multiple: false,
+    title: 'Choose a sync folder (e.g. inside iCloud Drive, Google Drive, or Dropbox)',
+  });
+  if (!selected || Array.isArray(selected)) return null;
+  return selected;
+}
+
+/**
+ * Export the full encrypted backup (entries + media) and write it into the sync folder.
+ */
+export async function byoCloudUpload(
+  password: string,
+  folderPath: string,
+): Promise<ByoCloudResult> {
+  try {
+    const blob = await exportWithMedia(password);
+    const bytesWritten = await invoke<number>('write_text_file', {
+      path: backupPathIn(folderPath),
+      contents: blob,
+    });
+    if (!bytesWritten || bytesWritten === 0) {
+      return { success: false, error: 'Backup file was not written.' };
+    }
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Upload failed' };
+  }
+}
+
+/**
+ * Read the encrypted backup from the sync folder and merge it into the local store.
+ */
+export async function byoCloudDownload(
+  password: string,
+  folderPath: string,
+): Promise<ByoCloudResult> {
+  try {
+    const blob = await invoke<string>('read_text_file', { path: backupPathIn(folderPath) });
+    const entriesCount = await encryptedImport(blob, password);
+    return { success: true, entriesCount };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Download failed' };
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -150,6 +150,8 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
     setReminderSound,
     setStorageType,
     setWebDAVConfig,
+    setByoCloudFolder,
+    setByoCloudLastSync,
     setHasSeenTutorial,
     setSTTEnabled,
     setSTTModel,
@@ -519,6 +521,8 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
           setWebDAVConfig={setWebDAVConfig}
           setSyncMode={setSyncMode}
           setSyncIntervalMinutes={setSyncIntervalMinutes}
+          setByoCloudFolder={setByoCloudFolder}
+          setByoCloudLastSync={setByoCloudLastSync}
         />
       )}
       {activeTab === 'ai' && (

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -88,6 +88,8 @@ interface SettingsState {
   setStorageType: (type: StorageBackend) => void;
   setWebDAVConfig: (config: Partial<WebDAVConfig>) => void;
   setLastSyncDate: (date: string, direction: 'upload' | 'download') => void;
+  setByoCloudFolder: (folderPath: string | null) => void;
+  setByoCloudLastSync: (date: string) => void;
 
   // Tutorial
   setHasSeenTutorial: (seen: boolean) => void;
@@ -523,6 +525,32 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
           ...state.settings.storage,
           lastSyncDate: date,
           lastSyncDirection: direction,
+        },
+      },
+      hasUnsavedChanges: true,
+    }));
+  },
+
+  setByoCloudFolder: (folderPath) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        storage: {
+          ...state.settings.storage,
+          byocloud: { ...state.settings.storage.byocloud, folderPath },
+        },
+      },
+      hasUnsavedChanges: true,
+    }));
+  },
+
+  setByoCloudLastSync: (date) => {
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        storage: {
+          ...state.settings.storage,
+          byocloud: { ...state.settings.storage.byocloud, lastSyncAt: date },
         },
       },
       hasUnsavedChanges: true,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -99,7 +99,7 @@ export interface ReminderSettings {
 }
 
 // Storage backend options
-export type StorageBackend = 'local' | 'webdav' | 'dropbox' | 'gdrive';
+export type StorageBackend = 'local' | 'webdav' | 'dropbox' | 'gdrive' | 'byocloud';
 
 // WebDAV connection configuration
 export interface WebDAVConfig {
@@ -119,6 +119,9 @@ interface StorageSettings {
     dropbox: { connected: boolean; lastSyncAt: string | null };
     gdrive: { connected: boolean; lastSyncAt: string | null };
   };
+  // BYO-Cloud folder sync: a user-picked folder mirrored to iCloud/Drive/Dropbox/OneDrive
+  // by the OS sync client. We write/read the encrypted backup blob there directly.
+  byocloud: { folderPath: string | null; lastSyncAt: string | null };
 }
 
 // Tutorial settings
@@ -316,6 +319,7 @@ export function createDefaultSettings(): AppSettings {
         dropbox: { connected: false, lastSyncAt: null },
         gdrive: { connected: false, lastSyncAt: null },
       },
+      byocloud: { folderPath: null, lastSyncAt: null },
     },
     tutorial: {
       hasSeenTutorial: false,


### PR DESCRIPTION
## What

Adds **BYO-Cloud folder sync** as the primary cloud-sync path (per `post-1.8.0-roadmap.md` §4 / `ios-app-v2-0.md` Phase 1a). Instead of registering an OAuth app and writing to a hidden app-folder, MoodHaven writes the **same encrypted `.moodhaven` blob the export path already produces** into a **user-picked folder** that happens to live inside iCloud Drive / Google Drive / Dropbox / OneDrive. The OS sync client handles propagation — no server, no OAuth, no per-provider API.

This PR ships the **desktop slice** (the roadmap's immediate win). Mobile (Android SAF persistable tree-URI, iOS security-scoped bookmark) is deferred to a spike, as the roadmap directs.

## How it works

```
exportWithMedia(password) → encrypted .moodhaven blob
    ↓  write_text_file → <folder>/moodhaven-backup.moodhaven
[ iCloud / Google Drive / Dropbox / OneDrive folder ]   (OS propagates)
    ↓  read_text_file ← <folder>/moodhaven-backup.moodhaven
encryptedImport(blob, password) → LWW merge into local SQLite
```

The provider only ever sees ciphertext — encryption happens on-device before the blob is written.

## Changes

- **Rust:** new `read_text_file` command, mirroring `write_text_file`'s sensitive-path guard (extracted into a shared `guard_user_file_path` helper so both honor the identical block-list); `require_unlocked`. Registered in `lib.rs`. No capabilities change (`allow-all-app-commands` covers it).
- **Settings:** `'byocloud'` `StorageBackend` + `byocloud {folderPath, lastSyncAt}` storage settings, store setters, defaults. Reads are defensive (`?.`) for existing users whose persisted settings predate the field.
- **Service:** `byoCloudService.ts` — `pickSyncFolder` (dialog `open({directory:true})`), `byoCloudUpload`, `byoCloudDownload`.
- **UI:** `SyncTab` gains a "Sync folder (iCloud/Drive/Dropbox)" option with a folder picker, **Back up now** / **Restore from folder** actions, and last-sync display.
- **Browser shim:** `read_text_file` throws "Folder sync requires the desktop app" (no filesystem in the web sandbox).
- **Docs:** `ios-app-v2-0.md` updated to mark BYO-Cloud as the primary Phase 1 path.

## Verification

- `npm run typecheck` ✅
- `npm run lint:ci` ✅
- `npx vitest run` ✅ 1512 passed (106 files)
- `cargo check` ✅ + `cargo fmt --check` ✅

## Not in scope

- Mobile folder access (Android tree-URI / iOS bookmark) — spike first, per roadmap.
- Auto-sync / on-foreground "newer backup detected" prompt — manual sync only in v1.
- Existing OAuth Dropbox/GDrive path is untouched (stays as the secondary "power user" option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)