### PR TITLE
feat(android): cloud-token key via AndroidKeyStore (Phase 2)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -86,7 +86,8 @@ fn main() {
     tauri_build::try_build(
         tauri_build::Attributes::new()
             .plugin("wear", tauri_build::InlinedPlugin::new())
-            .plugin("opener", tauri_build::InlinedPlugin::new()),
+            .plugin("opener", tauri_build::InlinedPlugin::new())
+            .plugin("securekey", tauri_build::InlinedPlugin::new()),
     )
     .expect("failed to run tauri-build");
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
     "wear:allow-wear-bridge-signal",
     "wear:allow-wear-flush-buffer",
     "wear:allow-wear-send-feedback",
-    "opener:allow-opener-open-file"
+    "opener:allow-opener-open-file",
+    "securekey:allow-securekey-get-cloud-token-key"
   ]
 }

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
@@ -18,6 +18,7 @@ class MainActivity : TauriActivity() {
     getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
     getPluginManager().load(null, "wear", WearPlugin(this), "{}")
     getPluginManager().load(null, "opener", OpenerPlugin(this), "{}")
+    getPluginManager().load(null, "securekey", SecureKeyPlugin(this), "{}")
     acquireMulticastLock()
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)

--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/SecureKeyPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/SecureKeyPlugin.kt
@@ -1,0 +1,112 @@
+package com.moodhaven.app
+
+import android.app.Activity
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import app.tauri.annotation.Command
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+import java.io.File
+import java.security.KeyStore
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+private const val TAG = "SecureKeyPlugin"
+private const val KEY_ALIAS = "MoodHavenTokenKey"
+private const val PREFS_NAME = "moodbloom_securekey"
+private const val PREF_ENC = "cloud_token_key_enc"
+private const val PREF_IV = "cloud_token_key_iv"
+private const val LEGACY_KEY_FILE = "cloud_token_key.bin"
+
+/**
+ * Hardware-backed storage for the cloud-token encryption key on Android.
+ *
+ * The 32-byte key (used Rust-side to AES-GCM the OAuth tokens) is wrapped under a
+ * non-exportable AndroidKeyStore AES key and persisted as ciphertext in private
+ * SharedPreferences — an upgrade over the bare 0600 file the Rust fallback writes.
+ *
+ * On first run it MIGRATES the existing `cloud_token_key.bin` bytes (so already
+ * stored tokens still decrypt) instead of generating a new key. The frontend
+ * fetches the key here at startup and hands it to Rust via `cloud_set_token_key`.
+ */
+@TauriPlugin
+class SecureKeyPlugin(private val activity: Activity) : Plugin(activity) {
+
+    @Command
+    fun getCloudTokenKey(invoke: Invoke) {
+        try {
+            val keyBytes = loadStoredKey() ?: migrateOrCreateKey()
+            val obj = JSObject()
+            obj.put("key", toHex(keyBytes))
+            invoke.resolve(obj)
+        } catch (e: Exception) {
+            Log.w(TAG, "getCloudTokenKey failed: ${e.message}")
+            invoke.reject("Could not resolve cloud token key: ${e.message}")
+        }
+    }
+
+    private fun loadStoredKey(): ByteArray? {
+        val prefs = activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val encB64 = prefs.getString(PREF_ENC, null) ?: return null
+        val ivB64 = prefs.getString(PREF_IV, null) ?: return null
+        val enc = Base64.decode(encB64, Base64.DEFAULT)
+        val iv = Base64.decode(ivB64, Base64.DEFAULT)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.DECRYPT_MODE, getKeyStoreKey(), GCMParameterSpec(128, iv))
+        }
+        return cipher.doFinal(enc)
+    }
+
+    private fun migrateOrCreateKey(): ByteArray {
+        // Prefer the bytes already on disk so existing tokens keep decrypting.
+        val legacy = File(activity.filesDir, LEGACY_KEY_FILE)
+        val keyBytes = if (legacy.exists() && legacy.length() == 32L) {
+            legacy.readBytes()
+        } else {
+            ByteArray(32).also { SecureRandom().nextBytes(it) }
+        }
+        storeKey(keyBytes)
+        return keyBytes
+    }
+
+    private fun storeKey(keyBytes: ByteArray) {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.ENCRYPT_MODE, getKeyStoreKey())
+        }
+        val enc = cipher.doFinal(keyBytes)
+        activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(PREF_ENC, Base64.encodeToString(enc, Base64.DEFAULT))
+            .putString(PREF_IV, Base64.encodeToString(cipher.iv, Base64.DEFAULT))
+            .apply()
+    }
+
+    private fun getKeyStoreKey(): SecretKey {
+        val ks = KeyStore.getInstance("AndroidKeyStore").also { it.load(null) }
+        (ks.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            // No setUserAuthenticationRequired — this key wraps a background secret,
+            // it must work without a biometric/PIN prompt.
+            .build()
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+            .apply { init(spec) }
+            .generateKey()
+    }
+
+    private fun toHex(bytes: ByteArray): String =
+        bytes.joinToString("") { "%02x".format(it) }
+}

--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -229,6 +229,7 @@ commands.allow = [
   "cloud_provider_disconnect",
   "cloud_provider_refresh_token",
   "cloud_provider_available",
+  "cloud_set_token_key",
 ]
 
 [[permission]]

--- a/src-tauri/permissions/securekey/autogenerated/reference.toml
+++ b/src-tauri/permissions/securekey/autogenerated/reference.toml
@@ -1,0 +1,13 @@
+# SecureKey plugin permissions
+# These allow the TypeScript layer to invoke the Android-native SecureKeyPlugin
+# via window.__TAURI_INTERNALS__.invoke('plugin:securekey|commandName', args).
+
+[[permission]]
+identifier = "allow-securekey-get-cloud-token-key"
+description = "Allow retrieving the AndroidKeyStore-backed per-device cloud token key."
+commands.allow = ["getCloudTokenKey"]
+
+[default]
+permissions = [
+  "allow-securekey-get-cloud-token-key",
+]

--- a/src-tauri/src/commands/cloud_providers.rs
+++ b/src-tauri/src/commands/cloud_providers.rs
@@ -149,7 +149,43 @@ use super::{require_unlocked, KEYRING_SERVICE};
 pub(crate) const TOKEN_KEYRING_ACCOUNT: &str = "cloud-token-encryption-key";
 const TOKEN_MARKER: &str = "__tok_v1:";
 
+/// In-memory cloud-token key supplied by the platform's secure store.
+///
+/// On Android the OS keyring crate is unavailable, so the desktop fallback writes
+/// a bare 0600 key file. When present, this override (populated at startup from
+/// the AndroidKeyStore-backed `securekey` plugin via `cloud_set_token_key`) is
+/// preferred over both keyring and file — giving hardware-backed key-at-rest. If
+/// it is never set (bootstrap skipped/failed), resolution falls back to the
+/// existing keyring→file path, so no platform regresses.
+#[derive(Default)]
+pub struct CloudTokenKeyOverride(pub std::sync::Mutex<Option<Zeroizing<[u8; 32]>>>);
+
+/// Store the platform-provided cloud-token key for this session. Idempotent;
+/// validates the key is exactly 32 bytes of hex. Not lock-gated — it runs at
+/// startup before unlock and never touches journal data.
+#[tauri::command]
+pub fn cloud_set_token_key(
+    state: tauri::State<'_, CloudTokenKeyOverride>,
+    key_hex: String,
+) -> Result<(), String> {
+    let bytes = hex::decode(key_hex.trim()).map_err(|_| "invalid token key hex".to_string())?;
+    let arr = <[u8; 32]>::try_from(bytes.as_slice())
+        .map_err(|_| "token key must be 32 bytes".to_string())?;
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    *guard = Some(Zeroizing::new(arr));
+    Ok(())
+}
+
 fn load_or_create_token_key(app: &AppHandle) -> Result<Zeroizing<[u8; 32]>, String> {
+    // Platform secure-store override (Android KeyStore) takes precedence.
+    if let Some(state) = app.try_state::<CloudTokenKeyOverride>() {
+        if let Ok(guard) = state.0.lock() {
+            if let Some(key) = guard.as_ref() {
+                return Ok(Zeroizing::new(**key));
+            }
+        }
+    }
+
     if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, TOKEN_KEYRING_ACCOUNT) {
         if let Ok(hex) = entry.get_password().map(Zeroizing::new) {
             if let Ok(bytes) = hex::decode(hex.trim()) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -583,6 +583,9 @@ pub fn run() {
             // STT model download state (cancellation tokens)
             app.manage(commands::DownloadState::default());
 
+            // Cloud-token key override (Android KeyStore-backed; see cloud_providers)
+            app.manage(commands::cloud_providers::CloudTokenKeyOverride::default());
+
             // Sweep leftover preview temp files from previous sessions
             let _ = commands::sweep_preview_temp(app.handle().clone());
 
@@ -848,6 +851,7 @@ pub fn run() {
             commands::cloud_provider_upload_blob,
             commands::cloud_provider_download_blob,
             commands::cloud_provider_status,
+            commands::cloud_set_token_key,
             commands::cloud_provider_disconnect,
             commands::cloud_provider_refresh_token,
             commands::cloud_provider_available,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -383,6 +383,9 @@ pub fn run() {
         // Registers the Android-native OpenerPlugin so `invoke('plugin:opener|*')`
         // routes to the Kotlin OpenerPlugin (system viewer via ACTION_VIEW intent).
         .plugin(tauri::plugin::Builder::<_, ()>::new("opener").build())
+        // Registers the Android-native SecureKeyPlugin so `invoke('plugin:securekey|*')`
+        // routes to the Kotlin SecureKeyPlugin (AndroidKeyStore-backed cloud token key).
+        .plugin(tauri::plugin::Builder::<_, ()>::new("securekey").build())
         .setup(|app| {
             // If a full-restore pending file exists, verify its SHA-256 checksum then
             // swap it in before opening the DB.  This prevents a tampered pending

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,6 +185,17 @@ function MainApp() {
     }
   }, [isUnlocked, settingsLoadedForSession, hasSeenTutorial, showDisclaimer]);
 
+  // Android: bootstrap the hardware-backed cloud-token key once at startup so
+  // OAuth tokens encrypt under AndroidKeyStore, not the bare 0600 fallback file.
+  useEffect(() => {
+    if (!isAndroid) return;
+    import('./lib/services/cloudProvidersService').then(({ bootstrapAndroidCloudTokenKey }) => {
+      bootstrapAndroidCloudTokenKey().catch((err) =>
+        logger.warn('Cloud token key bootstrap failed:', { error: String(err) })
+      );
+    });
+  }, [isAndroid]);
+
   // Helper: run a silent background sync (no UI feedback — fire and forget)
   const runBackgroundSync = useCallback(() => {
     if (!isUnlocked || storageType !== 'webdav' || !webdavConfig?.url || !sessionPassword) return;

--- a/src/lib/services/cloudProvidersService.ts
+++ b/src/lib/services/cloudProvidersService.ts
@@ -28,6 +28,18 @@ export async function cloudProviderAvailable(provider: 'dropbox' | 'gdrive'): Pr
   return invoke<boolean>('cloud_provider_available', { provider });
 }
 
+/**
+ * Android only: fetch the cloud-token encryption key from the AndroidKeyStore-backed
+ * `securekey` plugin and hand it to Rust, so OAuth tokens are encrypted under a
+ * hardware-backed key instead of the bare 0600 fallback file. Best-effort — on
+ * failure Rust falls back to its keyring→file path, so cloud sync still works.
+ * Must run before any cloud-token operation; called once at startup.
+ */
+export async function bootstrapAndroidCloudTokenKey(): Promise<void> {
+  const { key } = await invoke<{ key: string }>('plugin:securekey|getCloudTokenKey');
+  await invoke('cloud_set_token_key', { keyHex: key });
+}
+
 async function cloudProviderUploadBlob(
   provider: 'dropbox' | 'gdrive',
   blob: string,


### PR DESCRIPTION
## Why

On Android the `keyring` crate has no backend, so cloud OAuth-token encryption fell back to a bare `0600` key file (`cloud_token_key.bin`). App storage is sandboxed, so it isn't world-readable — but it's weaker than the desktop OS keyring. This wraps that 32-byte key under a non-exportable **AndroidKeyStore** AES key (hardware-backed where available).

## Design (regression-safe by construction)

- **`SecureKeyPlugin.kt`** (new): `getCloudTokenKey()` returns the key as hex, persisted **KeyStore-encrypted** in private SharedPreferences. On first run it **migrates the existing `cloud_token_key.bin` bytes** (so already-stored tokens still decrypt) instead of generating a fresh key. The wrapping key is *not* user-auth-gated (it protects a background secret, no biometric prompt).
- **Rust**: a `CloudTokenKeyOverride` managed state + `cloud_set_token_key` command. `load_or_create_token_key` prefers the override, **else falls back to the existing keyring→file path** — so if the bootstrap is skipped or fails, behavior is unchanged.
- **Frontend**: `App` bootstraps the key once at startup on Android (best-effort; logs and degrades on failure).

Worst realistic failure mode is "no change" (falls back to the file). The only honest caveat: for existing installs the legacy `.bin` is **left in place** as that fallback — deleting it (to fully remove the weaker copy) is a device-verified follow-up.

## Verification

- `cargo check`/`clippy` ✅ · `cargo test` cloud ✅ (7) · `typecheck`/`lint` ✅ · `vitest` ✅ (1512).
- Kotlin + KeyStore aren't exercised by CI.
- **Owner, on device (important — critical token path):**
  1. Existing install with a connected provider → upgrade → confirm the provider stays connected and a sync round-trips (proves the `.bin`→KeyStore migration preserved the key).
  2. Fresh install → connect a provider → kill/relaunch → confirm tokens still decrypt (proves KeyStore persistence).

## Notes

Android-native + sits in the primary cloud-sync path; please device-test the migration before merging. Branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)