### PR TITLE
feat(android): capability-honest mobile UI + reachable StillHaven nav (standalone Phase 1)

### DIFF
--- a/active-plans/android-standalone.md
+++ b/active-plans/android-standalone.md
@@ -1,0 +1,119 @@
+# Android: from bridge to standalone app
+
+> **Status (2026-06-11):** Phase 1 in progress (this branch). The mobile UI shell already
+> exists — this plan reframes the Android app as a first-class, standalone ecosystem node
+> (phone-first journaling), not just the Wear→desktop bridge it's been perceived as.
+
+---
+
+## Why this exists
+
+The Tauri Android shell already runs the full React app, and the `android-foundation-stages-A1-to-A6`
+commit (`c7dd2c4`, on `main`) shipped a mobile layout shell, mobile writing/timeline/calendar
+adaptations, and touch-CSS polish. So the app is **not** actually a bridge — but it *feels* like one
+because (a) a few desktop-only features render on Android where they can't work, (b) some real views
+aren't reachable from the mobile nav, and (c) a handful of Rust commands lack Android `cfg` branches.
+
+The owner's intent: a standalone phone app with **ecosystem tie-in** (cloud sync as the cross-device
+glue, optional peer sync on LAN, watch capture), where the bridge is one capability among many — not
+the product.
+
+---
+
+## Current state (what already works on Android)
+
+**UI / navigation (already shipped):**
+- `MobileLayout` + `MobileHeader` + `BottomTabBar` (5 tabs: Write · Journal · Insights · Calendar · More).
+- App.tsx swaps `MainLayout` ↔ `MobileLayout` via `(isAndroid || isMobileViewport)`.
+- Mobile-adapted: WritingView (responsive drawers, scrollable toolbar), CalendarPage (full-screen grid
+  + slide-in day overlay), SettingsPage (list→detail flow). Timeline/OnThisDay/Insights/Lock/Setup are
+  centered-`max-w` cards + responsive grids — acceptable on a phone, not custom-tuned.
+
+**Rust / native (cross-platform, works on Android):**
+- SQLite + SQLCipher at-rest, journal CRUD, analytics.
+- Auth / 2FA / session lock / rate limiting.
+- Peer sync engine (TCP) + pairing + identity; cloud sync (WebDAV + Dropbox/GDrive OAuth).
+- Encrypted media + voice-memo storage; settings; logging.
+- Native Android biometric unlock via `BiometricPlugin.kt` (Android KeyStore) — separate from the
+  desktop keyring path.
+
+**Per-screen mobile status**
+
+| Screen | Status |
+|---|---|
+| Writing, Calendar, Settings | adapted (custom mobile layout) |
+| Timeline, On This Day, Insights, Lock, Setup | acceptable-responsive (centered card / responsive grid) |
+| StillHaven / Sessions, Journal overview | reachable only via desktop sidebar (nav gap → Phase 1) |
+
+---
+
+## Phase 1 — capability honesty + nav reachability (this PR, frontend-only)
+
+Verifiable in the web build at a phone viewport + typecheck/vitest; no APK needed.
+
+- **Mic button** (`EditorToolbar.tsx`): was gated `!isIOS`, so it rendered on Android where the
+  whisper sidecar can't run. Now gated `isDesktop` (STT is desktop-only; absent on iOS/Android and the
+  browser build). _Adopt the `canSTT` capability flag once the platform-detection refactor lands._
+- **Self-update panel** (`AboutTab.tsx`): was `!isIOS`; Android `can_self_update` is always false.
+  Now gated `isDesktop` (mobile is store/APK-distributed; browser can't self-update). Version/about
+  info still shows everywhere.
+- **Mobile nav reachability** (`BottomTabBar.tsx`): the "More" sheet now exposes **StillHaven** +
+  **Sessions** when `VITE_FEATURE_STILL && wellness.stillhavenEnabled` (mirrors the desktop
+  `SidebarNavigation` guard); `isMoreActive` updated so the More tab shows active on those views.
+
+_Deferred within Phase 1:_ Books / `journalOverview` reachability on mobile (needs a book picker in
+the sheet) — small follow-up.
+
+---
+
+## Phase 2 — native correctness (needs cargo/APK; owner-verified)
+
+Each item is a runtime gap on Android that web testing can't catch.
+
+- `commands/data_management.rs` `open_log_folder` (~L139) and `commands/media.rs`
+  `open_media_attachment` (~L445): only `macos`/`windows`/`linux` arms → error on Android. Add an
+  `target_os = "android"` branch (Android `ACTION_VIEW`/share intent via the declared FileProvider, or
+  a graceful "not available" result). Media decrypts but currently can't be opened.
+- `commands/cloud_providers.rs`: OAuth token key falls back to an on-disk `cloud_token_key.bin` on
+  Android (the `keyring` crate is desktop-only) → weaker token-at-rest than desktop. Move to Android
+  KeyStore (parity with `BiometricPlugin.kt`).
+- `gen/android/app/src/main/AndroidManifest.xml`: add `CHANGE_WIFI_MULTICAST_STATE` and acquire a
+  Wi-Fi `MulticastLock` so mDNS discovery works; today only direct TCP connect succeeds, so peer
+  discovery is unreliable on Android.
+- `tauri.conf.json`: add a `bundle.android` block (parity with the `iOS` block: min SDK, signing).
+  `externalBin` (whisper) correctly never ships on Android.
+- Export UX: `write_text_file` works (pure I/O) but there's no share/save-to-Downloads intent — exports
+  land in app storage with no way to surface them. Add a share intent.
+
+---
+
+## Phase 3 — ecosystem tie-in (the "node, not bridge" story)
+
+- **Cloud sync = primary cross-device path** and already works on Android with no gates — make it the
+  headline sync story in onboarding/Settings on mobile.
+- **Peer sync** lights up once Phase 2 multicast lands; the Devices/peer-sync UI is iOS-gated but not
+  Android-gated, so it's already reachable.
+- **Watch capture on standalone Android:** `useWearVoiceMemos` transcription is intentionally
+  `!isAndroid`-gated (whisper is desktop-only). Decide: (a) keep raw memo for desktop transcription via
+  sync, or (b) add a phone-side cloud STT path later. Mood-tap signals already flow through
+  `WearListenerService` → `useWearSignals`.
+
+---
+
+## Phase 4 — distribution
+
+- No self-update on Android (correct) — document the Play Store / sideload-APK channel.
+- AAB SHA-256 checksums already emitted to `latest-release.json` (PR #58 / `scripts/`).
+- Decide package/signing identity and min SDK before first public APK.
+
+---
+
+## Verification (Phase 1)
+
+1. `npm run typecheck`, `npm run lint:ci`, `npm test` (vitest) — green.
+2. `npm run dev:web` at a phone viewport (e.g. 390×844):
+   - Writing toolbar: no mic button (web `isDesktop` false).
+   - More sheet: StillHaven + Sessions appear when StillHaven is enabled in Settings; both navigate and
+     the More tab shows active.
+   - About: no self-update panel; version info still present.
+3. Owner runs `npm run tauri android dev` on device/emulator to confirm on-device and to drive Phase 2.

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -52,7 +52,7 @@ export function CollapsibleToolbar({
   quickCapture = false,
   onToggleQuickCapture,
 }: CollapsibleToolbarProps) {
-  const { isIOS } = usePlatform();
+  const { isDesktop } = usePlatform();
   const [formatState, setFormatState] = useState<Record<string, boolean>>({});
   const toolbarPanelRef = useRef<HTMLDivElement>(null);
 
@@ -195,8 +195,9 @@ export function CollapsibleToolbar({
             onClick={onEmojiClick}
           />
 
-          {/* Speech-to-text: quick capture toggle + mic button — sidecar unavailable on iOS */}
-          {onMicClick && !isIOS && (
+          {/* Speech-to-text: quick capture toggle + mic button — whisper sidecar is
+              desktop-only (absent on iOS/Android; no sidecar in the browser build) */}
+          {onMicClick && isDesktop && (
             <>
               <TBDivider />
               {onToggleQuickCapture && (

--- a/src/components/layout/BottomTabBar.tsx
+++ b/src/components/layout/BottomTabBar.tsx
@@ -2,10 +2,12 @@
  * BottomTabBar — 5-tab Android navigation bar.
  *
  * Tabs: Write | Journal | Insights | Calendar | More
- * "More" opens an overlay sheet: On This Day, Settings, Sync, Lock
+ * "More" opens an overlay sheet: On This Day, StillHaven (when enabled),
+ * Settings, Sync, Lock
  */
 
 import { useState } from 'react';
+import { useSettingsStore } from '../../stores/settingsStore';
 import type { ViewType } from './Sidebar';
 
 interface Tab {
@@ -60,6 +62,16 @@ const ICON_LOCK = (
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
   </svg>
 );
+const ICON_STILL = (
+  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5c.75-3 3.75-6 8.25-6s7.5 3 8.25 6M3.75 13.5c-.75 3 .75 5.25 3 6s4.5.75 5.25.75 3.75.25 5.25-.75 3.75-3 3-6M3.75 13.5h16.5" />
+  </svg>
+);
+const ICON_SESSIONS = (
+  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+  </svg>
+);
 
 const TABS: Tab[] = [
   { id: 'writing',   label: 'Write',    icon: ICON_WRITE },
@@ -78,8 +90,14 @@ interface BottomTabBarProps {
 
 export function BottomTabBar({ currentView, onNavigate, onLock, onOpenSync }: BottomTabBarProps) {
   const [showMore, setShowMore] = useState(false);
+  const stillhavenEnabled = useSettingsStore((s) => s.settings.wellness?.stillhavenEnabled ?? false);
+  const showStill = import.meta.env.VITE_FEATURE_STILL && stillhavenEnabled;
 
-  const isMoreActive = currentView === 'onthisday' || currentView === 'settings';
+  const isMoreActive =
+    currentView === 'onthisday' ||
+    currentView === 'settings' ||
+    currentView === 'still' ||
+    currentView === 'stillSessions';
 
   const handleTab = (id: ViewType | 'more') => {
     if (id === 'more') {
@@ -112,6 +130,24 @@ export function BottomTabBar({ currentView, onNavigate, onLock, onOpenSync }: Bo
                   {ICON_ONTHISDAY}
                   <span className="font-medium">On This Day</span>
                 </button>
+                {showStill && (
+                  <>
+                    <button
+                      onClick={() => { setShowMore(false); onNavigate('still'); }}
+                      className="w-full flex items-center gap-3 px-3 py-3.5 rounded-xl text-left text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 active:bg-slate-100 dark:active:bg-slate-700 transition-colors min-h-[52px]"
+                    >
+                      {ICON_STILL}
+                      <span className="font-medium">StillHaven</span>
+                    </button>
+                    <button
+                      onClick={() => { setShowMore(false); onNavigate('stillSessions'); }}
+                      className="w-full flex items-center gap-3 px-3 py-3.5 rounded-xl text-left text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 active:bg-slate-100 dark:active:bg-slate-700 transition-colors min-h-[52px]"
+                    >
+                      {ICON_SESSIONS}
+                      <span className="font-medium">Sessions</span>
+                    </button>
+                  </>
+                )}
                 <button
                   onClick={() => { setShowMore(false); onNavigate('settings'); }}
                   className="w-full flex items-center gap-3 px-3 py-3.5 rounded-xl text-left text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 active:bg-slate-100 dark:active:bg-slate-700 transition-colors min-h-[52px]"


### PR DESCRIPTION
## Why

Reframes the Android build as a **standalone phone app**, not a Wear→desktop bridge. The Tauri Android shell already runs the full React app (mobile layout shell shipped in `android-foundation-stages-A1-to-A6`), so this is **not** a rebuild — it fixes the things that make it *feel* like a half-port: desktop-only features rendering where they can't work, and real views unreachable from the mobile nav.

Frontend-only, web-verifiable (typecheck + vitest + phone-viewport). Native correctness (Rust `cfg` branches, manifest multicast permission, `tauri.conf.json` android block) and ecosystem tie-in are scoped in the roadmap doc as Phases 2–4 — they need an on-device APK to verify and are intentionally **out of this PR**.

## Changes

- **Mic button** (`EditorToolbar.tsx`): gated `!isIOS` → `isDesktop`. The whisper STT sidecar is desktop-only, but the button previously rendered on Android where it can't function.
- **Self-update panel** (`AboutTab.tsx`): gated `!isIOS` → `isDesktop`. Android `can_self_update` is always false (store/APK distributed); browser can't self-update either. Version/about info still shows on all platforms.
- **Mobile nav reachability** (`BottomTabBar.tsx`): the "More" sheet now exposes **StillHaven** + **Sessions** when `VITE_FEATURE_STILL && wellness.stillhavenEnabled`, mirroring the desktop `SidebarNavigation` guard; `isMoreActive` updated so the More tab highlights on those views.
- **`active-plans/android-standalone.md`** (new): phased roadmap driving follow-up PRs — Phase 2 (native cfg/manifest/keystore), Phase 3 (cloud-sync-as-glue, peer sync, watch capture), Phase 4 (distribution).

## Verification

- `npm run typecheck` ✅ · `npm run lint:ci` ✅ · `npm test` ✅ (1515 tests, 106 files)
- Added Android + browser negative cases to `EditorToolbar.test.tsx` and `AboutTab.test.tsx`.
- **On-device:** owner to run `npm run tauri android dev` to confirm and drive Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)