### PR TITLE
feat(android): open media attachments via ACTION_VIEW intent (Phase 2)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -84,7 +84,9 @@ fn main() {
     // Tauri looks up plugin commands under the plugin's own namespace, not __app-acl__.
     // The permission definitions are read from permissions/wear/**/*.toml.
     tauri_build::try_build(
-        tauri_build::Attributes::new().plugin("wear", tauri_build::InlinedPlugin::new()),
+        tauri_build::Attributes::new()
+            .plugin("wear", tauri_build::InlinedPlugin::new())
+            .plugin("opener", tauri_build::InlinedPlugin::new()),
     )
     .expect("failed to run tauri-build");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "wear:allow-wear-check-connection",
     "wear:allow-wear-bridge-signal",
     "wear:allow-wear-flush-buffer",
-    "wear:allow-wear-send-feedback"
+    "wear:allow-wear-send-feedback",
+    "opener:allow-opener-open-file"
   ]
 }

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
@@ -17,6 +17,7 @@ class MainActivity : TauriActivity() {
     installSplashScreen()
     getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
     getPluginManager().load(null, "wear", WearPlugin(this), "{}")
+    getPluginManager().load(null, "opener", OpenerPlugin(this), "{}")
     acquireMulticastLock()
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/OpenerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/OpenerPlugin.kt
@@ -1,0 +1,60 @@
+package com.moodhaven.app
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import app.tauri.annotation.Command
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.Plugin
+import java.io.File
+
+private const val TAG = "OpenerPlugin"
+
+/**
+ * Opens a local file with the system viewer via an ACTION_VIEW intent, using the
+ * app's FileProvider to grant the receiving app temporary read access.
+ *
+ * Android has no equivalent of the desktop `xdg-open`/`open` launchers, so
+ * `open_media_attachment` (Rust) decrypts to a temp file and returns its path;
+ * the frontend then calls this plugin to display it.
+ */
+@TauriPlugin
+class OpenerPlugin(private val activity: Activity) : Plugin(activity) {
+
+    @Command
+    fun openFile(invoke: Invoke) {
+        val path = invoke.getArgs().optString("path", "")
+        if (path.isEmpty()) {
+            invoke.reject("path is required")
+            return
+        }
+        val file = File(path)
+        if (!file.exists()) {
+            invoke.reject("file not found: $path")
+            return
+        }
+        try {
+            val authority = "${activity.packageName}.fileprovider"
+            val uri = FileProvider.getUriForFile(activity, authority, file)
+            val ext = MimeTypeMap.getFileExtensionFromUrl(path).lowercase()
+            val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+                ?: "application/octet-stream"
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, mime)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            activity.startActivity(intent)
+            invoke.resolve()
+        } catch (e: ActivityNotFoundException) {
+            invoke.reject("No app available to open this file type")
+        } catch (e: Exception) {
+            Log.w(TAG, "openFile failed: ${e.message}")
+            invoke.reject("Could not open file: ${e.message}")
+        }
+    }
+}

--- a/src-tauri/permissions/opener/autogenerated/reference.toml
+++ b/src-tauri/permissions/opener/autogenerated/reference.toml
@@ -1,0 +1,13 @@
+# Opener plugin permissions
+# These allow the TypeScript layer to invoke the Android-native OpenerPlugin
+# via window.__TAURI_INTERNALS__.invoke('plugin:opener|commandName', args).
+
+[[permission]]
+identifier = "allow-opener-open-file"
+description = "Allow opening a local file with the system viewer via an ACTION_VIEW intent."
+commands.allow = ["openFile"]
+
+[default]
+permissions = [
+  "allow-opener-open-file",
+]

--- a/src-tauri/src/commands/media.rs
+++ b/src-tauri/src/commands/media.rs
@@ -638,6 +638,12 @@ pub fn list_entry_media(
 
 /// Decrypt a media file to a temp location and open it with the system viewer.
 /// The temp file is automatically deleted after 60 seconds.
+///
+/// Returns the temp file path **on Android only** (empty string on desktop). On
+/// desktop the OS viewer is launched here; Android has no `Command` launcher, so
+/// the frontend opens the returned path via the `opener` plugin (ACTION_VIEW +
+/// FileProvider). The temp file lives under the app cache dir, which the
+/// FileProvider already exposes via `cache-path` in `file_paths.xml`.
 #[tauri::command]
 pub fn open_media_attachment(
     app: AppHandle,
@@ -645,7 +651,7 @@ pub fn open_media_attachment(
     lock: State<'_, AppLockState>,
     media_id: String,
     password: String,
-) -> Result<(), String> {
+) -> Result<String, String> {
     require_unlocked(&lock)?;
     let (enc_path, filename) = {
         let conn = db.conn.lock().map_err(|e| e.to_string())?;
@@ -667,33 +673,43 @@ pub fn open_media_attachment(
     std::fs::write(&temp_path, &plaintext).map_err(|e| format!("Write temp file: {}", e))?;
 
     // Open with platform default viewer
-    let _temp_str = temp_path.to_str().ok_or("Non-UTF8 temp path")?.to_string();
+    let temp_str = temp_path.to_str().ok_or("Non-UTF8 temp path")?.to_string();
 
     #[cfg(target_os = "macos")]
     std::process::Command::new("open")
-        .arg(&_temp_str)
+        .arg(&temp_str)
         .spawn()
         .map_err(|e| format!("open: {}", e))?;
 
     #[cfg(target_os = "windows")]
     std::process::Command::new("cmd")
-        .args(["/c", "start", "", &_temp_str])
+        .args(["/c", "start", "", &temp_str])
         .spawn()
         .map_err(|e| format!("start: {}", e))?;
 
     #[cfg(target_os = "linux")]
     std::process::Command::new("xdg-open")
-        .arg(&_temp_str)
+        .arg(&temp_str)
         .spawn()
         .map_err(|e| format!("xdg-open: {}", e))?;
 
-    // Auto-cleanup after 10 s
+    // Desktop launchers already opened the file; Android hands the path back to
+    // the frontend, which fires an ACTION_VIEW intent via the opener plugin.
+    #[cfg(target_os = "android")]
+    let result_path = temp_str;
+    #[cfg(not(target_os = "android"))]
+    let result_path = {
+        let _ = temp_str;
+        String::new()
+    };
+
+    // Auto-cleanup — long enough for a viewer (or the Android app chooser) to read.
     std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_secs(10));
+        std::thread::sleep(std::time::Duration::from_secs(60));
         let _ = std::fs::remove_file(&temp_path);
     });
 
-    Ok(())
+    Ok(result_path)
 }
 
 /// Decrypt an image attachment and return a base64-encoded JPEG thumbnail

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -380,6 +380,9 @@ pub fn run() {
         // Registers the Android-native WearPlugin so Tauri's IPC router can route
         // `invoke('plugin:wear|*')` calls to the Kotlin WearPlugin via pluginManager.
         .plugin(tauri::plugin::Builder::<_, ()>::new("wear").build())
+        // Registers the Android-native OpenerPlugin so `invoke('plugin:opener|*')`
+        // routes to the Kotlin OpenerPlugin (system viewer via ACTION_VIEW intent).
+        .plugin(tauri::plugin::Builder::<_, ()>::new("opener").build())
         .setup(|app| {
             // If a full-restore pending file exists, verify its SHA-256 checksum then
             // swap it in before opening the DB.  This prevents a tampered pending

--- a/src/lib/services/mediaService.ts
+++ b/src/lib/services/mediaService.ts
@@ -83,9 +83,16 @@ export async function listAllMedia(): Promise<MediaAttachment[]> {
 /**
  * Decrypt a media file to a temp location and open it with the system viewer.
  * The temp file is automatically deleted after 60 seconds.
+ *
+ * Desktop opens the file in the Rust command and returns an empty string. Android
+ * has no native launcher, so Rust returns the temp path and we fire an
+ * ACTION_VIEW intent via the `opener` plugin (FileProvider).
  */
 export async function openMedia(mediaId: string, password: string): Promise<void> {
-  return invoke('open_media_attachment', { mediaId, password });
+  const path = await invoke<string>('open_media_attachment', { mediaId, password });
+  if (path) {
+    await invoke('plugin:opener|openFile', { path });
+  }
 }
 
 /**


### PR DESCRIPTION
## Why

On Android, `open_media_attachment` silently no-op'd — the desktop `xdg-open`/`open`/`start` launchers are `#[cfg]`'d out, so tapping an attachment decrypted a temp file and then did nothing. This makes attachments actually viewable on the phone.

## Change

- **Rust** (`media.rs`): `open_media_attachment` now returns the decrypted temp path **on Android** (empty string on desktop, which still launches the OS viewer in-command as before). Temp-file auto-cleanup bumped 10s → 60s so the Android app-chooser/viewer has time to read.
- **Kotlin** (`OpenerPlugin.kt`, new): an `opener` Tauri plugin with `openFile(path)` — builds a `content://` URI via the existing **FileProvider** (`${applicationId}.fileprovider`), derives the MIME from the extension, and fires `ACTION_VIEW` with `FLAG_GRANT_READ_URI_PERMISSION`. Registered in `MainActivity`. No `file_paths.xml` change needed — the temp file lives under the app **cache dir**, already exposed by the existing `cache-path` entry.
- **Frontend** (`mediaService.ts`): `openMedia` opens the returned path via `plugin:opener|openFile` when Rust hands one back (Android only) — no platform check needed, since desktop returns `""`.

## Verification

- `cargo check` ✅ · `cargo clippy --all-targets` ✅ · `npm run typecheck`/`lint:ci` ✅ · `vitest` ✅ (1512).
- Kotlin isn't compiled by CI (no gradle in the Rust/Frontend jobs).
- **Owner, on device:** attach a photo to an entry, tap it → it opens in the gallery/viewer via the app chooser; confirm no crash on an unknown file type (rejects with "No app available…").

## Notes

- `open_log_folder` (the other silent no-op) is left out — there's no folder-browser equivalent on Android; hiding that button on mobile belongs with the Phase-3 UX PR.
- Android-native; can't be runtime-verified from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)