### PR TITLE
fix(web): repair WritingView crash on browser build

### DIFF
--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -112,6 +112,10 @@ export function RichTextEditor({
           keepMarks: true,
           keepAttributes: false,
         },
+        // StarterKit v3 bundles Link + Underline; disable so the explicitly
+        // configured extensions below win (avoids duplicate-name warning).
+        link: false,
+        underline: false,
       }),
       Underline,
       TaskList,

--- a/src/lib/backend/browser-invoke.test.ts
+++ b/src/lib/backend/browser-invoke.test.ts
@@ -290,3 +290,17 @@ describe('session lock gate (data commands — PT7 default-deny parity)', () => 
     await invoke('lock_app');
   });
 });
+
+// ---------------------------------------------------------------------------
+// pin_* — desktop-only stubs (no "unhandled command" warning in browser)
+// ---------------------------------------------------------------------------
+
+describe('PIN unlock browser stubs', () => {
+  it('pin_is_enabled returns false', async () => {
+    expect(await invoke<boolean>('pin_is_enabled')).toBe(false);
+  });
+
+  it('pin_unlock throws a desktop-only error', async () => {
+    await expect(invoke('pin_unlock', { pin: '1234' })).rejects.toThrow(/desktop app/);
+  });
+});

--- a/src/lib/backend/browser-invoke.ts
+++ b/src/lib/backend/browser-invoke.ts
@@ -478,6 +478,15 @@ async function dispatch(command: string, p: Params): Promise<any> {
       return null;
     }
 
+    // PIN unlock — not supported in browser build (no OS-backed secure storage)
+    case 'pin_is_enabled':
+      return false;
+    case 'pin_setup':
+    case 'pin_disable':
+      return undefined;
+    case 'pin_unlock':
+      throw new Error('PIN unlock requires the desktop app');
+
     // -----------------------------------------------------------------------
     // Unsupported in browser — Tauri-only features
     // -----------------------------------------------------------------------

--- a/src/lib/services/settingsService.test.ts
+++ b/src/lib/services/settingsService.test.ts
@@ -60,6 +60,18 @@ describe('settingsService', () => {
       mockInvoke.mockResolvedValue('not valid json');
       await expect(loadSettings()).resolves.toEqual(createDefaultSettings());
     });
+
+    it('deep-merges nested defaults absent from an older stored blob', async () => {
+      // A blob from a build that predates writing appearance: `appearance`
+      // exists but lacks the nested `writing` key. A shallow merge would drop
+      // `appearance.writing`, crashing WritingView on `writing.fontFamily`.
+      const stored = { appearance: { theme: 'dark', compactMode: true } };
+      mockInvoke.mockResolvedValue(JSON.stringify(stored));
+      const result = await loadSettings();
+      expect(result.appearance.writing).toEqual(createDefaultSettings().appearance.writing);
+      expect(result.appearance.theme).toBe('dark');
+      expect(result.appearance.compactMode).toBe(true);
+    });
   });
 
   // ── saveSettings ────────────────────────────────────────────

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -20,6 +20,27 @@ const SENSITIVE_PATHS = ['ai.openai.apiKey', 'webdav.password'] as const;
 
 const MARKER = '__enc_v1:';
 
+/** True for plain objects (not arrays, not null). */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively merge a stored blob over defaults so that nested keys absent from
+ * the blob (e.g. `appearance.writing` from a build that predates writing
+ * appearance) fall back to their defaults instead of being dropped. The stored
+ * value wins for primitives and arrays; only plain objects are merged.
+ */
+function deepMerge<T>(defaults: T, blob: Partial<T> | undefined): T {
+  if (!isPlainObject(blob)) return defaults;
+  const out: Record<string, unknown> = { ...(defaults as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(blob)) {
+    const base = (defaults as Record<string, unknown>)[key];
+    out[key] = isPlainObject(base) && isPlainObject(value) ? deepMerge(base, value) : value;
+  }
+  return out as T;
+}
+
 /** Read a nested value from an object by dot-path. */
 function getByPath(obj: Record<string, unknown>, path: string): unknown {
   return path.split('.').reduce<unknown>((acc, key) => {
@@ -105,7 +126,7 @@ export async function loadSettings(password?: string): Promise<AppSettings> {
         await decryptSensitiveFields(blob, password);
         if (hadPlaintext) {
           // Re-save to encrypt the plaintext fields (fire-and-forget, non-blocking).
-          const settings = { ...createDefaultSettings(), ...(blob as Partial<AppSettings>) };
+          const settings = deepMerge(createDefaultSettings(), blob as Partial<AppSettings>);
           saveSettings(settings, password).catch(() => {});
         }
       } else {
@@ -117,7 +138,7 @@ export async function loadSettings(password?: string): Promise<AppSettings> {
           }
         }
       }
-      return { ...createDefaultSettings(), ...(blob as Partial<AppSettings>) };
+      return deepMerge(createDefaultSettings(), blob as Partial<AppSettings>);
     }
     return createDefaultSettings();
   } catch (error) {


### PR DESCRIPTION
## Why
The browser/PWA build at journal.moodhaven.app crashed on the WritingView with **"Something went wrong rendering this view"** and `TypeError: can't access property "fontFamily", ie is undefined`, plus console noise (`unhandled command: pin_is_enabled`, TipTap duplicate-extension warning).

## What
- **Settings crash (root cause):** `loadSettings` did a shallow spread `{ ...defaults, ...blob }`. A persisted `appearance` object from a build that predates the writing-appearance feature has no `writing` key, so the stored `appearance` replaced the default `appearance.writing` entirely → `settings.appearance.writing` was `undefined`. Replaced with a recursive `deepMerge(defaults, blob)` so nested defaults always fall back. Added a regression test.
- **`pin_*` browser shim:** `pin_is_enabled`/`pin_setup`/`pin_disable`/`pin_unlock` now have explicit browser-shim cases instead of falling through to the warn-and-return-null path.
- **TipTap duplicate extensions:** StarterKit v3 bundles Link + Underline; disabled both in `StarterKit.configure` so the explicitly configured extensions win, clearing the `Duplicate extension names found: ['link', 'underline']` warning.

## Test
- `npx tsc --noEmit`, `npm run lint:ci` clean
- `settingsService.test.ts` (+ new deep-merge case) and `browser-invoke.test.ts` (+ pin stub cases) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
