### PR TITLE
fix(website): bind "VirusTotal scanned" badge to the actual report

### DIFF
--- a/scripts/update-latest-release-json.cjs
+++ b/scripts/update-latest-release-json.cjs
@@ -64,12 +64,15 @@ function computeSeverity(tag) {
   return major > 1 || (major === 1 && minor >= 8) ? 'security' : 'recommended';
 }
 
+const virusTotalAsset = release.assets.find((a) => a.name === 'virustotal.txt');
+
 const payload = {
   version: release.tagName,
   releaseUrl: release.url,
   publishedAt: release.publishedAt,
   severity: computeSeverity(release.tagName),
   assets,
+  ...(virusTotalAsset ? { virusTotalUrl: virusTotalAsset.url } : {}),
 };
 
 const fs = require('fs');

--- a/website/app/download/DownloadClient.tsx
+++ b/website/app/download/DownloadClient.tsx
@@ -200,14 +200,16 @@ export default function DownloadClient({ release }: { release: LatestRelease | n
             {primaryAsset?.checksumVerified !== false && (
               <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ SHA-256 verified</span>
             )}
-            <a
-              href={release?.releaseUrl ?? "https://github.com/kenlacroix/moodhaven-journal/releases/latest"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full hover:text-neutral-700 hover:bg-neutral-200 focus-visible:ring-1 focus-visible:ring-primary-700"
-            >
-              ✓ VirusTotal scanned
-            </a>
+            {release?.virusTotalUrl && (
+              <a
+                href={release.virusTotalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full hover:text-neutral-700 hover:bg-neutral-200 focus-visible:ring-1 focus-visible:ring-primary-700"
+              >
+                ✓ VirusTotal scanned
+              </a>
+            )}
             <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ No account required</span>
             <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-100 px-2.5 py-1 rounded-full">✓ MIT licensed</span>
           </div>

--- a/website/lib/getLatestRelease.test.ts
+++ b/website/lib/getLatestRelease.test.ts
@@ -74,4 +74,45 @@ describe("getLatestRelease", () => {
     mockFetch({ ...VALID_PAYLOAD, assets: [] });
     expect(await getLatestRelease()).toBeNull();
   });
+
+  it("passes through virusTotalUrl from the fallback JSON", async () => {
+    const url =
+      "https://github.com/kenlacroix/moodhaven-journal/releases/download/v0.9.0/virustotal.txt";
+    mockFetch({ ...VALID_PAYLOAD, virusTotalUrl: url });
+    const result = await getLatestRelease();
+    expect(result?.virusTotalUrl).toBe(url);
+  });
+
+  it("rejects a non-github virusTotalUrl in the fallback JSON", async () => {
+    mockFetch({ ...VALID_PAYLOAD, virusTotalUrl: "https://evil.com/report.txt" });
+    expect(await getLatestRelease()).toBeNull();
+  });
+
+  it("leaves virusTotalUrl undefined when the release has no report", async () => {
+    mockFetch(VALID_PAYLOAD);
+    const result = await getLatestRelease();
+    expect(result?.virusTotalUrl).toBeUndefined();
+  });
+
+  it("extracts virusTotalUrl from the GitHub API asset list and drops it from assets", async () => {
+    const vtUrl =
+      "https://github.com/kenlacroix/moodhaven-journal/releases/download/v0.9.0/virustotal.txt";
+    mockFetch({
+      tag_name: "v0.9.0",
+      html_url: "https://github.com/kenlacroix/moodhaven-journal/releases/tag/v0.9.0",
+      published_at: "2026-04-01T00:00:00Z",
+      assets: [
+        {
+          name: "MoodHaven_0.9.0_amd64.AppImage",
+          browser_download_url:
+            "https://github.com/kenlacroix/moodhaven-journal/releases/download/v0.9.0/MoodHaven_0.9.0_amd64.AppImage",
+          size: 96_780_000,
+        },
+        { name: "virustotal.txt", browser_download_url: vtUrl, size: 1024 },
+      ],
+    });
+    const result = await getLatestRelease();
+    expect(result?.virusTotalUrl).toBe(vtUrl);
+    expect(result?.assets.map((a) => a.name)).not.toContain("virustotal.txt");
+  });
 });

--- a/website/lib/getLatestRelease.ts
+++ b/website/lib/getLatestRelease.ts
@@ -11,6 +11,8 @@ export interface LatestRelease {
   releaseUrl: string;
   publishedAt: string;
   assets: ReleaseAsset[];
+  /** download URL of the release's virustotal.txt report, when present. */
+  virusTotalUrl?: string;
 }
 
 const GITHUB_REPO = "kenlacroix/moodhaven-journal";
@@ -37,6 +39,7 @@ function parseGitHubApiResponse(data: unknown): LatestRelease | null {
   if (!releaseUrl.startsWith("https://github.com/")) return null;
 
   const assets: ReleaseAsset[] = [];
+  let virusTotalUrl: string | undefined;
   if (Array.isArray(d.assets)) {
     for (const asset of d.assets) {
       if (!asset || typeof asset !== "object") continue;
@@ -47,12 +50,16 @@ function parseGitHubApiResponse(data: unknown): LatestRelease | null {
       const size = typeof a.size === "number" ? a.size : 0;
 
       if (!name || !downloadUrl.startsWith("https://github.com/")) continue;
+      if (name === "virustotal.txt") {
+        virusTotalUrl = downloadUrl;
+        continue;
+      }
       assets.push({ name, downloadUrl, sizeLabel: formatBytes(size) });
     }
   }
 
   if (assets.length === 0) return null;
-  return { version, releaseUrl, publishedAt, assets };
+  return { version, releaseUrl, publishedAt, assets, virusTotalUrl };
 }
 
 function isValidRelease(data: unknown): data is LatestRelease {
@@ -65,6 +72,12 @@ function isValidRelease(data: unknown): data is LatestRelease {
   )
     return false;
   if (typeof d.publishedAt !== "string") return false;
+  if (
+    d.virusTotalUrl !== undefined &&
+    (typeof d.virusTotalUrl !== "string" ||
+      !d.virusTotalUrl.startsWith("https://github.com/"))
+  )
+    return false;
   if (!Array.isArray(d.assets)) return false;
   for (const asset of d.assets) {
     if (!asset || typeof asset !== "object") return false;


### PR DESCRIPTION
## What

The download page's **"✓ VirusTotal scanned"** chip was:
1. **Unconditional** — it always rendered, regardless of whether VirusTotal actually ran for the release. Accurate today (the CI key is set, so every release scans), but it would have falsely claimed "scanned" if a release were ever cut without VT.
2. **Linked to the generic release page** — clicking it didn't take you to the actual report.

## Fix

- `website/lib/getLatestRelease.ts` — parse `virustotal.txt` from the GitHub API asset list into `LatestRelease.virusTotalUrl` (and exclude it from the displayed download assets). Validate it as a `github.com` URL on the fallback-JSON path since it becomes an `href`.
- `scripts/update-latest-release-json.cjs` — emit `virusTotalUrl` in the CI-generated `latest-release.json` fallback.
- `website/app/download/DownloadClient.tsx` — gate the badge on `release.virusTotalUrl` and link it straight to the per-release `virustotal.txt`.

Now the chip only appears when a real VT report exists for that release, and it links to it.

## Tests

- 4 new cases in `getLatestRelease.test.ts` (API extraction + asset exclusion, fallback passthrough, non-github rejection, undefined-when-absent). 12/12 pass.
- `tsc --noEmit` clean; ESLint clean on changed files.

Core AV implementation (`scripts/submit-virustotal.cjs` + `build.yml` wiring) was reviewed and is correct/fail-safe — this PR only tightens the user-facing badge accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)