### PR TITLE
fix(android): use getPluginManager() for Tauri 2.11 plugin registration

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
@@ -7,8 +7,8 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     installSplashScreen()
-    pluginManager.load(null, "biometric", BiometricPlugin(this), "{}")
-    pluginManager.load(null, "wear", WearPlugin(this), "{}")
+    getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
+    getPluginManager().load(null, "wear", WearPlugin(this), "{}")
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
   }


### PR DESCRIPTION
## Problem

Every local Android build failed at `:app:compileUniversalDebugKotlin`:

```
e: …/MainActivity.kt:10:5 Unresolved reference: pluginManager
e: …/MainActivity.kt:11:5 Unresolved reference: pluginManager
```

`MainActivity` registered the custom **biometric** and **wear** plugins through a `pluginManager` *property* on `TauriActivity`. As of **Tauri 2.11** (the version resolved in `Cargo.lock`), the generated `TauriActivity` no longer exposes that property — it provides a method instead:

```kotlin
abstract class TauriActivity : WryActivity() {
  fun getPluginManager(): PluginManager { return PluginManager }
  ...
}
```

So `MainActivity.kt` was written against an older Tauri API, and the stale reference broke the Kotlin compile — blocking **all** Android builds (debug APK, the wear/phone bundles, and any integration branch built on top of `main`).

## Fix

Switch the two registration calls from the property to the accessor. The `load(...)` arguments are unchanged — `PluginManager.load(webView: WebView?, name: String, plugin: Plugin, config: String)` is identical in 2.11:

```diff
-    pluginManager.load(null, "biometric", BiometricPlugin(this), "{}")
-    pluginManager.load(null, "wear", WearPlugin(this), "{}")
+    getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
+    getPluginManager().load(null, "wear", WearPlugin(this), "{}")
```

## Verification

- `npm run tauri android build -- --apk --target aarch64 --debug` now compiles Kotlin and produces `app-universal-debug.apk`.
- Installed on a **Pixel 9 (Android)** and launched: app boots, lock screen renders, unlock works, biometric/wear plugin registration no longer throws at compile time.
- Used the resulting APK to run the Phase 1 capability-gate QA — all gates pass.

Scoped to `MainActivity.kt` only; no feature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)