### PR TITLE
test(db): crash-replay harness for encrypt_in_place

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,14 @@ jobs:
         working-directory: src-tauri
         run: cargo test
 
+      - name: Crash-replay SIGKILL harness (Layer B)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        # Literally kill -9 the migration at each on-disk boundary and assert startup
+        # recovery never loses data. kill -9 is Linux/macOS only; Windows boundaries are
+        # covered by the Layer-A state-injection matrix in `cargo test` above.
+        run: ./scripts/crash-replay.sh
+
       - name: Cargo audit (CVE check)
         if: matrix.os == 'ubuntu-latest'
         working-directory: src-tauri

--- a/active-plans/change-password.md
+++ b/active-plans/change-password.md
@@ -1,0 +1,302 @@
+# Change Master Password
+
+> **Status:** Plan / not started. Grounded in a full read of the crypto stack (2026-06-08).
+> **Estimated effort:** ~1 week for the re-encrypt approach (Approach A). The wrap-the-key
+> refactor (Approach B) is a larger, separate follow-up.
+> **Owner:** TBD
+
+---
+
+## 0. Product judgment & decision (2026-06-08)
+
+**Decision: build it.** The user value alone is modest — for a local-first, offline, no-account
+journal there's no server credential to revoke, so password *rotation* mostly serves "someone saw
+my password" (rare) plus "table-stakes button users expect." Forgot-password is already covered by
+the Recovery Key + Erase & Start Fresh and is **not** what this feature addresses (it requires the
+current password).
+
+**The real driver is exposure.** "I built crash-safe master-password rotation across a
+double-encryption layer (SQLCipher outer + per-field AES-GCM inner), with SIGKILL crash-replay
+tests" is a strong engineering-writing story — in the same vein as the self-pentest series. So this
+is built **as a feature *and* as the basis for a blog post**, and that combination is what justifies
+the ~1 week against its modest raw demand.
+
+**Implication for how we build it:** lean into the parts that make the best post — the
+two-layer/two-runtime re-encryption, the atomicity design, the crash-recovery marker, and the
+crash-replay test matrix. Those are exactly the load-bearing engineering bits anyway, so the blog
+angle and the correctness work point the same direction. See §11 for the writing plan.
+
+---
+
+## 1. Goal
+
+Let an unlocked user change their master password from **Settings → Privacy**, preserving all
+data and every dependent unlock path, without ever weakening the zero-knowledge model or risking
+data loss on interruption.
+
+Not in scope: password *reset* without the old password (that is what the Recovery Key and
+"Erase & Start Fresh" already cover). Change-password **requires the current password**.
+
+---
+
+## 2. Why this is not a one-liner
+
+The password *is* the key. There is no master key to re-point, so "change password" means
+**re-deriving keys and re-encrypting / re-wrapping everything that depends on the old password.**
+There are two independent encryption layers, both keyed off the password, and the work spans both
+the Rust backend and the JS frontend (where the per-field keys live).
+
+### Two password-derived layers
+
+| Layer | Key | Where | Salt | Re-encrypt cost |
+|---|---|---|---|---|
+| **Outer — SQLCipher whole-DB** | `PBKDF2(password, db_salt, 600k)` applied as raw `PRAGMA key = "x'…'"` | `src-tauri/src/db/mod.rs`; salt in `db_state.json` | one salt | one atomic rekey of the file |
+| **Inner — per-field AES-256-GCM** | `PBKDF2(password, per-field salt, 600k)` | frontend `src/lib/services/crypto.ts`; per-row blobs | one salt **per blob** | decrypt + re-encrypt **every** blob |
+
+On the encrypted path (all v1.8.0+ installs) SQLCipher's MAC verification on key-apply *is* the
+password check — there is no separate verifier-hash compare (`journal.rs::verify_password`,
+encrypted branch). The legacy `password_hash`/`password_salt` in `user_settings` is only consulted
+on the pre-migration unencrypted path, but we still update it on change for consistency.
+
+### Everything that depends on the old password
+
+From a full audit of the stack:
+
+| # | Item | File(s) | Stored as | Action on change |
+|---|---|---|---|---|
+| 1 | Journal entry content | `crypto.ts`, `commands/journal.rs` | per-field blob (own salt) | **re-encrypt** (FE has the key) |
+| 2 | Signals payload | `signalService.ts`, `commands/signals.rs` | per-field blob | **re-encrypt** (FE) |
+| 3 | Media attachments | `commands/media.rs` (MBMF, 32-byte salt header) | encrypted files on disk | **re-encrypt** (Rust) |
+| 4 | SQLCipher DB key | `db/mod.rs`, `db_state.json` | password-derived, salt on disk | **rekey** the whole file (Rust) |
+| 5 | TOTP secret | `commands/two_factor.rs` (`enc:v1:…`) | per-field blob | **re-encrypt** (Rust) |
+| 6 | PIN unlock | `commands/pin_unlock.rs` | wrapped copy of the password | **stale → re-wrap or disable** |
+| 7 | Desktop biometric | `commands/biometric.rs` | password in OS keyring | **stale → re-store or clear** |
+| 8 | Recovery key | `recoveryKeyService.ts` | wrapped copy of the password | **stale → regenerate** |
+| 9 | Verifier hash | `crypto.ts::hashPassword`, `journal.rs` | PBKDF2 hash + salt | **update** |
+| 10 | Hardware key | `commands/hardware_key.rs` | independent secret (NOT the password) | **no action** |
+| 11 | Export files | `commands/data_management.rs` | self-contained envelope per export | **no action** (old backups keep old password) |
+
+Items 1–5 + 9 are the irreversible re-encryption work. Items 6–8 are convenience copies that
+become stale; the safe default is to **invalidate** them and prompt re-setup (re-wrapping them
+silently is possible but multiplies the atomic surface — see §5). Item 10 is genuinely independent.
+Item 11 needs nothing.
+
+---
+
+## 3. Two approaches
+
+### Approach A — Re-encrypt in place (recommended first)
+
+Decrypt every dependent blob with the old password, re-encrypt with the new one; rekey the outer
+SQLCipher layer; update the verifier; invalidate stale convenience copies. No architecture change,
+ships a real feature. Cost is **O(data size)** and the hard part is crash-safety across the
+JS/Rust boundary and the on-disk media files.
+
+**Pros:** no schema/crypto-core change; entries stay individually keyed (the current model);
+nothing new to maintain. **Cons:** every change-password re-encrypts all data; media (filesystem,
+non-transactional) is the crash-safety weak point; orchestration spans FE + Rust.
+
+### Approach B — Wrap-the-key indirection (later refactor)
+
+Introduce a random **master data key (MDK)** that encrypts all fields; store the MDK encrypted by
+the password-derived key (exactly the shape PIN/biometric/recovery already use for the password).
+Change-password then only re-wraps the MDK — **O(1)**, instant, trivially atomic (one blob write).
+
+**Pros:** change-password and all future rotations become a single cheap, atomic re-wrap; PIN /
+biometric / recovery wrap the *MDK* instead of the password, so they survive a password change
+without re-setup. **Cons:** it is a crypto-core change; current blobs are keyed directly by the
+password, so adopting it still requires a **one-time full re-encryption migration** (essentially
+one run of Approach A) plus careful versioning and its own crash-safe migration. Bigger up-front
+risk for a feature users hit rarely.
+
+**Recommendation:** ship **Approach A** now (real feature, no core change). Treat **Approach B**
+as a separate, later refactor — and note that when B lands, the migration *is* an A-style
+re-encrypt, so A's machinery (batching, the pending-marker, media swap) is reused, not thrown away.
+
+The rest of this plan details Approach A.
+
+---
+
+## 4. Approach A — implementation
+
+### Orchestration model
+
+Per-field keys for entries (1) and signals (2) live only in JS, so the FE must do that
+re-encryption; media (3), TOTP (5), the DB rekey (4), verifier (9), and convenience-copy
+invalidation (6–8) are Rust-side. The FE orchestrates; Rust performs the irreversible file ops last,
+gated by a crash-recovery marker that mirrors the existing `moodhaven_restore.pending` + `.sha256`
+pattern.
+
+### Phase sequence
+
+1. **FE — collect & validate.** User enters current + new + confirm. Verify current via
+   `verify_password`. Enforce new-password strength and `new != current`.
+2. **FE — inner re-encrypt (entries + signals).** Stream in batches: fetch blobs → `decrypt(old)`
+   → `encrypt(new)`. Do **not** mutate the DB yet; build the batch of new blobs. Batching keeps
+   memory bounded for large journals; entries are text so this is cheap, but stream rather than
+   load-all.
+3. **FE → Rust `password_change_begin`.** Write `password_change.pending` (phase marker, new salt,
+   old/new key material held only in memory for the call). From here, startup recovery owns the
+   outcome.
+4. **Rust — atomic DB transaction (still on the OLD SQLCipher key):** in one SQLite txn:
+   bulk-UPDATE the re-encrypted entry + signal blobs (passed from FE), re-encrypt the TOTP secret
+   (Rust holds old+new password), write the new verifier hash/salt, and write the FE-computed
+   regenerated recovery-key blob (if recovery enabled). Commit atomically. Inner layer is now fully
+   on the new password; outer layer still old.
+5. **Rust — media re-encrypt (the hard part).** For each MBMF file: decrypt(old) → encrypt(new) to
+   a staging file → fsync → atomic rename over the original, recording each completed file in the
+   pending marker so a crash can resume. Reuse `media.rs`'s existing encrypt/decrypt helpers and the
+   Windows-safe rename pattern already in `db/mod.rs`.
+6. **Rust — rekey outer SQLCipher.** Add `rekey_in_place(new_key, new_salt_b64)` to `db/mod.rs`,
+   modeled on `encrypt_in_place` (either `PRAGMA rekey = "x'<newhex>'"` if validated reliable on all
+   three OSes, or the `sqlcipher_export`-into-new-keyed-file + crash-safe swap that the codebase
+   already trusts). Write the new salt to `db_state.json`. Update `db_key_state` to the new key.
+7. **Rust — invalidate stale convenience copies & finish.** Disable/clear PIN (`pin_*`), clear the
+   desktop biometric keyring entry (`biometric_clear_session`). Recovery key was regenerated in
+   step 4 (or disable + prompt if we choose not to auto-regen). Delete `password_change.pending`.
+   Return a summary of which factors now need re-setup.
+8. **FE — post-change UX.** Confirm success; surface a checklist: "Re-enable PIN / biometric"
+   (recovery key already updated, or "regenerate recovery key" if not auto-handled).
+
+### Startup crash recovery
+
+On launch, if `password_change.pending` exists, read its phase:
+- Inner txn not committed → the txn rolled back; data is wholly on the **old** password. Recover by
+  discarding the marker and telling the user the change did not complete (retry).
+- Inner committed, media/rekey incomplete → resume media swap from the recorded progress, then
+  finish the rekey, then clear the marker. The marker must carry enough to finish deterministically
+  (new salt + per-file media progress); old/new key material is **not** persisted to disk — if the
+  process died, recovery requires the user to re-enter both passwords to resume, or we roll forward
+  only the parts that don't need a key (rename of already-staged media) and re-prompt for the rekey.
+  **Design decision to finalize in implementation:** simplest safe option is to make steps 4–6 a
+  single Rust call so a crash leaves only "before txn commit" (full rollback to old) or "after rekey"
+  (fully new) — minimizing the resumable middle. Media staging happens before the txn commit so a
+  crash before commit just leaves orphan staging files to GC.
+
+### New / changed commands (sketch)
+
+- `password_change_begin` / `password_change_commit(entries, signals, recoveryBlob, oldPw, newPw)` —
+  or a single `change_master_password(...)` that does steps 4–6 atomically (preferred for crash-safety).
+- `db/mod.rs::rekey_in_place(new_key, new_salt_b64)`.
+- `media.rs::reencrypt_all(old_pw, new_pw)` (staging + swap + progress).
+- `two_factor.rs::reencrypt_totp(old_pw, new_pw)`.
+- Reuse existing: `verify_password`, `store_password_hash`, `pin_disable`, `biometric_clear_session`,
+  recovery-key store.
+- Register in `lib.rs` + `capabilities/default.json`; all gated by `require_unlocked`.
+
+---
+
+## 5. Convenience copies: invalidate vs. re-wrap
+
+Default: **invalidate and prompt** (disable PIN, clear biometric; regenerate or disable recovery
+key). Rationale: re-wrapping PIN/biometric requires their secrets (the PIN itself; an OS-keyring
+write) inside the same atomic window, widening the failure surface for marginal UX gain on a rare
+action. The post-change checklist makes re-setup a 10-second task. Recovery key is the one worth
+auto-regenerating in-band (FE can compute the new wrapped blob from the known recovery code only if
+the user re-enters it — otherwise prompt to generate a fresh one and re-display it once).
+
+(Approach B removes this problem entirely: those factors wrap the MDK, not the password, so they
+survive a change untouched.)
+
+---
+
+## 6. UX
+
+- **Settings → Privacy → Change Password** (new row near PIN/biometric).
+- Modal: current password, new password (strength meter), confirm. Inline note: "Changing your
+  password re-encrypts your journal — keep the app open until it finishes."
+- Progress UI for the re-encryption (entries/media count), since large journals take real time —
+  reuse the migration-progress emit pattern noted in the P0 roadmap item.
+- On completion: success + a checklist of factors to re-enable (PIN, biometric) and the
+  regenerated recovery key (shown once) if applicable.
+- Hard-lock the UI against navigation/lock during the operation; the marker protects against crash
+  but we should not invite one.
+
+---
+
+## 7. Testing
+
+> **The crash-replay test infrastructure is being built first, on its own branch, before this
+> feature** — see [`crash-replay-harness.md`](crash-replay-harness.md). It is proven against the
+> existing `encrypt_in_place` migration and then reused here by dropping `crash_point!` markers into
+> `change_master_password`'s phase boundaries and un-ignoring the placeholder matrix. The SIGKILL
+> output it produces is the credibility anchor for the blog post (§11).
+
+- **Rust integration (highest value):** seed an encrypted DB with entries + signals + media + TOTP
+  + PIN + recovery key → run change_master_password → assert: old password fails, new password
+  unlocks, all entries/signals/media decrypt under the new password, TOTP still validates, PIN is
+  disabled, recovery key regenerated (or disabled), `db_state.json` salt updated.
+- **Crash-replay:** SIGKILL at each phase boundary (before txn commit, mid-media, after rekey) →
+  relaunch → assert either clean "old password still works" or "new password works", never a
+  half-state, never data loss. This is the load-bearing test.
+- **Password-mismatch / wrong current password** → rejected before any mutation.
+- **FE unit:** the batch decrypt-old/encrypt-new transform round-trips.
+- Fits the existing CI `cargo test` + vitest lanes.
+
+---
+
+## 8. Risks
+
+- **Data loss on interruption** — the entire reason for the pending-marker + single-atomic-Rust-call
+  design and the crash-replay tests. Treat as the #1 risk.
+- **Media swap** (filesystem, non-transactional) — the weakest link; stage-then-rename with progress.
+- **Outer/inner skew** — inner committed but outer not rekeyed (or vice versa) must be impossible to
+  leave persistent; collapse steps 4–6 into one Rust call.
+- **Memory** for large journals — stream/batch the FE re-encryption, don't load all blobs at once.
+- **Cross-boundary orchestration** — FE holds entry/signal keys, Rust holds the rest; keep the
+  irreversible ops Rust-side and last.
+
+---
+
+## 9. Out of scope / explicitly not building
+
+- Password *reset* without the old password (covered by Recovery Key + Erase & Start Fresh).
+- Auto-re-wrapping PIN/biometric in-band (invalidate + prompt instead; revisit under Approach B).
+- Hardware-key changes (independent of the password).
+- Migrating old export files (they are self-contained under the password used at export time).
+
+---
+
+## 10. Recommendation
+
+Build **Approach A** as one well-tested feature: a single atomic Rust `change_master_password`
+spanning the inner re-encrypt commit → media swap → outer rekey, fronted by a batched FE
+re-encryption and a crash-recovery marker, with invalidate-and-prompt for convenience factors.
+Defer **Approach B** (wrap-the-key MDK) as a separate refactor whose one-time migration reuses this
+machinery — and which then makes every future password change instant and atomic.
+
+---
+
+## 11. Blog post (the exposure deliverable)
+
+This feature is being built partly to write about it, like the self-pentest series. Capture the
+material *while building*, not after — screenshots, the crash-replay test output, the before/after
+architecture.
+
+**Working title:** "Changing a password is a one-liner — unless you encrypt everything. How I built
+crash-safe master-password rotation."
+
+**The narrative arc (this is the post):**
+1. The naïve expectation — "Settings → Change Password, how hard can it be?"
+2. The reveal — in a zero-knowledge app the password *is* the key; there's nothing to "update."
+3. The complication — **two** password-derived layers (SQLCipher outer + per-field AES-GCM inner),
+   keyed across **two** runtimes (JS holds entry/signal keys, Rust holds the rest).
+4. The real enemy — atomicity. Re-encrypting an entire encrypted database where one layer is in a
+   SQLite transaction and the other is loose files on disk, such that a crash never loses data.
+5. The design — the `password_change.pending` marker, collapsing inner-commit → media-swap →
+   outer-rekey into one atomic call, invalidate-vs-rewrap for convenience factors.
+6. The proof — SIGKILL at every phase boundary, assert no half-state, ever. Show the test matrix.
+7. The "do it right" coda — the wrap-the-key (MDK) refactor that makes it all O(1), and why I
+   shipped the honest version first.
+
+**Two cuts, matching the established framing** ([[feedback-pentest-blog-framing]]):
+- **MoodHaven site** — user-trust voice: "what changing your password actually does, and why it's
+  safe to interrupt."
+- **Personal site** — engineering/learning voice: the full two-layer atomicity story; this is the
+  exposure piece.
+
+**Assets to capture during the build:** the dependency table (§2), the phase-sequence diagram (§4),
+the crash-replay results (§7), and a short clip/screens of the progress UI on a large journal.
+
+**Sequencing:** write the post *after* the feature lands and the crash-replay suite is green — the
+test output is the credibility anchor, same as the pentest pcaps were.

--- a/active-plans/crash-replay-harness.md
+++ b/active-plans/crash-replay-harness.md
@@ -1,6 +1,9 @@
 # Crash-Replay Test Harness (the credibility anchor)
 
-> **Status:** Plan / not started — *do not build yet.* This doc is the build spec.
+> **Status:** ✅ Built (2026-06-08). Layer A matrix (9 boundary tests, 5 ignored
+> change-password placeholders) green under `cargo test`; Layer B `kill -9` harness green
+> (5/5 boundaries survive SIGKILL). Wired into `.github/workflows/test.yml`. Captured
+> exhibit + matrix output in §9 below for the blog.
 > **Branch:** `test/crash-replay-harness` (own branch + PR, planning committed first).
 > **Parent epic:** [`change-password.md`](change-password.md) §7. Built **first**, against the
 > **existing** crash-safe migration (`encrypt_in_place`), then reused by `change_master_password`.
@@ -206,3 +209,51 @@ Windows SIGKILL.
 - Release build proven to compile the macro to a no-op (no `MH_CRASH_*` effect).
 - `change_master_password` placeholder matrix present and `#[ignore]`d with descriptive names.
 - The exhibit table + the `cargo test` matrix output captured for the blog (`change-password.md` §11).
+
+---
+
+## 9. Build results (captured 2026-06-08)
+
+**Files:** `crash_point!` macro + `crash_inject` + 5 boundary hooks in `src-tauri/src/db/mod.rs`;
+B6′ interrupted-rename backup-restore branch in `Database::new`; `src-tauri/src/db/crash_replay.rs`
+(Layer A); `src-tauri/examples/crash_probe.rs` + `scripts/crash-replay.sh` (Layer B); CI step in
+`.github/workflows/test.yml`. Release-inertness guard `crash_point_is_inert_in_release`
+(`#[cfg(not(debug_assertions))]`) verified under `cargo test --release`.
+
+### Layer A — `cargo test db::crash_replay` (the regression net)
+
+```
+test db::crash_replay::migration::b0_before_salt_write ... ok
+test db::crash_replay::migration::b1_salt_written_no_tmp ... ok
+test db::crash_replay::migration::b2_valid_tmp_promotes ... ok
+test db::crash_replay::migration::b2p_corrupt_tmp_preserves_original ... ok
+test db::crash_replay::migration::b3_state_true_valid_tmp_promotes ... ok
+test db::crash_replay::migration::b4_conn_placeholder_swapped ... ok
+test db::crash_replay::migration::b5_wal_removed_before_rename ... ok
+test db::crash_replay::migration::b6_rename_done ... ok
+test db::crash_replay::migration::b6p_rename_interrupted_backup_restore ... ok
+test db::crash_replay::change_master_password::cmp_b0_inner_txn_pre_commit_recovers_old ... ignored
+test db::crash_replay::change_master_password::cmp_b1_post_commit_pre_media_recovers_new ... ignored
+test db::crash_replay::change_master_password::cmp_b2_mid_media_swap_recovers_new ... ignored
+test db::crash_replay::change_master_password::cmp_b3_post_media_pre_rekey_recovers_new ... ignored
+test db::crash_replay::change_master_password::cmp_b4_post_rekey_pre_marker_clear_recovers_new ... ignored
+```
+
+### Layer B — `scripts/crash-replay.sh` (the blog exhibit)
+
+```
+boundary                   killed   recovered   sentinel result
+--------                   ------   ---------   -------- ------
+encrypt.after_salt         SIGKILL  old         intact   PASS
+encrypt.after_export       SIGKILL  new         intact   PASS
+encrypt.after_state_true   SIGKILL  new         intact   PASS
+encrypt.before_rename      SIGKILL  new         intact   PASS
+encrypt.after_rename       SIGKILL  new         intact   PASS
+
+→ 5/5 boundaries: data survived a kill -9 at every step
+```
+
+**Note vs. §5.3 sketch:** the sketch guessed `encrypt.before_rename → old`; the real code recovers
+`new` there (once `encrypted:true` + a valid tmp are on disk, recovery always promotes). The harness
+reports the *actual* outcome — only the invariant (`old XOR new`, sentinel intact) is asserted, not a
+hardcoded old/new split. One genuinely-`old` SIGKILL exhibit remains (`after_salt`, no tmp yet).

--- a/active-plans/crash-replay-harness.md
+++ b/active-plans/crash-replay-harness.md
@@ -1,0 +1,208 @@
+# Crash-Replay Test Harness (the credibility anchor)
+
+> **Status:** Plan / not started — *do not build yet.* This doc is the build spec.
+> **Branch:** `test/crash-replay-harness` (own branch + PR, planning committed first).
+> **Parent epic:** [`change-password.md`](change-password.md) §7. Built **first**, against the
+> **existing** crash-safe migration (`encrypt_in_place`), then reused by `change_master_password`.
+> **Why this exists:** the SIGKILL crash-replay test *output* is the credibility anchor for the
+> change-password blog post — the same role the packet captures played in the self-pentest series.
+> Grounded in a full read of `src-tauri/src/db/mod.rs` (`encrypt_in_place` + existing crash tests).
+
+---
+
+## 1. Goal
+
+A reusable harness that **proves a crash mid-re-encryption never loses data and never leaves a
+half-state** — for any operation that rewrites the encrypted DB. Build it now against the operation
+that already exists and is already crash-safe (`encrypt_in_place`, the plaintext→SQLCipher
+migration), turning today's two ad-hoc tests into a **complete, named phase matrix**, and add a
+**literal `kill -9` subprocess harness** on top. When `change_master_password` lands, it plugs into
+the same harness with zero new infrastructure.
+
+**The one invariant, stated once:** after a crash at any boundary and the next startup recovery, the
+database is **either fully in the pre-operation state OR fully in the post-operation state — never a
+mix, never unreadable, never empty.** Every test asserts exactly this.
+
+---
+
+## 2. Two complementary layers
+
+| Layer | Mechanism | Runs in | Role |
+|---|---|---|---|
+| **A. State-injection** | construct the exact on-disk intermediate state a crash leaves, boot, assert recovery | `cargo test` (existing CI lane) | the convention already used in `db/mod.rs`; fast, deterministic, the regression net |
+| **B. Literal SIGKILL** | spawn a real process, `kill -9` it *at* a boundary, relaunch, assert recovery | `scripts/crash-replay.sh` (separate CI target / manual) | the credibility anchor — a genuinely killed process, real `db_state.json`/WAL/tmp on disk, exit code 137 |
+
+Layer A is what `pentest.yml` / `cargo test` already does (see `startup_recovery_preserves_original_when_tmp_is_corrupt`, `apply_key_promotes_valid_pending_tmp_after_verification`). We **generalize and complete** it. Layer B is new and is the blog material.
+
+---
+
+## 3. The real crash boundaries (from `encrypt_in_place`)
+
+`encrypt_in_place(key, salt_b64)` in `db/mod.rs` already has documented crash-safety. Its boundaries,
+with the exact on-disk state and the required recovery outcome:
+
+| # | Boundary (after…) | code | On-disk state | Recovery must yield |
+|---|---|---|---|---|
+| B0 | before salt pre-write | ln 459 | plaintext db, no `db_state` salt | **old** (plaintext intact) |
+| B1 | salt written, `encrypted:false` | ln 459–465 | plaintext db + salt, no tmp | **old** (salt-only is harmless; migration re-runs) |
+| B2 | `sqlcipher_export` to tmp | ln 477 | plaintext db + **valid** `moodhaven_enc.db` + salt | **new**, via key-verified promotion in `apply_key` |
+| B2′ | export **interrupted** (truncated tmp) | ln 477 mid-write | plaintext db + **corrupt** tmp + salt | **old** — corrupt tmp must NOT clobber original (the SQLC-004 data-loss guard) |
+| B3 | `encrypted:true` written | ln 496–502 | valid tmp + `encrypted:true` | **new** (promotion completes) |
+| B4 | conn → in-memory placeholder | ln 504–511 | same on disk | **new** |
+| B5 | WAL/SHM removed | ln 516–525 | same | **new** |
+| B6 | rename tmp → final | ln 564–566 (unix) / 531–562 (win) | encrypted db at final path | **new** (fully migrated) |
+| B6′ | rename **interrupted** (win: original moved to backup, tmp not yet in place) | ln 540–555 | `moodhaven_old.db` + tmp | **old or new**, never lost — backup-restore path |
+
+B2′ and B6′ are the dangerous ones and already have partial coverage. The matrix makes all of B0–B6
+explicit and named.
+
+---
+
+## 4. Layer A — state-injection harness (`cargo test`)
+
+### 4.1 New test-support module: `db/crash_replay.rs` (`#[cfg(test)]`)
+
+Reusable helpers, so each boundary test is ~10 lines instead of ~40:
+
+- `fn seed_plaintext_db(dir, rows: &[(&str,&str)]) -> PathBuf` — real `Database::new` (full schema +
+  migrations) with known journal rows. (Mirrors the seeding in the existing tests.)
+- `fn inject_valid_tmp(db_path, key, salt_b64)` / `fn inject_corrupt_tmp(db_path, salt_b64)` —
+  produce the B2 / B2′ on-disk state.
+- `fn write_state(db_path, encrypted, salt)` — thin wrapper over `write_db_state`.
+- **The invariant assertions (the heart):**
+  - `assert_old_intact(db_path, expected_rows)` — opens **without** a key, all rows match.
+  - `assert_new_intact(db_path, key, expected_rows)` — opens **with** the key, all rows match.
+  - `assert_recovered_old_xor_new(db_path, key, expected_rows)` — exactly one of the above holds;
+    the file is never simultaneously broken/empty/half.
+- `fn boot(db_path) -> Database` / `fn boot_and_apply_key(db_path, key)` — drive `Database::new`
+  (startup recovery) and the `apply_key` deferred-promotion path.
+
+### 4.2 Complete the migration phase matrix
+
+One named `#[test]` per boundary in §3 (B0–B6, B2′, B6′), each: seed → inject boundary state →
+boot/recover → assert the required outcome. The two existing tests fold into this matrix (B2′ and B2
+respectively) using the shared helpers — no behavior change, just consolidation + the missing
+boundaries filled in. Output reads as a clean checklist:
+
+```
+test db::crash_replay::migration::b0_before_salt_write ... ok
+test db::crash_replay::migration::b1_salt_written_no_tmp ... ok
+test db::crash_replay::migration::b2_valid_tmp_promotes ... ok
+test db::crash_replay::migration::b2p_corrupt_tmp_preserves_original ... ok
+...
+test db::crash_replay::migration::b6p_rename_interrupted_backup_restore ... ok
+```
+
+### 4.3 Forward-looking `change_master_password` matrix (placeholders)
+
+`#[ignore = "pending change_master_password (active-plans/change-password.md)"]` stubs, one per
+future boundary from `change-password.md` §4 (inner-txn pre-commit, post-commit/pre-media,
+mid-media-swap, post-media/pre-rekey, post-rekey/pre-marker-clear). Each names its expected
+old-XOR-new outcome. Writing the test names before the feature is itself a strong blog beat
+("the crash tests existed before the code").
+
+---
+
+## 5. Layer B — literal SIGKILL subprocess harness (the anchor)
+
+### 5.1 `crash_point!` macro (debug-only, zero-cost in release)
+
+A tiny macro placed at each boundary inside the crash-safe operation:
+
+```rust
+// fires only in debug builds AND only when MH_CRASH_POINT matches; compiles to nothing in release
+crash_point!("encrypt.after_export");
+```
+
+Behavior when armed (debug + env match):
+- **park mode (default):** create the readiness file `$MH_CRASH_READY` then block forever
+  (`loop { sleep }`). The process is parked *exactly* at the boundary, dangerous step not yet done —
+  the parent then sends a real `SIGKILL`. This makes the kill **deterministic** (no timing race) while
+  remaining a genuine external `kill -9`.
+- **abort mode (`MH_CRASH_MODE=abort`):** `std::process::abort()` — for environments where the parent
+  can't signal (immediate uncatchable crash, no unwinding/flush; equivalent crash semantics).
+
+Gating: `#[cfg(debug_assertions)]` body; in release the macro expands to `()`. Belt-and-suspenders:
+also no-op unless `MH_CRASH_POINT` is set, so even a debug build is inert in normal use. **No release
+behavior change whatsoever.**
+
+Placed in `encrypt_in_place` at B1, B2, B3, B5, B6 (the points where a crash leaves a distinct
+on-disk state). Same macro is later dropped into `change_master_password` at its phase boundaries —
+that's the whole reuse story.
+
+### 5.2 `examples/crash_probe.rs`
+
+A cargo **example** (not bundled in the app) exposing two subcommands over the crate's public API:
+- `crash_probe seed <dir>` — build a seeded plaintext DB with a known sentinel row.
+- `crash_probe migrate <dir> <password>` — run the real unlock/`encrypt_in_place` path (honoring
+  `MH_CRASH_POINT`).
+- `crash_probe verify <dir> <password>` — boot (startup recovery) + assert `old XOR new` and that the
+  sentinel row survives; exit 0 on the invariant holding, non-zero otherwise.
+
+### 5.3 `scripts/crash-replay.sh`
+
+For each boundary in a list:
+1. fresh temp profile → `crash_probe seed`.
+2. `MH_CRASH_POINT=<b> crash_probe migrate &` → wait for `$MH_CRASH_READY` → `kill -9 $!` →
+   confirm exit status `137` (SIGKILL).
+3. `crash_probe verify` → record PASS/FAIL.
+4. print a table — **this table is the blog exhibit**:
+
+```
+boundary                    killed   recovered   sentinel
+encrypt.after_salt          SIGKILL  old         intact
+encrypt.after_export        SIGKILL  new         intact
+encrypt.after_state_true    SIGKILL  new         intact
+encrypt.before_rename       SIGKILL  old         intact
+encrypt.after_rename        SIGKILL  new         intact
+→ 5/5 boundaries: data survived a kill -9 at every step
+```
+
+### 5.4 Platform note
+
+`kill -9` semantics are Linux/macOS. The park-and-kill harness runs on the Linux CI lane (and macOS
+locally). On Windows the same boundaries are covered by Layer A state-injection (which already
+exercises the Windows-specific backup-restore rename path B6′). Document this split; don't fake
+Windows SIGKILL.
+
+---
+
+## 6. What this PR builds vs. defers
+
+**This branch/PR (`test/crash-replay-harness`) — when we build it:**
+- `crash_point!` macro (debug-only) + its placement in `encrypt_in_place`.
+- `db/crash_replay.rs` state-injection harness + complete migration matrix (Layer A).
+- `examples/crash_probe.rs` + `scripts/crash-replay.sh` (Layer B) proven against the migration.
+- CI: migration matrix in the existing `cargo test`; `crash-replay.sh` as a Linux CI step (or `make`
+  target) that fails the build if any boundary loses data.
+- The `change_master_password` placeholder matrix (ignored tests).
+
+**Deferred to the change-password feature PR:**
+- `crash_point!` placements inside `change_master_password` + un-ignoring its matrix + adding its
+  boundaries to `crash-replay.sh`.
+
+**Right now (this commit): planning only.** No code.
+
+---
+
+## 7. Risks & mitigations
+
+- **Instrumenting production code** (`crash_point!` in `encrypt_in_place`) — mitigated by
+  double-gating (`cfg(debug_assertions)` + env), expands to nothing in release; add a release-build
+  assertion/test that the macro is inert.
+- **Non-determinism of literal kill** — solved by park-and-kill (readiness file), not sleep-then-kill.
+- **Test flakiness from leftover temp profiles / WAL handles** — each case uses a fresh temp dir and
+  cleans up; mirror the existing tests' `remove_dir_all`.
+- **Scope creep into the feature** — this branch only touches the *existing* migration op; the
+  feature op is explicitly deferred.
+
+---
+
+## 8. Definition of done (for the build PR, later)
+
+- All §3 boundaries have a green Layer-A test; the two existing tests are folded in.
+- `scripts/crash-replay.sh` exits 0 with every boundary `recovered ∈ {old,new}` and `sentinel intact`,
+  and prints the exhibit table.
+- Release build proven to compile the macro to a no-op (no `MH_CRASH_*` effect).
+- `change_master_password` placeholder matrix present and `#[ignore]`d with descriptive names.
+- The exhibit table + the `cargo test` matrix output captured for the blog (`change-password.md` §11).

--- a/scripts/crash-replay.sh
+++ b/scripts/crash-replay.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# crash-replay.sh — Layer B of the crash-replay harness (the credibility anchor).
+#
+# For each crash boundary in encrypt_in_place, this:
+#   1. seeds a fresh plaintext DB with a known sentinel row,
+#   2. runs the real migration parked AT the boundary, sends a genuine `kill -9`,
+#      and confirms the process died with exit status 137 (SIGKILL),
+#   3. boots the recovery path and asserts the data is either fully old or fully new,
+#      with the sentinel row intact — never a half-state, never lost.
+#
+# It prints the exhibit table and exits non-zero if any boundary loses data, so it can
+# gate CI. `kill -9` is Linux/macOS only; the same boundaries are covered on Windows by
+# the Layer-A state-injection matrix (cargo test db::crash_replay).
+#
+# Usage: scripts/crash-replay.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAURI_DIR="$REPO_ROOT/src-tauri"
+BIN="$TAURI_DIR/target/debug/examples/crash_probe"
+PW="correct horse battery staple"
+
+# Boundaries to kill at, in migration order. The expected recovery (old/new) is reported
+# by the probe, not asserted here — the harness only requires old XOR new + sentinel intact.
+BOUNDARIES=(
+  encrypt.after_salt
+  encrypt.after_export
+  encrypt.after_state_true
+  encrypt.before_rename
+  encrypt.after_rename
+)
+
+echo "==> building crash_probe (debug)"
+( cd "$TAURI_DIR" && cargo build --example crash_probe ) || {
+  echo "build failed"; exit 1;
+}
+[ -x "$BIN" ] || { echo "probe binary not found at $BIN"; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/mh_crash_replay.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+declare -a ROWS
+FAILS=0
+
+for b in "${BOUNDARIES[@]}"; do
+  dir="$WORK/$b"
+  ready="$dir/ready"
+  mkdir -p "$dir"
+
+  "$BIN" seed "$dir" >/dev/null || { echo "seed failed for $b"; FAILS=$((FAILS+1)); continue; }
+
+  # Run the migration parked at this boundary; kill it once it signals readiness. The
+  # brace group's stderr is dropped so the shell's async "Killed" job notice (expected —
+  # we sent the SIGKILL) doesn't pollute the exhibit output.
+  killed="TIMEOUT"
+  {
+    MH_CRASH_POINT="$b" MH_CRASH_READY="$ready" "$BIN" migrate "$dir" "$PW" >/dev/null 2>&1 &
+    pid=$!
+    for _ in $(seq 1 200); do      # ~10s
+      if [ -f "$ready" ]; then
+        kill -9 "$pid" 2>/dev/null
+        wait "$pid"; status=$?
+        if [ "$status" -eq 137 ]; then killed="SIGKILL"; else killed="exit:$status"; fi
+        break
+      fi
+      if ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid"; killed="EXITED:$?"   # migrate finished without parking — harness error
+        break
+      fi
+      sleep 0.05
+    done
+    if [ "$killed" = "TIMEOUT" ]; then
+      kill -9 "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+    fi
+  } 2>/dev/null
+
+  # Recover + assert the invariant.
+  if out="$("$BIN" verify "$dir" "$PW")"; then
+    verdict="PASS"
+  else
+    verdict="FAIL"; FAILS=$((FAILS+1))
+  fi
+  recovered="$(printf '%s' "$out" | sed -n 's/.*recovered=\([a-z]*\).*/\1/p')"
+  sentinel="$(printf '%s' "$out" | sed -n 's/.*sentinel=\([A-Za-z]*\).*/\1/p')"
+  [ -n "$recovered" ] || recovered="?"
+  [ -n "$sentinel" ] || sentinel="?"
+  [ "$killed" = "SIGKILL" ] || FAILS=$((FAILS+1))
+
+  ROWS+=("$(printf '%-26s %-8s %-11s %-8s %s' "$b" "$killed" "$recovered" "$sentinel" "$verdict")")
+done
+
+echo
+printf '%-26s %-8s %-11s %-8s %s\n' "boundary" "killed" "recovered" "sentinel" "result"
+printf '%-26s %-8s %-11s %-8s %s\n' "--------" "------" "---------" "--------" "------"
+for r in "${ROWS[@]}"; do echo "$r"; done
+echo
+
+total=${#BOUNDARIES[@]}
+if [ "$FAILS" -eq 0 ]; then
+  echo "→ $total/$total boundaries: data survived a kill -9 at every step"
+  exit 0
+else
+  echo "→ $FAILS failure(s) across $total boundaries — see table above"
+  exit 1
+fi

--- a/src-tauri/examples/crash_probe.rs
+++ b/src-tauri/examples/crash_probe.rs
@@ -1,0 +1,186 @@
+//! crash_probe — Layer B subprocess for the crash-replay harness.
+//!
+//! Exposes the real seed / migrate / verify path over the crate's public API so
+//! `scripts/crash-replay.sh` can `kill -9` the `migrate` run *at* a boundary (via the
+//! `crash_point!` hooks in `encrypt_in_place`, armed with `MH_CRASH_POINT` /
+//! `MH_CRASH_READY`) and then prove startup recovery never loses data.
+//!
+//!   crash_probe seed    <dir>            — build a seeded plaintext DB + sentinel row
+//!   crash_probe migrate <dir> <password> — run the real encrypt_in_place (honors MH_CRASH_POINT)
+//!   crash_probe verify  <dir> <password> — boot + recover; exit 0 iff old XOR new, sentinel intact
+//!
+//! This is a cargo *example* (debug build), never bundled into the app.
+
+use moodhaven_journal_lib::db::{read_db_state, Database};
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+const SENTINEL_ID: &str = "sentinel";
+const SENTINEL_VAL: &str = "precious-original-data";
+/// Constant salt so the three separate processes derive the same key from a password.
+const PROBE_SALT: &[u8] = b"moodhaven-crash-probe-salt-v1";
+
+fn salt_b64() -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(PROBE_SALT)
+}
+
+/// Same PBKDF2-HMAC-SHA256 / 600k-iteration derivation the app uses at unlock.
+fn derive_key(password: &str) -> [u8; 32] {
+    use hmac::Hmac;
+    use sha2::Sha256;
+    let mut key = [0u8; 32];
+    pbkdf2::pbkdf2::<Hmac<Sha256>>(password.as_bytes(), PROBE_SALT, 600_000, &mut key)
+        .expect("pbkdf2");
+    key
+}
+
+fn db_path(dir: &str) -> PathBuf {
+    Path::new(dir).join("moodhaven.db")
+}
+
+fn cmd_seed(dir: &str) {
+    let _ = std::fs::create_dir_all(dir);
+    let path = db_path(dir);
+    let db = Database::new(path.clone()).expect("seed: Database::new");
+    {
+        let conn = db.conn.lock().expect("seed: lock");
+        conn.execute(
+            "INSERT INTO journal_entries (id, encrypted_content, mood, created_at, updated_at)
+             VALUES (?1, ?2, 3, datetime('now'), datetime('now'))",
+            rusqlite::params![SENTINEL_ID, SENTINEL_VAL],
+        )
+        .expect("seed: insert sentinel row");
+    }
+    println!("seeded plaintext DB at {}", path.display());
+}
+
+fn cmd_migrate(dir: &str, password: &str) {
+    let path = db_path(dir);
+    let db = Database::new(path).expect("migrate: Database::new");
+    let key = derive_key(password);
+    // encrypt_in_place fires crash_point!(...) at each boundary; if MH_CRASH_POINT is
+    // armed the process parks there (and kill -9 lands) and this call never returns.
+    db.encrypt_in_place(&key, &salt_b64())
+        .expect("migrate: encrypt_in_place");
+    println!("migration completed without hitting a crash point");
+}
+
+fn plaintext_has_sentinel(path: &Path) -> bool {
+    Connection::open(path)
+        .ok()
+        .and_then(|c| {
+            c.query_row(
+                "SELECT encrypted_content FROM journal_entries WHERE id = ?1",
+                [SENTINEL_ID],
+                |r| r.get::<_, String>(0),
+            )
+            .ok()
+        })
+        .map(|v| v == SENTINEL_VAL)
+        .unwrap_or(false)
+}
+
+fn keyed_has_sentinel(path: &Path, hex_key: &str) -> bool {
+    let c = match Connection::open(path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    if c.execute_batch(&format!("PRAGMA key = \"x'{hex_key}'\";"))
+        .is_err()
+    {
+        return false;
+    }
+    c.query_row(
+        "SELECT encrypted_content FROM journal_entries WHERE id = ?1",
+        [SENTINEL_ID],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+    .map(|v| v == SENTINEL_VAL)
+    .unwrap_or(false)
+}
+
+enum Rec {
+    Old,
+    New,
+}
+
+/// Drive the real recovery: boot, and if it routes to the encrypted path, apply the key
+/// (key-verified promotion). On the corrupt-tmp revert, re-boot once like a retry unlock.
+fn recover(path: &Path, key: &[u8; 32]) -> Rec {
+    let db = Database::new(path.to_path_buf()).expect("verify: Database::new");
+    if read_db_state(path).encrypted {
+        match db.apply_key(key) {
+            Ok(()) => {
+                drop(db);
+                Rec::New
+            }
+            Err(_) => {
+                drop(db);
+                let _ = Database::new(path.to_path_buf()).expect("verify: re-boot after revert");
+                Rec::Old
+            }
+        }
+    } else {
+        drop(db);
+        Rec::Old
+    }
+}
+
+fn cmd_verify(dir: &str, password: &str) -> ! {
+    let path = db_path(dir);
+    let key = derive_key(password);
+    let hex_key = hex::encode(key);
+
+    let rec = recover(&path, &key);
+    let old = plaintext_has_sentinel(&path);
+    let new = keyed_has_sentinel(&path, &hex_key);
+
+    let (which, sentinel) = match rec {
+        Rec::Old => ("old", old),
+        Rec::New => ("new", new),
+    };
+    // Invariant: exactly one form is readable (no mixed/half state) AND the sentinel
+    // survived in the form we recovered into.
+    let ok = sentinel && (old ^ new);
+    println!(
+        "recovered={which} sentinel={}",
+        if sentinel { "intact" } else { "LOST" }
+    );
+    if ok {
+        exit(0);
+    }
+    eprintln!("INVARIANT VIOLATED: old={old} new={new} (must be exactly one, sentinel intact)");
+    exit(1);
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let usage = || -> ! {
+        eprintln!("usage: crash_probe <seed|migrate|verify> <dir> [password]");
+        exit(2);
+    };
+    match args.get(1).map(String::as_str) {
+        Some("seed") => {
+            let dir = args.get(2).unwrap_or_else(|| usage());
+            cmd_seed(dir);
+        }
+        Some("migrate") => {
+            let (dir, pw) = match (args.get(2), args.get(3)) {
+                (Some(d), Some(p)) => (d, p),
+                _ => usage(),
+            };
+            cmd_migrate(dir, pw);
+        }
+        Some("verify") => {
+            let (dir, pw) = match (args.get(2), args.get(3)) {
+                (Some(d), Some(p)) => (d, p),
+                _ => usage(),
+            };
+            cmd_verify(dir, pw);
+        }
+        _ => usage(),
+    }
+}

--- a/src-tauri/src/db/crash_replay.rs
+++ b/src-tauri/src/db/crash_replay.rs
@@ -1,0 +1,418 @@
+//! Crash-replay test harness — Layer A (state injection).
+//!
+//! Proves the one invariant for every operation that rewrites the encrypted DB:
+//! after a crash at any boundary and the next startup recovery, the database is
+//! **either fully in the pre-operation state OR fully in the post-operation state —
+//! never a mix, never unreadable, never empty.**
+//!
+//! Each boundary test constructs the exact on-disk intermediate state a crash leaves
+//! behind (the helpers below), drives the real `Database::new` startup recovery plus the
+//! `apply_key` deferred-promotion path, and asserts `old XOR new` with the sentinel row
+//! intact. This is the same convention the two original ad-hoc tests in `mod.rs` used,
+//! generalized into a complete, named phase matrix for `encrypt_in_place`.
+//!
+//! Layer B (a literal `kill -9` against the same boundaries) lives in
+//! `examples/crash_probe.rs` + `scripts/crash-replay.sh`.
+
+use super::{read_db_state, write_db_state, Database, DbStateFile};
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/// The known journal row every boundary test seeds and then re-reads. If recovery
+/// loses or half-writes data, this row goes missing or unreadable.
+const SENTINEL_ID: &str = "sentinel";
+const SENTINEL_VAL: &str = "precious-original-data";
+/// base64("test-salt") — stand-in for the PBKDF2 salt pre-written by `encrypt_in_place`.
+const SALT_B64: &str = "dGVzdC1zYWx0";
+
+/// A deterministic 32-byte key and its hex form (the raw `x'..'` SQLCipher key).
+fn test_key() -> ([u8; 32], String) {
+    let mut k = [0u8; 32];
+    for (i, b) in k.iter_mut().enumerate() {
+        *b = (i as u8).wrapping_mul(7).wrapping_add(1);
+    }
+    let hex = hex::encode(k);
+    (k, hex)
+}
+
+/// Fresh, isolated temp profile dir per test (mirrors the existing tests' cleanup).
+fn fresh_dir(tag: &str) -> PathBuf {
+    let base = std::env::temp_dir().join(format!("mh_cr_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).expect("create temp profile dir");
+    base
+}
+
+// ── State-injection helpers (build a boundary's exact on-disk state) ─────────
+
+/// Seed a real plaintext DB (full schema + migrations via `Database::new`) with the
+/// known sentinel row. Leaves no `db_state.json` — callers write the boundary state.
+fn seed_plaintext_db(db_path: &Path) {
+    let seed = Database::new(db_path.to_path_buf()).expect("seed plaintext DB");
+    {
+        let conn = seed.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO journal_entries (id, encrypted_content, mood, created_at, updated_at)
+             VALUES (?1, ?2, 3, datetime('now'), datetime('now'))",
+            rusqlite::params![SENTINEL_ID, SENTINEL_VAL],
+        )
+        .expect("insert sentinel row");
+    }
+    drop(seed);
+}
+
+/// Produce a VALID encrypted `moodhaven_enc.db` from the seeded plaintext DB — the B2/B3
+/// on-disk state where `sqlcipher_export` completed before the crash.
+fn inject_valid_tmp(db_path: &Path, hex_key: &str) {
+    let tmp = db_path.with_file_name("moodhaven_enc.db");
+    let _ = std::fs::remove_file(&tmp);
+    let c = Connection::open(db_path).expect("open plaintext to export");
+    let tmp_str = tmp.to_str().unwrap();
+    c.execute_batch(&format!(
+        "ATTACH DATABASE '{tmp_str}' AS encrypted KEY \"x'{hex_key}'\";
+         SELECT sqlcipher_export('encrypted');
+         DETACH DATABASE encrypted;"
+    ))
+    .expect("sqlcipher_export to valid tmp");
+}
+
+/// Produce a TRUNCATED/garbage `moodhaven_enc.db` — the B2′ on-disk state where the
+/// process was killed mid-export. Must never clobber the intact original (SQLC-004).
+fn inject_corrupt_tmp(db_path: &Path) {
+    let tmp = db_path.with_file_name("moodhaven_enc.db");
+    std::fs::write(&tmp, b"\x00\x01corrupt-truncated-not-a-db\xff\xfe").expect("write corrupt tmp");
+}
+
+/// Thin wrapper over `write_db_state` for boundary setup.
+fn write_state(db_path: &Path, encrypted: bool, salt: Option<&str>) {
+    write_db_state(
+        db_path,
+        &DbStateFile {
+            encrypted,
+            salt: salt.map(str::to_string),
+        },
+    )
+    .expect("write db_state.json");
+}
+
+// ── The invariant (the heart of the harness) ────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Recovered {
+    Old,
+    New,
+}
+
+/// True if the file at `db_path` is a plaintext DB still serving the sentinel row.
+fn plaintext_has_sentinel(db_path: &Path) -> bool {
+    Connection::open(db_path)
+        .ok()
+        .and_then(|c| {
+            c.query_row(
+                "SELECT encrypted_content FROM journal_entries WHERE id = ?1",
+                [SENTINEL_ID],
+                |r| r.get::<_, String>(0),
+            )
+            .ok()
+        })
+        .map(|v| v == SENTINEL_VAL)
+        .unwrap_or(false)
+}
+
+/// True if the file at `db_path` is an encrypted DB serving the sentinel row under `key`.
+fn keyed_has_sentinel(db_path: &Path, hex_key: &str) -> bool {
+    Database::open_keyed(db_path, hex_key)
+        .ok()
+        .and_then(|c| {
+            c.query_row(
+                "SELECT encrypted_content FROM journal_entries WHERE id = ?1",
+                [SENTINEL_ID],
+                |r| r.get::<_, String>(0),
+            )
+            .ok()
+        })
+        .map(|v| v == SENTINEL_VAL)
+        .unwrap_or(false)
+}
+
+/// Drive the REAL recovery path: `Database::new` (startup recovery) and, if it routes to
+/// the encrypted path, `apply_key` (deferred key-verified promotion). On a corrupt-tmp
+/// revert (`apply_key` returns the "unlock again" error), re-boot once — exactly what the
+/// app does when the user retries the unlock — and resolve against the restored plaintext.
+fn recover(db_path: &Path, key: &[u8; 32]) -> Recovered {
+    let db = Database::new(db_path.to_path_buf()).expect("Database::new must not fail on recovery");
+    if read_db_state(db_path).encrypted {
+        match db.apply_key(key) {
+            Ok(()) => {
+                drop(db);
+                Recovered::New
+            }
+            Err(_) => {
+                // apply_key key-verified a corrupt tmp, discarded it, and reverted
+                // db_state to plaintext. The retry boot opens the intact original.
+                drop(db);
+                let again =
+                    Database::new(db_path.to_path_buf()).expect("re-boot after corrupt-tmp revert");
+                drop(again);
+                Recovered::Old
+            }
+        }
+    } else {
+        drop(db);
+        Recovered::Old
+    }
+}
+
+/// Run recovery, then assert the invariant: exactly one of {old plaintext, new encrypted}
+/// is readable with the sentinel intact, and the *other* form is NOT also readable (no
+/// mixed/half state). Returns which state we recovered into so the test can assert intent.
+fn assert_invariant(db_path: &Path, key: &[u8; 32], hex_key: &str) -> Recovered {
+    let rec = recover(db_path, key);
+    let tmp = db_path.with_file_name("moodhaven_enc.db");
+    match rec {
+        Recovered::Old => {
+            assert!(
+                plaintext_has_sentinel(db_path),
+                "recovered=old: plaintext original must serve the sentinel row"
+            );
+            assert!(
+                !keyed_has_sentinel(db_path, hex_key),
+                "recovered=old: the DB must NOT also be readable as encrypted (mixed state)"
+            );
+        }
+        Recovered::New => {
+            assert!(
+                !tmp.exists(),
+                "recovered=new: the pending tmp must be promoted away"
+            );
+            assert!(
+                keyed_has_sentinel(db_path, hex_key),
+                "recovered=new: encrypted DB must serve the sentinel row"
+            );
+            assert!(
+                !plaintext_has_sentinel(db_path),
+                "recovered=new: the DB must NOT also be readable as plaintext (mixed state)"
+            );
+        }
+    }
+    rec
+}
+
+// ── Migration phase matrix (encrypt_in_place, B0–B6 + B2′ + B6′) ─────────────
+
+mod migration {
+    use super::*;
+
+    // B0 — crash before the salt pre-write: plaintext DB, no db_state, no tmp.
+    // The migration simply never started → recover to the intact plaintext original.
+    #[test]
+    fn b0_before_salt_write() {
+        let base = fresh_dir("b0");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::Old);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B1 — crash after the salt was pre-written but before the export created any tmp:
+    // plaintext DB + db_state{encrypted:false, salt}, no tmp. Salt-only is harmless; the
+    // migration re-runs next time → recover to the intact plaintext original.
+    #[test]
+    fn b1_salt_written_no_tmp() {
+        let base = fresh_dir("b1");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        write_state(&db, false, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::Old);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B2 — crash after a VALID export, before the encrypted:true write: plaintext DB +
+    // valid tmp + db_state{encrypted:false, salt}. Startup flips db_state to encrypted:true
+    // and apply_key key-verifies + promotes the tmp → recover to the new encrypted DB.
+    #[test]
+    fn b2_valid_tmp_promotes() {
+        let base = fresh_dir("b2");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        write_state(&db, false, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B2′ — crash mid-export leaves a CORRUPT/truncated tmp next to the intact plaintext
+    // DB (db_state{encrypted:false, salt}). The corrupt tmp must NOT clobber the original
+    // (the SQLC-004 data-loss guard) → recover to the intact plaintext original.
+    // This folds in the original `startup_recovery_preserves_original_when_tmp_is_corrupt`.
+    #[test]
+    fn b2p_corrupt_tmp_preserves_original() {
+        let base = fresh_dir("b2p");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_corrupt_tmp(&db);
+        write_state(&db, false, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::Old);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B3 — crash after the encrypted:true write, before the conn placeholder swap:
+    // valid tmp + db_state{encrypted:true, salt}. Startup defers, apply_key promotes the
+    // verified tmp → recover to the new encrypted DB.
+    // This folds in the original `apply_key_promotes_valid_pending_tmp_after_verification`.
+    #[test]
+    fn b3_state_true_valid_tmp_promotes() {
+        let base = fresh_dir("b3");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        write_state(&db, true, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B4 — crash after the conn → in-memory placeholder swap. On-disk state is identical
+    // to B3 (the swap is in-memory only), so a fresh process recovers identically → new.
+    #[test]
+    fn b4_conn_placeholder_swapped() {
+        let base = fresh_dir("b4");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        write_state(&db, true, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B5 — crash after the original's stale WAL/SHM were removed, before the rename. The
+    // removed sidecars belong to the about-to-be-discarded plaintext original, so the
+    // on-disk recovery state still matches B3 → new.
+    #[test]
+    fn b5_wal_removed_before_rename() {
+        let base = fresh_dir("b5");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        // Simulate the original's WAL/SHM having been swept just before the rename.
+        let _ = std::fs::remove_file(db.with_extension("db-wal"));
+        let _ = std::fs::remove_file(db.with_extension("db-shm"));
+        write_state(&db, true, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B6 — crash after the rename completed: the encrypted DB is live at moodhaven.db,
+    // no tmp, db_state{encrypted:true, salt}. apply_key opens the on-disk file directly →
+    // recover to the new encrypted DB (the fully-migrated steady state).
+    #[test]
+    fn b6_rename_done() {
+        let base = fresh_dir("b6");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        // Complete the rename: the encrypted tmp becomes the live DB.
+        std::fs::rename(db.with_file_name("moodhaven_enc.db"), &db).expect("promote rename");
+        write_state(&db, true, Some(SALT_B64));
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // B6′ — crash in the backup-and-rename window: the original was moved aside to
+    // moodhaven_old.db and the encrypted tmp is not yet in place (moodhaven.db absent),
+    // db_state{encrypted:true, salt}. Startup restores the backup, then apply_key promotes
+    // the verified tmp → recover to the new encrypted DB, never losing data.
+    #[test]
+    fn b6p_rename_interrupted_backup_restore() {
+        let base = fresh_dir("b6p");
+        let db = base.join("moodhaven.db");
+        let (key, hex) = test_key();
+
+        seed_plaintext_db(&db);
+        inject_valid_tmp(&db, &hex);
+        write_state(&db, true, Some(SALT_B64));
+        // Simulate the window: original moved to backup, tmp not yet renamed into place.
+        std::fs::rename(&db, db.with_file_name("moodhaven_old.db")).expect("move original aside");
+        assert!(
+            !db.exists(),
+            "precondition: live DB is absent in the backup window"
+        );
+
+        assert_eq!(assert_invariant(&db, &key, &hex), Recovered::New);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}
+
+// ── Forward-looking change_master_password matrix (placeholders) ─────────────
+//
+// One #[ignore]d stub per future boundary from active-plans/change-password.md §4. They
+// name the boundary and its expected old-XOR-new outcome BEFORE the feature exists; the
+// change-password PR drops `crash_point!`s at these boundaries and un-ignores each test.
+mod change_master_password {
+    const PENDING: &str = "pending change_master_password (active-plans/change-password.md)";
+
+    // Inner txn (entries + signals + TOTP + verifier) not yet committed: SQLite rolled it
+    // back → data is wholly on the OLD password (outer + inner). Recover = old.
+    #[test]
+    #[ignore = "pending change_master_password (active-plans/change-password.md)"]
+    fn cmp_b0_inner_txn_pre_commit_recovers_old() {
+        unimplemented!("{PENDING} — expected recovered=old (txn rolled back)");
+    }
+
+    // Inner txn committed (inner layer on NEW password) but media/rekey not started: the
+    // pending marker drives resume forward → recover = new.
+    #[test]
+    #[ignore = "pending change_master_password (active-plans/change-password.md)"]
+    fn cmp_b1_post_commit_pre_media_recovers_new() {
+        unimplemented!("{PENDING} — expected recovered=new (resume media + rekey)");
+    }
+
+    // Crash mid media-file swap: per-file progress in the marker lets recovery resume the
+    // remaining files, then finish the rekey → recover = new.
+    #[test]
+    #[ignore = "pending change_master_password (active-plans/change-password.md)"]
+    fn cmp_b2_mid_media_swap_recovers_new() {
+        unimplemented!("{PENDING} — expected recovered=new (resume from media progress)");
+    }
+
+    // All media re-encrypted, outer SQLCipher rekey not yet applied: resume the rekey from
+    // the marker (new salt recorded) → recover = new.
+    #[test]
+    #[ignore = "pending change_master_password (active-plans/change-password.md)"]
+    fn cmp_b3_post_media_pre_rekey_recovers_new() {
+        unimplemented!("{PENDING} — expected recovered=new (resume outer rekey)");
+    }
+
+    // Rekey applied, pending marker not yet cleared: clearing the marker is idempotent →
+    // recover = new.
+    #[test]
+    #[ignore = "pending change_master_password (active-plans/change-password.md)"]
+    fn cmp_b4_post_rekey_pre_marker_clear_recovers_new() {
+        unimplemented!("{PENDING} — expected recovered=new (idempotent marker clear)");
+    }
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -18,6 +18,9 @@ pub mod signals;
 pub mod still;
 pub mod voice_memos;
 
+#[cfg(test)]
+mod crash_replay;
+
 pub use analytics::*;
 pub use books::*;
 pub use journal::*;
@@ -63,6 +66,61 @@ fn write_db_state(db_path: &Path, state: &DbStateFile) -> Result<(), String> {
 }
 
 // ============================================================================
+// Crash-replay harness hook (Layer B — literal SIGKILL)
+// ============================================================================
+
+/// Crash-injection hook for the crash-replay test harness (`scripts/crash-replay.sh`).
+///
+/// Debug-only and inert by default: it does nothing unless the `MH_CRASH_POINT`
+/// environment variable is set and exactly matches `label`. When armed it stops the
+/// process *at this exact boundary* so an external `kill -9` lands deterministically:
+///
+/// - **park mode (default):** create the readiness file named by `MH_CRASH_READY`
+///   (so the parent knows the dangerous step has not yet run), then block forever.
+///   The parent then sends a genuine `SIGKILL`.
+/// - **abort mode (`MH_CRASH_MODE=abort`):** `std::process::abort()` immediately —
+///   for environments where the parent cannot signal the child.
+///
+/// There is NO release-build effect: `crash_point!` compiles this call out entirely in
+/// release (`debug_assertions` off), and even in debug it is a no-op unless armed.
+#[cfg(debug_assertions)]
+pub fn crash_inject(label: &str) {
+    match std::env::var("MH_CRASH_POINT") {
+        Ok(want) if want == label => {}
+        _ => return,
+    }
+    log::warn!("[crash_point] armed boundary reached: {label}");
+    if let Ok(ready) = std::env::var("MH_CRASH_READY") {
+        if !ready.is_empty() {
+            let _ = std::fs::write(&ready, label.as_bytes());
+        }
+    }
+    if std::env::var("MH_CRASH_MODE").ok().as_deref() == Some("abort") {
+        std::process::abort();
+    }
+    // Park at the boundary; the harness sends SIGKILL. Sleep in long ticks — the
+    // process is killed externally, so this loop never exits on its own.
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}
+
+/// Fire a named crash boundary for the crash-replay harness.
+///
+/// Expands to nothing in release builds (gated on `debug_assertions`); in debug builds
+/// it is still inert unless `MH_CRASH_POINT` matches the label (see [`crash_inject`]).
+macro_rules! crash_point {
+    ($label:expr) => {{
+        #[cfg(debug_assertions)]
+        $crate::db::crash_inject($label);
+    }};
+}
+// Re-exported for reuse by the change_master_password feature PR, which will drop the
+// same macro at its phase boundaries (active-plans/change-password.md §7).
+#[allow(unused_imports)]
+pub(crate) use crash_point;
+
+// ============================================================================
 // User settings row
 // ============================================================================
 
@@ -86,6 +144,22 @@ impl Database {
     /// call `apply_key()` after the user authenticates before the connection is usable.
     pub fn new(db_path: PathBuf) -> Result<Self, String> {
         let mut state = read_db_state(&db_path);
+
+        // Recovery (B6′ — interrupted rename): the Windows backup-and-rename window in
+        // encrypt_in_place / atomic_promote moves the original aside to moodhaven_old.db
+        // before renaming the encrypted tmp into place. A crash in that window can leave
+        // moodhaven.db absent while the backup survives. If the live DB is missing but the
+        // backup exists, restore it so the normal tmp / key-verified promotion below can run.
+        // Cross-platform safe: it fires only when the live file is absent AND a backup is
+        // present, so it never clobbers an already-promoted encrypted DB.
+        let backup_path = db_path.with_file_name("moodhaven_old.db");
+        if !db_path.exists() && backup_path.exists() {
+            log::warn!(
+                "[sqlcipher] moodhaven.db missing but moodhaven_old.db backup present — \
+                 restoring backup (interrupted-rename recovery, B6′)"
+            );
+            let _ = std::fs::rename(&backup_path, &db_path);
+        }
 
         // Recovery: if moodhaven_enc.db exists, a previous migration was interrupted.
         // Determine how far it got based on the salt pre-write and encrypted flag.
@@ -463,6 +537,7 @@ impl Database {
                 salt: Some(salt_b64.to_string()),
             },
         )?;
+        crash_point!("encrypt.after_salt");
 
         // 1. Flush WAL and export to encrypted tmp file (hold conn lock for this block)
         {
@@ -489,6 +564,7 @@ impl Database {
                 .execute_batch("SELECT count(*) FROM sqlite_master;")
                 .map_err(|_| "encrypted db unreadable after export".to_string())?;
         }
+        crash_point!("encrypt.after_export");
 
         // 3. Write db_state.json BEFORE releasing the file handle. This must happen before
         //    the rename: if a crash occurs between here and step 6, Database::new() will
@@ -500,6 +576,7 @@ impl Database {
                 salt: Some(salt_b64.to_string()),
             },
         )?;
+        crash_point!("encrypt.after_state_true");
 
         // 4. Release the original file by replacing the conn with an in-memory placeholder
         {
@@ -523,6 +600,7 @@ impl Database {
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+        crash_point!("encrypt.before_rename");
 
         // 6. Rename encrypted tmp to final path.
         //    On Windows, rename fails if the destination exists — move the original to a
@@ -586,6 +664,7 @@ impl Database {
             }
             return Err(e);
         }
+        crash_point!("encrypt.after_rename");
 
         // 7. Open final keyed connection to the encrypted file
         {
@@ -1145,6 +1224,19 @@ pub fn is_2fa_enabled(db: &Database) -> Result<bool, String> {
 #[cfg(test)]
 mod sqlcipher_key_tests {
     use rusqlite::Connection;
+
+    // Release-build inertness guard (crash-replay harness DoD): in release the
+    // `crash_point!` macro must expand to nothing, so even an armed `MH_CRASH_POINT`
+    // can neither park nor abort. Compiled only under `cargo test --release`; if the
+    // macro were active here it would block forever and hang the test run.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn crash_point_is_inert_in_release() {
+        std::env::set_var("MH_CRASH_POINT", "encrypt.after_salt");
+        super::crash_point!("encrypt.after_salt");
+        std::env::remove_var("MH_CRASH_POINT");
+        // Reaching this line proves the boundary did not park or abort in release.
+    }
 
     // Regression guard for the SQLCipher key-application bug: the DB is encrypted
     // with a RAW key via `ATTACH ... KEY "x'<hex>'"`, so it MUST be read back with


### PR DESCRIPTION
## What

Builds the **crash-replay test harness** against the existing crash-safe SQLCipher migration (`encrypt_in_place`), per `active-plans/crash-replay-harness.md`. This is the credibility anchor for the upcoming change-password blog post — the same role packet captures played in the self-pentest series.

The one invariant, asserted everywhere: **after a crash at any boundary and the next startup recovery, the DB is either fully in the pre-op state OR fully in the post-op state — never a mix, never unreadable, never empty.**

## Two layers

**Layer A — state-injection matrix** (`src-tauri/src/db/crash_replay.rs`, runs in `cargo test`)
- 9 named boundary tests `b0`–`b6` + `b2′`/`b6′`: seed → inject the exact on-disk crash state → drive real `Database::new` + `apply_key` recovery → assert `old XOR new`, sentinel intact.
- The two prior ad-hoc tests fold in as `b2p` / `b3`.
- 5 `#[ignore]`d `change_master_password::cmp_b*` placeholders naming the future feature's boundaries before the code exists.

**Layer B — literal `kill -9`** (`scripts/crash-replay.sh` + `examples/crash_probe.rs`)
- `crash_point!` macro (debug-only, double-gated on `MH_CRASH_POINT`) at 5 boundaries in `encrypt_in_place`, parks the process so an external SIGKILL lands deterministically.
- Script kills each boundary, confirms exit 137, prints the exhibit table.

```
boundary                   killed   recovered   sentinel result
encrypt.after_salt         SIGKILL  old         intact   PASS
encrypt.after_export       SIGKILL  new         intact   PASS
encrypt.after_state_true   SIGKILL  new         intact   PASS
encrypt.before_rename      SIGKILL  new         intact   PASS
encrypt.after_rename       SIGKILL  new         intact   PASS
→ 5/5 boundaries: data survived a kill -9 at every step
```

## Also

- `Database::new`: restore `moodhaven_old.db` when the live DB is absent (B6′ interrupted-rename recovery) — closes a data-loss gap the harness exposed. Cross-platform-safe; fires only in the crashed-backup window.
- `crash_point_is_inert_in_release` (`#[cfg(not(debug_assertions))]`) proves the macro compiles to a no-op in release (verified under `cargo test --release`).
- Wired the SIGKILL harness into `.github/workflows/test.yml` (Linux-only; Windows boundaries covered by Layer A).

## Verification

- `cargo test`: 214 passed, 5 ignored, 0 failed.
- `scripts/crash-replay.sh`: 5/5 SIGKILL boundaries survive.
- `cargo fmt --check`, `cargo clippy --all-targets`: clean.
- No release behavior change — macro is double-gated and inert outside debug + armed env.

## Not included (deferred to the change-password feature PR)

`crash_point!` placements inside `change_master_password`, un-ignoring its `cmp_b*` matrix, and adding its boundaries to `crash-replay.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
