### PR TITLE
feat(android): MulticastLock so mDNS peer discovery works (Phase 2)

### DIFF
--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,11 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- mDNS/DNS-SD peer discovery: receiving multicast requires a held
+         WifiManager.MulticastLock, which in turn requires this permission.
+         Without it, mdns-sd never sees peers on Android (only direct TCP works). -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
@@ -1,15 +1,47 @@
 package com.moodhaven.app
 
+import android.content.Context
+import android.net.wifi.WifiManager
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
 class MainActivity : TauriActivity() {
+  // Held for the app's lifetime so mdns-sd can receive multicast peer-discovery
+  // packets. Android drops multicast to the app unless a MulticastLock is held;
+  // without it, peer discovery silently finds nothing (only direct TCP works).
+  private var multicastLock: WifiManager.MulticastLock? = null
+
   override fun onCreate(savedInstanceState: Bundle?) {
     installSplashScreen()
     getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
     getPluginManager().load(null, "wear", WearPlugin(this), "{}")
+    acquireMulticastLock()
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+  }
+
+  private fun acquireMulticastLock() {
+    try {
+      val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+      multicastLock = wifi?.createMulticastLock("moodhaven-mdns")?.apply {
+        setReferenceCounted(false)
+        acquire()
+      }
+    } catch (e: Exception) {
+      // Non-fatal: discovery degrades to direct-connect only.
+      Log.w("MoodHaven", "Failed to acquire multicast lock: ${e.message}")
+    }
+  }
+
+  override fun onDestroy() {
+    try {
+      multicastLock?.takeIf { it.isHeld }?.release()
+    } catch (e: Exception) {
+      Log.w("MoodHaven", "Failed to release multicast lock: ${e.message}")
+    }
+    multicastLock = null
+    super.onDestroy()
   }
 }


### PR DESCRIPTION
## Why

On Android, the OS drops multicast packets to an app unless it holds a `WifiManager.MulticastLock`. Without it, `mdns-sd` discovery finds **no peers** — only direct TCP connect works, so pairing and peer sync (including the new voice-memo sync in #164) are unreliable on Android. This is the #1 native gap from `active-plans/android-standalone.md` Phase 2.

## Change (Android-only)

- `AndroidManifest.xml`: add `CHANGE_WIFI_MULTICAST_STATE` (+ `ACCESS_WIFI_STATE`).
- `MainActivity.kt`: acquire a non-reference-counted `MulticastLock` in `onCreate`, release in `onDestroy`. Held for the app lifetime (simple + race-free vs. the background discovery thread). Acquisition is best-effort — on failure it logs and degrades to direct-connect only, never crashes.

No Rust or frontend changes, so the Rust/Frontend CI jobs are unaffected (they don't compile the Android app).

## Trade-off

Lifetime-hold has a small battery cost vs. scoping the lock to active discovery. Scoping would require a Rust↔Kotlin plugin call around `peer_discovery_start/stop`; deferred as a refinement — correctness first.

## Verification

- **Owner, on device** (`npm run tauri android dev`): with two devices on the same Wi-Fi, the phone now appears in the desktop's nearby-devices list (and vice-versa); pairing + sync complete. Confirm discovery works where it previously found nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)