### PR TITLE
feat(sync): honest mobile sync clarity (Phase 3)

### DIFF
--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -224,6 +224,7 @@ commands.allow = [
   "cloud_provider_status",
   "cloud_provider_disconnect",
   "cloud_provider_refresh_token",
+  "cloud_provider_available",
 ]
 
 [[permission]]

--- a/src-tauri/src/commands/cloud_providers.rs
+++ b/src-tauri/src/commands/cloud_providers.rs
@@ -43,6 +43,19 @@ const DROPBOX_APP_KEY: &str = "DROPBOX_APP_KEY_PLACEHOLDER";
 const GOOGLE_CLIENT_ID: &str = "GOOGLE_CLIENT_ID_PLACEHOLDER";
 const GOOGLE_CLIENT_SECRET: &str = "GOOGLE_CLIENT_SECRET_PLACEHOLDER";
 
+/// Whether a managed cloud provider has real OAuth credentials compiled in.
+/// Returns false while the app ships with `*_PLACEHOLDER` creds, so the UI can
+/// mark Dropbox / Google Drive "coming soon" instead of offering a dead-end
+/// connect button. Auto-corrects once real credentials are baked in.
+#[tauri::command]
+pub fn cloud_provider_available(provider: String) -> bool {
+    match provider.as_str() {
+        "dropbox" => DROPBOX_APP_KEY != "DROPBOX_APP_KEY_PLACEHOLDER",
+        "gdrive" => GOOGLE_CLIENT_ID != "GOOGLE_CLIENT_ID_PLACEHOLDER",
+        _ => true,
+    }
+}
+
 // ============================================================================
 // Setting key helpers
 // ============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,6 +813,7 @@ pub fn run() {
             commands::cloud_provider_status,
             commands::cloud_provider_disconnect,
             commands::cloud_provider_refresh_token,
+            commands::cloud_provider_available,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/settings/tabs/AboutTab.tsx
+++ b/src/components/settings/tabs/AboutTab.tsx
@@ -147,22 +147,26 @@ export function AboutTab({
                 )}
               </div>
 
-              <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-700">
-                <p className="text-slate-700 dark:text-slate-200">Log File</p>
-                <button
-                  onClick={() => {
-                    if (logPath) {
-                      invoke('open_log_folder').catch((e: unknown) => {
-                        logger.error('open_log_folder failed', { err: String(e) });
-                      });
-                    }
-                  }}
-                  disabled={!logPath}
-                  className="px-3 py-1 text-sm rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                >
-                  Open Log Folder
-                </button>
-              </div>
+              {/* "Open Log Folder" only works on desktop — Android/iOS have no
+                  OS file-manager launcher, so the button would silently no-op. */}
+              {isDesktop && (
+                <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-700">
+                  <p className="text-slate-700 dark:text-slate-200">Log File</p>
+                  <button
+                    onClick={() => {
+                      if (logPath) {
+                        invoke('open_log_folder').catch((e: unknown) => {
+                          logger.error('open_log_folder failed', { err: String(e) });
+                        });
+                      }
+                    }}
+                    disabled={!logPath}
+                    className="px-3 py-1 text-sm rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Open Log Folder
+                  </button>
+                </div>
+              )}
             </>
           )}
 

--- a/src/components/settings/tabs/SyncTab.tsx
+++ b/src/components/settings/tabs/SyncTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { AppSettings, StorageBackend } from '../../../types/settings';
 import { SettingSection } from '../SettingSection';
 import { SettingSelect } from '../SettingSelect';
@@ -6,6 +6,7 @@ import { SettingInput } from '../SettingInput';
 import { testConnection as testWebDAVConnection } from '../../../lib/services/webdavService';
 import {
   cloudProviderAuthStart,
+  cloudProviderAvailable,
   cloudProviderDisconnect,
   syncUpload,
   syncDownload,
@@ -41,6 +42,23 @@ export function SyncTab({
   const [isConnecting, setIsConnecting] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncMessage, setSyncMessage] = useState<{ text: string; error: boolean } | null>(null);
+  // Managed providers are gated behind compile-time creds; show "coming soon"
+  // rather than a dead-end connect button while they're placeholders.
+  const [providerReady, setProviderReady] = useState({ dropbox: true, gdrive: true });
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([cloudProviderAvailable('dropbox'), cloudProviderAvailable('gdrive')])
+      .then(([dropbox, gdrive]) => {
+        if (active) setProviderReady({ dropbox, gdrive });
+      })
+      .catch(() => {
+        if (active) setProviderReady({ dropbox: false, gdrive: false });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const clearMessage = useCallback(() => setSyncMessage(null), []);
 
@@ -191,8 +209,8 @@ export function SyncTab({
           options={[
             { value: 'local', label: 'Local only' },
             { value: 'byocloud', label: 'Sync folder (iCloud/Drive/Dropbox)' },
-            { value: 'dropbox', label: 'Dropbox' },
-            { value: 'gdrive', label: 'Google Drive' },
+            { value: 'dropbox', label: providerReady.dropbox ? 'Dropbox' : 'Dropbox (coming soon)' },
+            { value: 'gdrive', label: providerReady.gdrive ? 'Google Drive' : 'Google Drive (coming soon)' },
             { value: 'webdav', label: 'WebDAV' },
           ]}
           onChange={(v) => setStorageType(v as StorageBackend)}
@@ -329,6 +347,11 @@ export function SyncTab({
                     Disconnect
                   </button>
                 </>
+              ) : cloudProviderKey && !providerReady[cloudProviderKey] ? (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  {providerLabel} sync is coming soon. For now, use <strong>WebDAV</strong> or a{' '}
+                  <strong>sync folder</strong> to back up across devices.
+                </p>
               ) : (
                 <button
                   type="button"

--- a/src/lib/backend/browser-invoke.ts
+++ b/src/lib/backend/browser-invoke.ts
@@ -729,6 +729,10 @@ async function dispatch(command: string, p: Params): Promise<any> {
     case 'get_activity_stats':
       return dbGetActivityStats();
 
+    // Managed cloud providers don't run in the browser build.
+    case 'cloud_provider_available':
+      return false;
+
     default:
       console.warn(`[browser-invoke] unhandled command: ${command}`, p);
       return null;

--- a/src/lib/services/cloudProvidersService.ts
+++ b/src/lib/services/cloudProvidersService.ts
@@ -19,6 +19,15 @@ export async function cloudProviderAuthStart(provider: 'dropbox' | 'gdrive'): Pr
   return invoke('cloud_provider_auth_start', { provider });
 }
 
+/**
+ * Whether a managed provider has real OAuth credentials compiled in. False while
+ * the build ships placeholder creds, so the UI can show "coming soon" instead of
+ * a dead-end connect button.
+ */
+export async function cloudProviderAvailable(provider: 'dropbox' | 'gdrive'): Promise<boolean> {
+  return invoke<boolean>('cloud_provider_available', { provider });
+}
+
 async function cloudProviderUploadBlob(
   provider: 'dropbox' | 'gdrive',
   blob: string,


### PR DESCRIPTION
## Why

Two capability-honesty fixes so users (especially on mobile) don't hit dead ends. Scope was deliberately trimmed: Dropbox/GDrive aren't functional yet (placeholder creds) and BYO-folder's Android support is unverified, so this PR makes the **truth** clear rather than headlining paths that may not work.

## Changes

- **Coming-soon providers**: Dropbox / Google Drive ship with `*_PLACEHOLDER` OAuth creds, so their connect buttons error. A new `cloud_provider_available(provider)` command reports whether real creds are compiled in. `SyncTab` labels them **"(coming soon)"** in the picker and, when one is selected, shows a note pointing to **WebDAV / sync folder** instead of a dead-end Connect button. **Auto-corrects** once real credentials are baked in — no UI change needed then. Stubbed `false` in the browser shim.
- **Hide Android no-op log button**: "Open Log Folder" is gated to `isDesktop` — Android/iOS have no OS file-manager launcher, so it silently did nothing. (This was the deferred item from the media-intent PR #166.)

## Verification

- `npm run typecheck` ✅ · `lint:ci` ✅ · `vitest` ✅ (1520) · `cargo check`/`clippy` ✅.
- Web-verifiable: at a phone viewport, Settings → Sync shows Dropbox/Drive as "(coming soon)"; About hides "Open Log Folder".
- **Owner, on device:** confirm the coming-soon copy reads right and WebDAV/sync-folder remain the offered cloud paths.

## Note

Branched off current `main` (which now includes the `canPeerSync/canSTT/canHardwareKey` capability flags and BYO-Cloud sync #149). The deeper "cloud is the headline" mobile UX is intentionally deferred until on-device testing tells us which sync paths actually work on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)