### PR TITLE
fix(writing): responsive scaling + appearance toolbar + surface polish

### DIFF
--- a/src/components/editor/EditorIcons.tsx
+++ b/src/components/editor/EditorIcons.tsx
@@ -2,7 +2,7 @@
 
 export function TBBoldIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 4h8a4 4 0 014 4 4 4 0 01-4 4H6z" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 12h9a4 4 0 014 4 4 4 0 01-4 4H6z" />
     </svg>
@@ -11,7 +11,7 @@ export function TBBoldIcon() {
 
 export function TBItalicIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M10 4h4m-2 0l-4 16m0 0h4" />
     </svg>
   );
@@ -19,7 +19,7 @@ export function TBItalicIcon() {
 
 export function TBUnderlineIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M7 4v7a5 5 0 0010 0V4M5 21h14" />
     </svg>
   );
@@ -27,7 +27,7 @@ export function TBUnderlineIcon() {
 
 export function TBStrikeIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M17 12H7m10-4a4 4 0 00-4-4H9a4 4 0 000 8m2 8a4 4 0 004-4" />
     </svg>
   );
@@ -35,7 +35,7 @@ export function TBStrikeIcon() {
 
 export function TBBulletListIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h9m-9 5.25h9m-9 5.25h9M4.5 6.75h.007v.008H4.5V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM4.5 12h.007v.008H4.5V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm-.375 5.25h.007v.008H4.5v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
     </svg>
   );
@@ -43,7 +43,7 @@ export function TBBulletListIcon() {
 
 export function TBOrderedListIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h9m-9 5.25h9m-9 5.25h9" />
       <text x="3" y="8.5" fontSize="6" fill="currentColor" fontFamily="sans-serif">1</text>
       <text x="3" y="14" fontSize="6" fill="currentColor" fontFamily="sans-serif">2</text>
@@ -54,7 +54,7 @@ export function TBOrderedListIcon() {
 
 export function TBLinkIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
     </svg>
   );
@@ -62,7 +62,7 @@ export function TBLinkIcon() {
 
 export function TBEmojiIcon() {
   return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   );
@@ -70,7 +70,7 @@ export function TBEmojiIcon() {
 
 export function TBHeading2Icon() {
   return (
-    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6v12M4 12h7M11 6v12" />
       <text x="15" y="19" fontSize="10" fill="currentColor" stroke="none" fontWeight="bold" fontFamily="sans-serif">2</text>
     </svg>
@@ -79,7 +79,7 @@ export function TBHeading2Icon() {
 
 export function TBHeading3Icon() {
   return (
-    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6v12M4 12h7M11 6v12" />
       <text x="15" y="19" fontSize="10" fill="currentColor" stroke="none" fontWeight="bold" fontFamily="sans-serif">3</text>
     </svg>
@@ -88,7 +88,7 @@ export function TBHeading3Icon() {
 
 export function TBBlockquoteIcon() {
   return (
-    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+    <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor" stroke="none">
       <path d="M6 17h3l2-4V7H5v6h3l-2 4zm8 0h3l2-4V7h-6v6h3l-2 4z" />
     </svg>
   );
@@ -96,7 +96,7 @@ export function TBBlockquoteIcon() {
 
 export function TBTaskListIcon() {
   return (
-    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
       <rect x="3" y="5" width="4" height="4" rx="0.5" strokeLinecap="round" strokeLinejoin="round" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M4.25 7l0.75 0.75L6.5 6" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M10 7h10" />
@@ -108,7 +108,7 @@ export function TBTaskListIcon() {
 
 export function TBMicIcon({ isRecording }: { isRecording?: boolean }) {
   return (
-    <svg className="w-4 h-4" fill={isRecording ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <svg className="w-[18px] h-[18px]" fill={isRecording ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
     </svg>
   );

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -244,7 +244,7 @@ function ToolbarBtn({
       title={label}
       aria-pressed={isActive}
       className={`
-        p-1.5 rounded transition-all duration-150 active:scale-90
+        p-2 rounded transition-all duration-150 active:scale-90
         ${isActive
           ? 'bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400'
           : 'text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-600 dark:hover:text-slate-300'
@@ -310,7 +310,7 @@ function MicButton({
         disabled={isProcessing}
         aria-label={title}
         title={title}
-        className={`p-1.5 rounded transition-all duration-150 active:scale-90 ${buttonClass} ${isProcessing ? 'cursor-wait' : ''}`}
+        className={`p-2 rounded transition-all duration-150 active:scale-90 ${buttonClass} ${isProcessing ? 'cursor-wait' : ''}`}
       >
         {isProcessing ? (
           <span className="flex items-center gap-1">
@@ -366,7 +366,7 @@ function QuickCaptureToggle({
       title="Quick capture (bypass formatting)"
       aria-pressed={active}
       className={[
-        'p-1.5 rounded transition-all duration-150 active:scale-90 min-w-[44px] min-h-[44px] flex items-center justify-center',
+        'p-2 rounded transition-all duration-150 active:scale-90 min-w-[44px] min-h-[44px] flex items-center justify-center',
         active
           ? 'text-amber-500 bg-amber-50 dark:bg-amber-900/20'
           : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-slate-100 dark:hover:bg-slate-800',

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -49,7 +49,7 @@ export function MainLayout({ currentView, onNavigate, onLock, onSelectEntry, onN
       </div>
 
       {/* Right column: TopBar + main content */}
-      <div className="flex-1 flex flex-col overflow-hidden min-h-0">
+      <div className="flex-1 flex flex-col overflow-hidden min-h-0 min-w-0">
         <TopBar
           currentView={currentView}
           onLock={onLock}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -79,22 +79,33 @@ function IconBtn({
   title,
   active,
   children,
+  id,
+  ariaLabel,
+  ariaExpanded,
+  className = '',
 }: {
   onClick: () => void;
   title: string;
   active?: boolean;
   children: React.ReactNode;
+  id?: string;
+  ariaLabel?: string;
+  ariaExpanded?: boolean;
+  className?: string;
 }) {
   return (
     <button
       type="button"
+      id={id}
       onClick={onClick}
       title={title}
+      aria-label={ariaLabel}
+      aria-expanded={ariaExpanded}
       className={`p-2 rounded-lg transition-all duration-200 ${
         active
           ? 'text-violet-500 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20'
           : 'text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:scale-95'
-      }`}
+      } ${className}`}
     >
       {children}
     </button>
@@ -116,6 +127,9 @@ export function TopBar({ currentView, onLock, onSelectEntry, onNewEntry, onOpenB
   const distractionFree = useSettingsStore((s) => s.distractionFree);
   const theme = useSettingsStore((s) => s.settings.appearance.theme);
   const setTheme = useSettingsStore((s) => s.setTheme);
+  const appearanceDrawerOpen = useSettingsStore((s) => s.appearanceDrawerOpen);
+  const appearanceHintPulse = useSettingsStore((s) => s.appearanceHintPulse);
+  const toggleAppearanceDrawer = useSettingsStore((s) => s.toggleAppearanceDrawer);
 
   const { summary: healthSummary, isEnabled: ouraEnabled } = useOuraContext();
   const hasHealth = ouraEnabled && healthSummary && healthSummary.badges.length > 0;
@@ -176,9 +190,24 @@ export function TopBar({ currentView, onLock, onSelectEntry, onNewEntry, onOpenB
           </svg>
         </IconBtn>
 
-        {/* Focus + fullscreen + breakout menu — only when writing */}
+        {/* Writing appearance (typography/tint) + focus menu — only when writing */}
         {currentView === 'writing' && (
-          <FocusMenu onOpenBreakout={onOpenBreakout} />
+          <>
+            <IconBtn
+              id="writing-appearance-toggle"
+              onClick={toggleAppearanceDrawer}
+              title="Writing appearance (⌘,)"
+              ariaLabel="Writing appearance"
+              ariaExpanded={appearanceDrawerOpen}
+              active={appearanceDrawerOpen}
+              className={appearanceHintPulse ? 'drawer-hint-pulse' : ''}
+            >
+              <span className="w-5 h-5 flex items-center justify-center font-semibold leading-none select-none">
+                <span className="text-[15px]">A</span><span className="text-[11px]">a</span>
+              </span>
+            </IconBtn>
+            <FocusMenu onOpenBreakout={onOpenBreakout} />
+          </>
         )}
 
         {/* Divider */}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -82,6 +82,7 @@ function IconBtn({
   id,
   ariaLabel,
   ariaExpanded,
+  ariaKeyshortcuts,
   className = '',
 }: {
   onClick: () => void;
@@ -91,6 +92,7 @@ function IconBtn({
   id?: string;
   ariaLabel?: string;
   ariaExpanded?: boolean;
+  ariaKeyshortcuts?: string;
   className?: string;
 }) {
   return (
@@ -101,6 +103,7 @@ function IconBtn({
       title={title}
       aria-label={ariaLabel}
       aria-expanded={ariaExpanded}
+      aria-keyshortcuts={ariaKeyshortcuts}
       className={`p-2 rounded-lg transition-all duration-200 ${
         active
           ? 'text-violet-500 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20'
@@ -199,6 +202,7 @@ export function TopBar({ currentView, onLock, onSelectEntry, onNewEntry, onOpenB
               title="Writing appearance (⌘,)"
               ariaLabel="Writing appearance"
               ariaExpanded={appearanceDrawerOpen}
+              ariaKeyshortcuts="Meta+, Control+,"
               active={appearanceDrawerOpen}
               className={appearanceHintPulse ? 'drawer-hint-pulse' : ''}
             >

--- a/src/pages/WritingView.tsx
+++ b/src/pages/WritingView.tsx
@@ -250,9 +250,11 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
 
   const [savedEntry, setSavedEntry] = useState<JournalEntry | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [appearanceDrawerOpen, setAppearanceDrawerOpen] = useState(false);
-  const appearanceToggleRef = useRef<HTMLButtonElement | null>(null);
-  const [pulseAppearanceHint, setPulseAppearanceHint] = useState(false);
+  // Appearance drawer open state is shared with the TopBar toggle via the store.
+  const appearanceDrawerOpen = useSettingsStore((s) => s.appearanceDrawerOpen);
+  const setAppearanceDrawerOpen = useSettingsStore((s) => s.setAppearanceDrawerOpen);
+  const toggleAppearanceDrawer = useSettingsStore((s) => s.toggleAppearanceDrawer);
+  const setAppearanceHintPulse = useSettingsStore((s) => s.setAppearanceHintPulse);
   const [tagManagerOpen, setTagManagerOpen] = useState(false);
   const [selectedActivityIds, setSelectedActivityIds] = useState<string[]>([]);
   const { activities, isLoading: activitiesLoading, addCustom: addCustomActivity, remove: removeCustomActivity } = useActivities();
@@ -384,7 +386,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
       }
       if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === ',') {
         e.preventDefault();
-        setAppearanceDrawerOpen((v) => !v);
+        toggleAppearanceDrawer();
       }
       if (e.key === 'Escape' && distractionFree) {
         e.preventDefault();
@@ -410,16 +412,16 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [distractionFree, setDistractionFree]);
+  }, [distractionFree, setDistractionFree, toggleAppearanceDrawer]);
 
   // First-visit discoverability pulse for the appearance toggle.
   // Writes the flag immediately (optimistic) so the pulse never re-fires
   // if the user closes the app mid-animation. Reset via Factory Reset.
   useEffect(() => {
     if (hasSeenWritingDrawerHint) return;
-    setPulseAppearanceHint(true);
+    setAppearanceHintPulse(true);
     setHasSeenWritingDrawerHint(true);
-    const t = setTimeout(() => setPulseAppearanceHint(false), 3000);
+    const t = setTimeout(() => setAppearanceHintPulse(false), 3000);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // mount only — intentional
@@ -1186,32 +1188,15 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
       style={{ ['--mh-writing-text-scale' as string]: String(writingAppearance.textScale) }}
       className={`h-full flex flex-col transition-all duration-500 ${distractionFree ? 'focus-bg' : 'writing-bg'}`}
     >
-      {/* Writing appearance drawer (Cmd/Ctrl+,) */}
-      <button
-        ref={appearanceToggleRef}
-        type="button"
-        onClick={() => setAppearanceDrawerOpen((v) => !v)}
-        aria-label="Writing appearance"
-        aria-expanded={appearanceDrawerOpen}
-        aria-keyshortcuts="Meta+, Control+,"
-        title="Writing appearance (⌘,)"
-        className={`fixed top-3 right-3 z-30 p-2 rounded-lg bg-white/70 dark:bg-slate-900/70 backdrop-blur text-neutral-500 hover:text-neutral-900 dark:text-slate-400 dark:hover:text-slate-100 hover:bg-white dark:hover:bg-slate-900 shadow-sm ring-1 ring-neutral-200 dark:ring-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center ${pulseAppearanceHint ? 'drawer-hint-pulse' : ''} ${distractionFree ? 'opacity-30 hover:opacity-100' : ''}`}
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <line x1="4" y1="21" x2="4" y2="14" /><line x1="4" y1="10" x2="4" y2="3" />
-          <line x1="12" y1="21" x2="12" y2="12" /><line x1="12" y1="8" x2="12" y2="3" />
-          <line x1="20" y1="21" x2="20" y2="16" /><line x1="20" y1="12" x2="20" y2="3" />
-          <line x1="1" y1="14" x2="7" y2="14" /><line x1="9" y1="8" x2="15" y2="8" /><line x1="17" y1="16" x2="23" y2="16" />
-        </svg>
-      </button>
+      {/* Writing appearance drawer — toggle lives in the TopBar action cluster */}
       <AppearanceDrawer
         open={appearanceDrawerOpen}
         onClose={() => setAppearanceDrawerOpen(false)}
-        returnFocusTo={appearanceToggleRef.current}
+        returnFocusTo={typeof document !== 'undefined' ? document.getElementById('writing-appearance-toggle') : null}
       />
 
-      <div className="flex-1 flex flex-col min-h-0 px-4 sm:px-8 lg:px-12 py-4 sm:py-7 lg:py-10">
-        <div className="flex-1 flex flex-col w-full min-h-0 relative">
+      <div className="flex-1 flex flex-col min-h-0 min-w-0 px-4 sm:px-8 lg:px-12 py-4 sm:py-7 lg:py-10">
+        <div className="flex-1 flex flex-col w-full min-h-0 min-w-0 relative">
 
           {/* ── Heading block: greeting + date + streak (new entries only) ── */}
           {!entryId && (
@@ -1291,7 +1276,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
               }`}
             >
               <div
-                className={`flex items-center justify-between mb-3 sm:mb-5 pb-3 sm:pb-4 border-b transition-colors duration-500 ${headerBorderColor}`}
+                className={`flex items-center justify-between flex-wrap gap-y-2 mb-3 sm:mb-5 pb-3 sm:pb-4 border-b transition-colors duration-500 ${headerBorderColor}`}
               >
                 {/* Mood picker */}
                 <div className="flex items-center gap-2.5">
@@ -1353,7 +1338,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
                 )}
 
                 {/* Right cluster: attach + tags + privacy + options menu */}
-                <div className="flex items-center gap-1.5">
+                <div className="flex items-center gap-1.5 min-w-0 flex-wrap justify-end">
                   {/* Attach media button — disabled until entry is saved */}
                   <button
                     type="button"
@@ -1416,7 +1401,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
               </div>
               {/* Inline tag chips — shown when entry has tags or after first save */}
               {(entryTags.length > 0 || !isNewEntry) && !distractionFree && (
-                <div className="flex items-center flex-wrap gap-1.5 mt-2 pt-2 border-t border-slate-100 dark:border-slate-800 max-h-[52px] overflow-hidden">
+                <div className="flex items-center flex-wrap gap-1.5 mt-2 pt-2 border-t border-slate-100 dark:border-slate-800 max-h-24 overflow-y-auto scrollbar-hide">
                   {entryTags.map((tag) => (
                     <span
                       key={tag}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -142,6 +142,14 @@ interface SettingsState {
   distractionFree: boolean;
   setDistractionFree: (v: boolean) => void;
 
+  // Writing appearance drawer — toggle lives in TopBar, drawer renders in
+  // WritingView, so the open + onboarding-pulse state is shared here.
+  appearanceDrawerOpen: boolean;
+  appearanceHintPulse: boolean;
+  setAppearanceDrawerOpen: (v: boolean) => void;
+  toggleAppearanceDrawer: () => void;
+  setAppearanceHintPulse: (v: boolean) => void;
+
   // Auto-save indicator (not persisted — set by WritingView, read by Sidebar)
   savingState: 'idle' | 'saving' | 'saved';
   lastAutoSaved: string | null; // ISO date string
@@ -157,6 +165,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   hasUnsavedChanges: false,
   scrollToSection: null,
   distractionFree: false,
+  appearanceDrawerOpen: false,
+  appearanceHintPulse: false,
   savingState: 'idle',
   lastAutoSaved: null,
 
@@ -808,6 +818,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   // Session UI
   setDistractionFree: (distractionFree) => set({ distractionFree }),
+  setAppearanceDrawerOpen: (appearanceDrawerOpen) => set({ appearanceDrawerOpen }),
+  toggleAppearanceDrawer: () => set((s) => ({ appearanceDrawerOpen: !s.appearanceDrawerOpen })),
+  setAppearanceHintPulse: (appearanceHintPulse) => set({ appearanceHintPulse }),
 
   // Auto-save indicator
   setSavingState: (savingState) => set({ savingState }),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -496,7 +496,8 @@
   line-height: var(--mh-writing-line-height);
   letter-spacing: var(--mh-writing-letter-spacing, normal);
   color: var(--mh-writing-fg);
-  max-width: var(--mh-writing-max-width);
+  /* Cap to the container so a wide width setting never overflows a narrow window. */
+  max-width: min(var(--mh-writing-max-width), 100%);
   margin-inline: auto;
   /* Transition kept short and on color-only — never on font-size or letter-spacing
    * (those would make typing feel laggy when the user tweaks). */
@@ -508,9 +509,9 @@
 }
 
 /* The editor's CARD background tracks the chosen tint. The outer page
- * background (writing-bg / focus-bg gradients) is intentionally NOT
- * variable-driven — those gradients are ambient atmosphere, separate
- * from the editor surface tint.
+ * background blends into the same tint (with a soft top highlight for depth)
+ * so the writing surface no longer reads as a colored panel floating on a
+ * contrasting page.
  *
  * !important is required to win over Tailwind's `bg-white dark:bg-slate-900`
  * on the same element — those utility classes are a fallback for when the
@@ -518,6 +519,18 @@
 [data-writing-prefs] .editor-surface {
   background-color: var(--mh-writing-bg) !important;
   transition: background-color 200ms ease;
+}
+
+[data-writing-prefs].writing-bg {
+  background:
+    radial-gradient(ellipse 130% 60% at 50% 0%, rgba(255, 255, 255, 0.35) 0%, transparent 55%),
+    var(--mh-writing-bg);
+  transition: background-color 200ms ease;
+}
+.dark [data-writing-prefs].writing-bg {
+  background:
+    radial-gradient(ellipse 130% 60% at 50% 0%, rgba(255, 255, 255, 0.04) 0%, transparent 55%),
+    var(--mh-writing-bg);
 }
 
 /* ── Android / touch device polish ──────────────────────────────────────────


### PR DESCRIPTION
## Why
Several WritingView / app-shell layout issues:
- When the window narrows, the writing view and header controls get clipped instead of reflowing.
- The writing-appearance button floated as a `fixed` element overlapping the TopBar — off-center, "sticking out," and its sliders icon read like a settings gear.
- The editor surface (tint) stood out as a colored panel against the rest of the app.
- Tag chips were clipped at the bottom of the editor.
- Toolbar buttons and icons were small.

## What
- **Responsive scaling:** added `min-w-0` to the layout flex columns and `flex-wrap` to the editor header cluster so content reflows rather than clipping down toward the 800px min window; capped the ProseMirror `max-width` to `min(var, 100%)`.
- **Appearance toggle:** moved out of the floating `fixed` button into the TopBar action cluster (writing view only), with an **"Aa"** glyph that reads as typography rather than settings. Open + onboarding-pulse state is shared via the settings store; `Cmd/Ctrl+,` still toggles it; focus returns to the toolbar button.
- **Surface blend:** the writing page background now derives from the chosen tint (with a soft top highlight for depth), so the editor surface stops standing out.
- **Tag chips:** the chip row scrolls (`max-h-24 overflow-y-auto scrollbar-hide`) instead of hard-clipping at 52px.
- **Legibility:** toolbar buttons bumped to `p-2`, editor icons to 18px.

## Notes
- Adds non-persisted `appearanceDrawerOpen` / `appearanceHintPulse` session UI state to `settingsStore`.
- The "Aa" icon / TopBar placement is easy to revisit if a different treatment is preferred.

## Test
- `npx tsc --noEmit`, `npm run lint:ci` clean
- `settingsStore`, `AppearanceDrawer`, `Sidebar`, `InsightsView` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
