### PR TITLE
feat(privacy): add Privacy Checkup deep-link to sidebar footer

### DIFF
--- a/src/components/layout/SidebarPrompts.tsx
+++ b/src/components/layout/SidebarPrompts.tsx
@@ -4,6 +4,7 @@ import { PeerSyncBadge } from '../peer-sync/PeerSyncBadge';
 import type { UseUpdateCheckReturn } from '../../hooks/useUpdateCheck';
 import { usePlatform } from '../../hooks/usePlatform';
 import { getMoodTrend } from '../../lib/services/analyticsService';
+import { useSettingsStore } from '../../stores/settingsStore';
 import type { ViewType } from './Sidebar';
 
 const MOOD_COLORS: Record<number, string> = {
@@ -217,8 +218,23 @@ export function SidebarPrompts({ collapsed, updateHook, onNavigate }: SidebarPro
       {/* 7-day mood sparkline */}
       {!isBrowser && <MoodSparkline collapsed={collapsed} />}
 
-      {/* User Guide + Support links */}
+      {/* Privacy Checkup + User Guide + Support links */}
       <div className={`px-3 pb-3 pt-1 border-t border-slate-100 dark:border-slate-800 space-y-2 ${collapsed ? 'flex flex-col items-center' : ''}`}>
+        <button
+          type="button"
+          aria-label="Privacy Checkup"
+          title="Privacy Checkup — see what's enabled at a glance"
+          onClick={() => {
+            useSettingsStore.getState().setScrollToSection('privacy-checkup');
+            onNavigate('settings');
+          }}
+          className="flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
+        >
+          <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
+          </svg>
+          {!collapsed && <span>Privacy Checkup</span>}
+        </button>
         <a
           href="https://github.com/kenlacroix/moodhaven-journal#readme"
           target="_blank"

--- a/src/components/settings/tabs/PrivacyTab.tsx
+++ b/src/components/settings/tabs/PrivacyTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
 import type { AppSettings } from '../../../types/settings';
 import type { TwoFactorStatus } from '../../../types/twoFactor';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -22,6 +23,7 @@ interface PrivacyTabProps {
   handleExport: () => void;
   setAutoLockTimeout: (v: number) => void;
   sessionPassword?: string;
+  transparencyRef?: RefObject<HTMLDivElement>;
 }
 
 export function PrivacyTab({
@@ -35,6 +37,7 @@ export function PrivacyTab({
   handleExport,
   setAutoLockTimeout,
   sessionPassword = '',
+  transparencyRef,
 }: PrivacyTabProps) {
   const { isAndroid, isBrowser, isDesktop } = usePlatform();
 
@@ -125,7 +128,7 @@ export function PrivacyTab({
           handleExport={handleExport}
         />
 
-        <TransparencySection settings={settings} isBrowser={isBrowser} />
+        <TransparencySection settings={settings} isBrowser={isBrowser} sectionRef={transparencyRef} />
       </div>
 
       {/* 2FA Setup Modal - TOTP */}

--- a/src/components/settings/tabs/PrivacyTransparency.tsx
+++ b/src/components/settings/tabs/PrivacyTransparency.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import type { Ref } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import type { AppSettings } from '../../../types/settings';
 import { SettingSection } from '../SettingSection';
@@ -31,9 +32,10 @@ function PrivacyStatRow({
 interface TransparencySectionProps {
   settings: AppSettings;
   isBrowser: boolean;
+  sectionRef?: Ref<HTMLDivElement>;
 }
 
-export function TransparencySection({ settings, isBrowser }: TransparencySectionProps) {
+export function TransparencySection({ settings, isBrowser, sectionRef }: TransparencySectionProps) {
   const [isExporting, setIsExporting] = useState(false);
 
   const cloudSync = settings.storage.type === 'webdav';
@@ -73,6 +75,7 @@ export function TransparencySection({ settings, isBrowser }: TransparencySection
   }, [isBrowser, cloudSync, aiEnabled, peerSync, sttLayer]);
 
   return (
+    <div ref={sectionRef} className="scroll-mt-4">
     <SettingSection
       title="Transparency"
       description="What MoodHaven does and does not do with your data"
@@ -159,5 +162,6 @@ export function TransparencySection({ settings, isBrowser }: TransparencySection
         </button>
       )}
     </SettingSection>
+    </div>
   );
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -183,6 +183,7 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
 
   const sttSectionRef = useRef<HTMLDivElement>(null);
   const aiSectionRef = useRef<HTMLDivElement>(null);
+  const transparencyRef = useRef<HTMLDivElement>(null);
 
   const [exportMatchCount, setExportMatchCount] = useState<number | null>(null);
   const [exportTags, setExportTags] = useState<string[]>([]);
@@ -254,6 +255,12 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
     } else if (scrollToSection === 'privacy') {
       setActiveTab('privacy');
       setScrollToSection(null);
+    } else if (scrollToSection === 'privacy-checkup') {
+      setActiveTab('privacy');
+      setScrollToSection(null);
+      setTimeout(() => {
+        transparencyRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 100);
     } else if (scrollToSection === 'health') {
       setActiveTab('health');
       setScrollToSection(null);
@@ -509,6 +516,7 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
           handleExport={handleExport}
           setAutoLockTimeout={setAutoLockTimeout}
           sessionPassword={getSessionPassword() ?? ''}
+          transparencyRef={transparencyRef}
         />
       )}
       {activeTab === 'sync' && (

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -35,7 +35,7 @@ import { cloudProviderStatus } from '../lib/services/cloudProvidersService';
 import { useAppStore } from './appStore';
 
 // Section to scroll to when settings page opens
-type SettingsScrollTarget = 'speech-to-text' | 'ai' | 'privacy' | 'health' | 'notifications' | 'sync' | null;
+type SettingsScrollTarget = 'speech-to-text' | 'ai' | 'privacy' | 'privacy-checkup' | 'health' | 'notifications' | 'sync' | null;
 
 interface SettingsState {
   settings: AppSettings;


### PR DESCRIPTION
## What

Adds a **Privacy Checkup** link to the sidebar footer (next to User Guide / Support). One click opens **Settings → Privacy** and scrolls straight to the existing **Transparency** section — the live, at-a-glance view of what's on/off: storage, cloud sync, AI insights, peer sync, STT formatting, telemetry, accounts.

## Why

For a privacy-first app, the transparency panel was the last section of the Privacy tab — four sections down — so almost no one saw it. This surfaces it from anywhere without rebuilding it as a separate dashboard view.

## How

- Reuses the existing `scrollToSection` deep-link mechanism (same pattern as the AI / Speech-to-Text settings links).
- New `'privacy-checkup'` scroll target: sets the Privacy tab active and `scrollIntoView`s the Transparency section via a threaded `RefObject` (SettingsPage → PrivacyTab → TransparencySection).
- No new `ViewType`, no new page, no duplicated panel.

## Scope decision

Considered a standalone dashboard view vs. a lightweight link — chose the link: the data is already assembled and these settings change rarely, so a new top-level surface wasn't worth the maintenance.

## Verification

- `npm run typecheck` — clean
- `npm run lint:ci` — clean
- `npx vitest run` — 1512 passed / 106 files, 0 failures
- `knip` — no new findings
- Adversarial diff review — no correctness bugs (ref threading, scroll-timing/mount race, browser-mode safety, JSX balance all confirmed; mirrors the proven AI deep-link path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)