### PR TITLE
fix(security): resolve CodeQL workflow-permissions and markdown sanitization alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ─────────────────────────────────────────────
   # Frontend: TypeScript type-check + unit tests

--- a/src/lib/utils/markdownUtils.ts
+++ b/src/lib/utils/markdownUtils.ts
@@ -39,17 +39,23 @@ export function htmlToMarkdown(html: string): string {
   // Paragraphs
   md = md.replace(/<p[^>]*>(.*?)<\/p>/gi, '$1\n\n');
 
-  // Strip remaining tags
-  md = md.replace(/<[^>]+>/g, '');
+  // Strip remaining tags — loop until stable so overlapping brackets
+  // (e.g. `<scr<script>ipt>`) can't reassemble into a tag after one pass.
+  let prev: string;
+  do {
+    prev = md;
+    md = md.replace(/<[^>]+>/g, '');
+  } while (md !== prev);
 
-  // Decode common HTML entities
+  // Decode common HTML entities — `&amp;` last, so `&amp;lt;` does not
+  // double-unescape into `<`.
   md = md
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&');
 
   // Collapse 3+ newlines to 2
   md = md.replace(/\n{3,}/g, '\n\n');
@@ -60,17 +66,26 @@ export function htmlToMarkdown(html: string): string {
 /** Strip all HTML tags and return plain text. */
 export function htmlToPlainText(html: string): string {
   if (!html) return '';
-  return html
+  let text = html
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<p[^>]*>/gi, '')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&')
+    .replace(/<\/p>/gi, '\n');
+
+  // Strip tags until stable (see htmlToMarkdown for the overlap rationale).
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(/<[^>]+>/g, '');
+  } while (text !== prev);
+
+  // Decode entities — `&amp;` last to avoid double-unescaping.
+  return text
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
     .trim();
 }
 


### PR DESCRIPTION
Addresses the CodeQL code-scanning advisories. Of 32 alerts, 25 were false positives (dismissed via API with documented reasons) and 7 were minor genuine issues fixed here.

## Fixes (7 alerts)
- **`.github/workflows/test.yml`** — add top-level `permissions: contents: read` for least-privilege `GITHUB_TOKEN`. Resolves the 3 `actions/missing-workflow-permissions` alerts. The `secrets` job keeps its own narrower override.
- **`src/lib/utils/markdownUtils.ts`** — resolves 4 alerts (`incomplete-multi-character-sanitization` ×2, `double-escaping` ×2):
  - Strip tags iteratively (loop until stable) so overlapping brackets like `<scr<script>ipt>` can't reassemble into a tag after a single pass.
  - Decode `&amp;` **last** so `&amp;lt;` does not double-unescape into `<`.

## Dismissed as false positives (25 alerts, no code change)
- **17 × `rust/hard-coded-cryptographic-value`** — test fixtures inside `#[cfg(test)] mod tests` (two_factor / journal / data_management / lib). Reason: *used in tests*.
- **3 × same rule** — `[0u8; N]` buffers immediately overwritten by `OsRng.fill_bytes()` (pin_unlock, media, peer_sync_engine). Salt/nonce/challenge is random at runtime; CodeQL doesn't track the fill. Reason: *false positive*.
- **4 × `js/stored-xss`** (website `/blog/${slug}` hrefs) — slug comes from author-controlled MDX filenames and the href is always `/blog/`-prefixed, so it can never be a `javascript:` URI. Reason: *false positive*.
- **1 × `js/prototype-pollution`** (`settingsService.setByPath`) — path comes only from the hard-coded `SENSITIVE_PATHS` constant, never user input. Reason: *false positive*.

Net: **0 real critical/high vulnerabilities.**

## Verification
- `npx tsc --noEmit` — clean
- `vitest run src/lib/utils` — 218 passed
- `test.yml` — valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)