### PR TITLE
chore(android): declare bundle.android minSdkVersion (Phase 2)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,6 +60,9 @@
       "minimumSystemVersion": "16.0",
       "developmentTeam": "REPLACE_WITH_APPLE_TEAM_ID"
     },
+    "android": {
+      "minSdkVersion": 24
+    },
     "linux": {
       "appimage": {
         "bundleMediaFramework": true


### PR DESCRIPTION
## Why

`tauri.conf.json` had `macOS`/`iOS`/`linux`/`windows` bundle blocks but no `android` one. This adds it for parity, making the Tauri config the source of truth for the minimum SDK.

## Change

```json
"android": { "minSdkVersion": 24 }
```

Matches the existing `minSdk = 24` in `gen/android/app/build.gradle.kts` (Android 7.0) — no behavior change, just declares it at the Tauri layer. `cargo check` confirms tauri-build accepts the field.

Signing/keystore config stays in gradle and is part of the Phase 4 distribution work (Play Store / signed APK), not this PR.

## Verification

- `cargo check` ✅ (tauri-build validated the schema).
- **Owner, on device:** `npm run tauri android build` still produces an AAB/APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)