### PR TITLE
feat(reset): relaunch into first-run after erase + hold-to-confirm

### DIFF
--- a/src-tauri/src/commands/data_management.rs
+++ b/src-tauri/src/commands/data_management.rs
@@ -193,6 +193,15 @@ pub fn exit_app(db_key: State<'_, DbKeyState>) {
     std::process::exit(0);
 }
 
+/// Relaunch the application (used after factory reset to return to first-run).
+/// Clears the in-memory DB key, then restarts the process so it reinitializes
+/// from the now-empty data directory and lands on the setup wizard.
+#[tauri::command]
+pub fn relaunch_app(app: AppHandle, db_key: State<'_, DbKeyState>) {
+    db_key.clear();
+    app.restart();
+}
+
 /// Factory reset - wipe all app data and return to first-run state.
 /// Intentionally does NOT require unlock — this is the "forgot password / erase
 /// everything" escape hatch and must work from the lock screen.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -672,6 +672,7 @@ pub fn run() {
             commands::get_data_stats,
             commands::write_text_file,
             commands::exit_app,
+            commands::relaunch_app,
             commands::get_log_path,
             commands::open_log_folder,
             commands::set_log_level,

--- a/src/components/settings/tabs/PrivacyDataManagement.tsx
+++ b/src/components/settings/tabs/PrivacyDataManagement.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { SettingSection } from '../SettingSection';
-import { factoryReset, exitApp } from '../../../lib/services/dataManagementService';
+import { factoryReset, relaunchApp } from '../../../lib/services/dataManagementService';
 import { logger } from '../../../lib/services/logger';
 
 interface PrivacyDataManagementProps {
@@ -34,10 +34,10 @@ export function PrivacyDataManagement({
       setIsResetting(false);
       return;
     }
-    // Wipe succeeded — exit to restart into first-run. A failure here is not a
-    // reset failure (data is already gone), so don't surface it as one.
-    await exitApp().catch((err) =>
-      logger.warn('exit_app after reset failed', { error: String(err) }),
+    // Wipe succeeded — relaunch into first-run. A failure here is not a reset
+    // failure (data is already gone), so don't surface it as one.
+    await relaunchApp().catch((err) =>
+      logger.warn('relaunch_app after reset failed', { error: String(err) }),
     );
   }, [resetConfirmText]);
 

--- a/src/lib/backend/browser-invoke.test.ts
+++ b/src/lib/backend/browser-invoke.test.ts
@@ -304,3 +304,34 @@ describe('PIN unlock browser stubs', () => {
     await expect(invoke('pin_unlock', { pin: '1234' })).rejects.toThrow(/desktop app/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// factory_reset — forgot-password escape hatch (must work while locked)
+// ---------------------------------------------------------------------------
+
+describe('invoke("factory_reset")', () => {
+  it('clears all stores even while locked', async () => {
+    await dbSetSetting('password_hash', 'somehash');
+    await dbCreateEntry({
+      id: 'e1',
+      encrypted_content: { iv: 'i', data: 'd', salt: 's' },
+      mood: 3,
+      privacy_mode: 0,
+      location_weather: null,
+      book_id: 'default',
+      pinned: 0,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      tags: [],
+      sealed_until: null,
+      capsule_type: null,
+      linked_original_id: null,
+      unsealed_at: null,
+      status: null,
+    });
+    await invoke('lock_app');
+    await expect(invoke<boolean>('factory_reset')).resolves.toBe(true);
+    expect(await dbGetSetting('password_hash')).toBeNull();
+    expect(await invoke('get_all_journal_entries').catch(() => 'locked')).toBe('locked');
+  });
+});

--- a/src/lib/backend/browser-invoke.ts
+++ b/src/lib/backend/browser-invoke.ts
@@ -418,11 +418,13 @@ async function dispatch(command: string, p: Params): Promise<any> {
       return true;
     }
     case 'factory_reset': {
-      if (!_browserSessionUnlocked) {
-        throw new Error('Session is locked');
-      }
+      // Intentionally NOT lock-gated — this is the lock-screen "Erase & Start
+      // Fresh" escape hatch and must work while locked, matching the desktop
+      // backend (factory_reset has no require_unlocked guard).
       const db = await openDB();
-      const stores = ['journal_entries', 'settings', 'books', 'webdav_state'];
+      // Clear every object store so nothing (incl. StillHaven sessions/samples)
+      // survives a reset. Iterating storeNames keeps this complete as stores grow.
+      const stores = Array.from(db.objectStoreNames);
       for (const storeName of stores) {
         await new Promise<void>((resolve, reject) => {
           const t = db.transaction(storeName, 'readwrite');
@@ -431,11 +433,13 @@ async function dispatch(command: string, p: Params): Promise<any> {
           req.onerror = () => reject(req.error);
         });
       }
+      _browserSessionUnlocked = false;
       return true;
     }
-    case 'exit_app': {
+    case 'exit_app':
+    case 'relaunch_app': {
       // window.close() is blocked by browsers unless the tab was opened by script.
-      // Reload instead so the app restarts cleanly (e.g. after factory reset).
+      // Reload instead so the app restarts cleanly into first-run (e.g. after reset).
       window.location.reload();
       return;
     }

--- a/src/lib/services/dataManagementService.ts
+++ b/src/lib/services/dataManagementService.ts
@@ -26,6 +26,14 @@ export async function exitApp(): Promise<void> {
   return invoke<void>('exit_app');
 }
 
+/**
+ * Relaunch the application into its first-run state (used after factory reset).
+ * Desktop restarts the process; the browser build reloads the page.
+ */
+export async function relaunchApp(): Promise<void> {
+  return invoke<void>('relaunch_app');
+}
+
 /** Optional filters for selective export. All fields optional; absent = no filter. */
 export interface ExportFilter {
   tags?: string[];

--- a/src/pages/LockScreen.tsx
+++ b/src/pages/LockScreen.tsx
@@ -972,7 +972,25 @@ export function LockScreen() {
                   onPointerUp={cancelHold}
                   onPointerLeave={cancelHold}
                   onPointerCancel={cancelHold}
+                  // Keyboard parity: hold Enter/Space to erase (ignore auto-repeat so the
+                  // hold timer starts once); releasing the key cancels — mirrors the pointer
+                  // gesture so the escape hatch is reachable without a mouse.
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      if (e.repeat) return;
+                      e.preventDefault();
+                      startHold();
+                    }
+                  }}
+                  onKeyUp={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      cancelHold();
+                    }
+                  }}
+                  onBlur={cancelHold}
                   disabled={isErasing || eraseConfirmText !== 'ERASE'}
+                  aria-label="Erase all data — press and hold for 2.5 seconds to confirm"
                   className="relative flex-1 py-3 overflow-hidden bg-rose-600 hover:bg-rose-700 disabled:bg-rose-300 dark:disabled:bg-rose-800 text-white font-medium rounded-xl transition-colors flex items-center justify-center gap-2 select-none"
                 >
                   {/* Hold-progress fill */}
@@ -981,7 +999,7 @@ export function LockScreen() {
                     className="absolute inset-y-0 left-0 bg-rose-800/60"
                     style={{ width: `${holdProgress * 100}%` }}
                   />
-                  <span className="relative flex items-center justify-center gap-2">
+                  <span role="status" aria-live="polite" className="relative flex items-center justify-center gap-2">
                     {isErasing ? (
                       <>
                         <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />

--- a/src/pages/LockScreen.tsx
+++ b/src/pages/LockScreen.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAppStore } from '../stores/appStore';
 import { get2FAStatus } from '../lib/services/twoFactorService';
 import { verifyUserPassword } from '../lib/services/journalService';
-import { factoryReset, exitApp } from '../lib/services/dataManagementService';
+import { factoryReset, relaunchApp } from '../lib/services/dataManagementService';
 import { recoverPassword, isRecoveryKeyEnabled } from '../lib/services/recoveryKeyService';
 import { pinIsEnabled, pinUnlock } from '../lib/services/pinUnlockService';
 import {
@@ -55,6 +55,9 @@ export function LockScreen() {
   const [verifiedPassword, setVerifiedPassword] = useState<string | null>(null);
   const [eraseConfirmText, setEraseConfirmText] = useState('');
   const [isErasing, setIsErasing] = useState(false);
+  const [holdProgress, setHoldProgress] = useState(0);
+  const holdRafRef = useRef<number | null>(null);
+  const holdStartRef = useRef<number>(0);
   const [recoveryKeyInput, setRecoveryKeyInput] = useState('');
   const [hasRecoveryKey, setHasRecoveryKey] = useState(false);
 
@@ -318,12 +321,43 @@ export function LockScreen() {
       setIsErasing(false);
       return;
     }
-    // Reset succeeded — exit so the app restarts into first-run. A failure here is
-    // not a reset failure (data is already wiped), so don't report it as one.
-    await exitApp().catch((err) =>
-      logger.warn('exit_app after reset failed', { error: String(err) }),
+    // Reset succeeded — relaunch into first-run. A failure here is not a reset
+    // failure (data is already wiped), so don't report it as one.
+    await relaunchApp().catch((err) =>
+      logger.warn('relaunch_app after reset failed', { error: String(err) }),
     );
   }, [eraseConfirmText]);
+
+  // Hold-to-confirm for the destructive erase: typing ERASE arms it, but the
+  // final wipe only fires after a deliberate ~2.5s press-and-hold. Defeats a
+  // casual "type erase + click" without requiring the password (which would
+  // break this forgot-password escape hatch).
+  const HOLD_MS = 2500;
+  const cancelHold = useCallback(() => {
+    if (holdRafRef.current !== null) {
+      cancelAnimationFrame(holdRafRef.current);
+      holdRafRef.current = null;
+    }
+    setHoldProgress(0);
+  }, []);
+
+  const startHold = useCallback(() => {
+    if (eraseConfirmText !== 'ERASE' || isErasing) return;
+    holdStartRef.current = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - holdStartRef.current) / HOLD_MS);
+      setHoldProgress(progress);
+      if (progress >= 1) {
+        holdRafRef.current = null;
+        void handleEraseAndReset();
+        return;
+      }
+      holdRafRef.current = requestAnimationFrame(tick);
+    };
+    holdRafRef.current = requestAnimationFrame(tick);
+  }, [eraseConfirmText, isErasing, handleEraseAndReset]);
+
+  useEffect(() => () => cancelHold(), [cancelHold]);
 
   // Handle PIN unlock submission
   const handlePinSubmit = useCallback(
@@ -380,10 +414,11 @@ export function LockScreen() {
 
   // Cancel erase flow
   const handleEraseCancel = useCallback(() => {
+    cancelHold();
     setStep('password');
     setEraseConfirmText('');
     setError(null);
-  }, []);
+  }, [cancelHold]);
 
   // Handle recovery key unlock
   const handleRecoveryKeySubmit = useCallback(
@@ -933,18 +968,31 @@ export function LockScreen() {
                 </button>
                 <button
                   type="button"
-                  onClick={handleEraseAndReset}
+                  onPointerDown={startHold}
+                  onPointerUp={cancelHold}
+                  onPointerLeave={cancelHold}
+                  onPointerCancel={cancelHold}
                   disabled={isErasing || eraseConfirmText !== 'ERASE'}
-                  className="flex-1 py-3 bg-rose-600 hover:bg-rose-700 disabled:bg-rose-300 dark:disabled:bg-rose-800 text-white font-medium rounded-xl transition-colors flex items-center justify-center gap-2"
+                  className="relative flex-1 py-3 overflow-hidden bg-rose-600 hover:bg-rose-700 disabled:bg-rose-300 dark:disabled:bg-rose-800 text-white font-medium rounded-xl transition-colors flex items-center justify-center gap-2 select-none"
                 >
-                  {isErasing ? (
-                    <>
-                      <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                      Erasing...
-                    </>
-                  ) : (
-                    'Erase & Start Fresh'
-                  )}
+                  {/* Hold-progress fill */}
+                  <span
+                    aria-hidden
+                    className="absolute inset-y-0 left-0 bg-rose-800/60"
+                    style={{ width: `${holdProgress * 100}%` }}
+                  />
+                  <span className="relative flex items-center justify-center gap-2">
+                    {isErasing ? (
+                      <>
+                        <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                        Erasing...
+                      </>
+                    ) : holdProgress > 0 ? (
+                      'Keep holding…'
+                    ) : (
+                      'Hold to Erase'
+                    )}
+                  </span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Why
Three issues with "Erase All Data" / factory reset:
1. **No relaunch:** after a wipe the desktop app exited and stayed closed — it never reopened into the fresh first-run state (the comments even claimed it would).
2. **DOS surface:** the lock-screen "Erase & Start Fresh" path is intentionally ungated (forgot-password escape hatch), so anyone at the keyboard could type `ERASE` and wipe everything.
3. **Browser gaps:** `factory_reset` was lock-gated in the browser shim (so the forgot-password recovery couldn't run while locked), and it left StillHaven stores behind.

## What
- **Relaunch into first-run:** new `relaunch_app` Tauri command (`AppHandle::restart`, modeled on `peer_apply_and_restart`), called after the wipe in both the lock-screen and Settings → Privacy reset paths. Browser shim reloads the page.
- **Browser shim:** `factory_reset` is no longer lock-gated (matches the desktop backend, which has no `require_unlocked`), and now clears **every** IndexedDB object store so StillHaven sessions/samples don't survive a reset.
- **DOS friction:** the lock-screen erase now requires type-`ERASE` **plus a deliberate ~2.5s press-and-hold** (visible progress fill) before firing. This defeats a casual type-and-click wipe **without** requiring the master password, which would break the recovery use-case.

> Erase friction approach chosen: type-ERASE + hold-to-confirm. An opt-in TOTP-gated erase (when 2FA is enabled) was considered and can be added later if desired.

## Test
- `cargo check`, `npx tsc --noEmit`, `npm run lint:ci` clean
- `browser-invoke.test.ts` + new "factory_reset clears all stores while locked" case pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
