### PR TITLE
feat(web): durable-storage guard + backup nudge (PWA)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 import { useAppBanners } from './hooks/useAppBanners';
+import { useStoragePersistence } from './hooks/useStoragePersistence';
 import { BreakoutWriterApp } from './components/breakout/BreakoutWriterApp';
 
 // Views are lazy-loaded: only the initial WritingView is preloaded; all others
@@ -131,6 +132,12 @@ function MainApp() {
     onThisDayOldestYear,
     dismissOnThisDay,
   } = useAppBanners(isUnlocked && !!sessionPassword);
+
+  // Browser/PWA only: request durable IndexedDB storage once per session; nudge a
+  // backup if the browser denies it (eviction would lose the journal).
+  const { showBackupNudge, dismissBackupNudge } = useStoragePersistence(
+    isUnlocked && !!sessionPassword
+  );
 
   useEffect(() => {
     const init = async () => {
@@ -474,6 +481,36 @@ function MainApp() {
           <button
             type="button"
             onClick={dismissOnThisDay}
+            aria-label="Dismiss"
+            className="flex-shrink-0 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {/* Browser/PWA: durable storage denied — nudge an encrypted backup */}
+      {showBackupNudge && (
+        <div className="fixed bottom-5 left-5 z-50 flex items-start gap-3 px-4 py-3 rounded-xl bg-white dark:bg-slate-800 border border-amber-300 dark:border-amber-700 shadow-lg max-w-xs animate-slide-up" role="alert">
+          <span className="text-base mt-0.5">⚠️</span>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">Back up your journal</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+              This browser may clear MoodHaven's stored data when disk space runs low. Export an encrypted backup to be safe.
+            </p>
+            <button
+              type="button"
+              onClick={() => { dismissBackupNudge(); handleNavigate('settings'); }}
+              className="mt-1.5 text-xs font-medium text-violet-600 dark:text-violet-400 hover:underline"
+            >
+              Back up now
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={dismissBackupNudge}
             aria-label="Dismiss"
             className="flex-shrink-0 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
           >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ function App() {
 function MainApp() {
   const { isUnlocked, isInitialized, checkInitialization, lock, sessionPassword } = useAppStore();
   const loadSettings = useSettingsStore((s) => s.loadSettings);
+  const setScrollToSection = useSettingsStore((s) => s.setScrollToSection);
   const hasSeenTutorial = useSettingsStore((s) => s.settings.tutorial?.hasSeenTutorial);
   const hasSeenDisclaimer = useSettingsStore((s) => s.settings.wellness?.hasSeenDisclaimer ?? true);
   const stillhavenEnabled = useSettingsStore((s) => s.settings.wellness?.stillhavenEnabled ?? false);
@@ -502,7 +503,7 @@ function MainApp() {
             </p>
             <button
               type="button"
-              onClick={() => { dismissBackupNudge(); handleNavigate('settings'); }}
+              onClick={() => { dismissBackupNudge(); setScrollToSection('export'); handleNavigate('settings'); }}
               className="mt-1.5 text-xs font-medium text-violet-600 dark:text-violet-400 hover:underline"
             >
               Back up now

--- a/src/hooks/useStoragePersistence.test.ts
+++ b/src/hooks/useStoragePersistence.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useStoragePersistence } from './useStoragePersistence';
+
+vi.mock('../lib/services/storagePersistence', () => ({
+  ensurePersistentStorage: vi.fn(),
+}));
+
+// The global test setup stubs window.__TAURI_INTERNALS__, so usePlatform().isBrowser
+// is false by default. Force browser mode here to exercise the hook's active path.
+vi.mock('./usePlatform', () => ({
+  usePlatform: () => ({ isBrowser: true }),
+}));
+
+import { ensurePersistentStorage } from '../lib/services/storagePersistence';
+
+const mockEnsure = vi.mocked(ensurePersistentStorage);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  mockEnsure.mockResolvedValue('persisted');
+});
+
+describe('useStoragePersistence', () => {
+  it('does nothing when enabled=false', async () => {
+    const { result } = renderHook(() => useStoragePersistence(false));
+    await act(async () => { /* flush */ });
+    expect(mockEnsure).not.toHaveBeenCalled();
+    expect(result.current.showBackupNudge).toBe(false);
+  });
+
+  it('does not show the nudge when storage is persisted', async () => {
+    mockEnsure.mockResolvedValue('persisted');
+    const { result } = renderHook(() => useStoragePersistence(true));
+    await waitFor(() => expect(mockEnsure).toHaveBeenCalled());
+    expect(result.current.showBackupNudge).toBe(false);
+  });
+
+  it('shows the backup nudge when storage is denied', async () => {
+    mockEnsure.mockResolvedValue('denied');
+    const { result } = renderHook(() => useStoragePersistence(true));
+    await waitFor(() => expect(result.current.showBackupNudge).toBe(true));
+  });
+
+  it('does not show the nudge when the API is unsupported', async () => {
+    mockEnsure.mockResolvedValue('unsupported');
+    const { result } = renderHook(() => useStoragePersistence(true));
+    await waitFor(() => expect(mockEnsure).toHaveBeenCalled());
+    expect(result.current.showBackupNudge).toBe(false);
+  });
+
+  it('checks only once per session', async () => {
+    const first = renderHook(() => useStoragePersistence(true));
+    await waitFor(() => expect(mockEnsure).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    renderHook(() => useStoragePersistence(true));
+    await act(async () => { /* flush */ });
+    expect(mockEnsure).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be dismissed', async () => {
+    mockEnsure.mockResolvedValue('denied');
+    const { result } = renderHook(() => useStoragePersistence(true));
+    await waitFor(() => expect(result.current.showBackupNudge).toBe(true));
+    act(() => result.current.dismissBackupNudge());
+    expect(result.current.showBackupNudge).toBe(false);
+  });
+});

--- a/src/hooks/useStoragePersistence.ts
+++ b/src/hooks/useStoragePersistence.ts
@@ -1,0 +1,53 @@
+/**
+ * useStoragePersistence — fires once per unlock session in the browser/PWA build to
+ * request durable IndexedDB storage (see `storagePersistence.ts`). If the browser
+ * denies persistence, the journal can be evicted under storage pressure, so the hook
+ * surfaces a one-time "back up your journal" nudge.
+ *
+ * Browser-only: gated on `usePlatform().isBrowser`, so it is inert in the desktop and
+ * native mobile builds (real filesystem, no eviction risk).
+ */
+
+import { useEffect, useState } from 'react';
+import { usePlatform } from './usePlatform';
+import { ensurePersistentStorage } from '../lib/services/storagePersistence';
+import { logger } from '../lib/services/logger';
+
+const SESSION_KEY = 'mb_storage_persist_checked';
+
+export interface StoragePersistenceState {
+  /** True only in the browser build when the browser denied durable storage. */
+  showBackupNudge: boolean;
+  dismissBackupNudge: () => void;
+}
+
+export function useStoragePersistence(enabled: boolean): StoragePersistenceState {
+  const { isBrowser } = usePlatform();
+  const [showBackupNudge, setShowBackupNudge] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !isBrowser) return;
+    if (sessionStorage.getItem(SESSION_KEY)) return;
+
+    let cancelled = false;
+    ensurePersistentStorage()
+      .then((state) => {
+        if (cancelled) return;
+        // Checked once per session regardless of outcome — no point re-prompting.
+        sessionStorage.setItem(SESSION_KEY, '1');
+        if (state === 'denied') setShowBackupNudge(true);
+      })
+      .catch((error) => {
+        logger.warn('[useStoragePersistence] persist check failed', { error: String(error) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, isBrowser]);
+
+  return {
+    showBackupNudge,
+    dismissBackupNudge: () => setShowBackupNudge(false),
+  };
+}

--- a/src/lib/services/storagePersistence.test.ts
+++ b/src/lib/services/storagePersistence.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ensurePersistentStorage } from './storagePersistence';
+
+function stubStorageManager(value: Partial<StorageManager> | undefined) {
+  Object.defineProperty(navigator, 'storage', {
+    value,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  // Restore whatever jsdom provides by default between tests.
+  stubStorageManager(undefined);
+  vi.restoreAllMocks();
+});
+
+describe('ensurePersistentStorage', () => {
+  it('returns "unsupported" when the Storage Manager API is missing', async () => {
+    stubStorageManager(undefined);
+    expect(await ensurePersistentStorage()).toBe('unsupported');
+  });
+
+  it('returns "unsupported" when persist/persisted are not functions', async () => {
+    stubStorageManager({} as StorageManager);
+    expect(await ensurePersistentStorage()).toBe('unsupported');
+  });
+
+  it('returns "persisted" without re-prompting when already persisted', async () => {
+    const persist = vi.fn();
+    stubStorageManager({
+      persisted: vi.fn().mockResolvedValue(true),
+      persist,
+    } as unknown as StorageManager);
+    expect(await ensurePersistentStorage()).toBe('persisted');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('returns "persisted" when the browser grants the request', async () => {
+    stubStorageManager({
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(true),
+    } as unknown as StorageManager);
+    expect(await ensurePersistentStorage()).toBe('persisted');
+  });
+
+  it('returns "denied" when the browser declines the request', async () => {
+    stubStorageManager({
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(false),
+    } as unknown as StorageManager);
+    expect(await ensurePersistentStorage()).toBe('denied');
+  });
+
+  it('returns "unsupported" when the API throws', async () => {
+    stubStorageManager({
+      persisted: vi.fn().mockRejectedValue(new Error('boom')),
+      persist: vi.fn(),
+    } as unknown as StorageManager);
+    expect(await ensurePersistentStorage()).toBe('unsupported');
+  });
+});

--- a/src/lib/services/storagePersistence.ts
+++ b/src/lib/services/storagePersistence.ts
@@ -1,0 +1,36 @@
+/**
+ * storagePersistence — request durable IndexedDB storage in the browser/PWA build.
+ *
+ * Browsers may evict IndexedDB under storage pressure; in the web build that means
+ * losing the journal. `navigator.storage.persist()` asks the browser to exempt this
+ * origin from automatic eviction. Desktop/native builds are unaffected (they use a
+ * real filesystem) — callers gate this to the browser build.
+ */
+
+export type PersistenceState = 'persisted' | 'denied' | 'unsupported';
+
+/**
+ * Ensure the origin has durable storage. Returns:
+ *  - `'persisted'`   — storage is (now or already) exempt from eviction
+ *  - `'denied'`      — the browser declined the request (eviction still possible)
+ *  - `'unsupported'` — the Storage Manager API is unavailable or threw
+ *
+ * Idempotent and safe to call repeatedly: if storage is already persisted it
+ * short-circuits without re-prompting.
+ */
+export async function ensurePersistentStorage(): Promise<PersistenceState> {
+  const storage = typeof navigator !== 'undefined' ? navigator.storage : undefined;
+  if (
+    !storage ||
+    typeof storage.persist !== 'function' ||
+    typeof storage.persisted !== 'function'
+  ) {
+    return 'unsupported';
+  }
+  try {
+    if (await storage.persisted()) return 'persisted';
+    return (await storage.persist()) ? 'persisted' : 'denied';
+  } catch {
+    return 'unsupported';
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -257,6 +257,9 @@ export function SettingsPage({ updateHook, onClose }: SettingsPageProps) {
     } else if (scrollToSection === 'sync') {
       setActiveTab('sync');
       setScrollToSection(null);
+    } else if (scrollToSection === 'export') {
+      setActiveTab('export');
+      setScrollToSection(null);
     } else if (scrollToSection === 'privacy') {
       setActiveTab('privacy');
       setScrollToSection(null);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -35,7 +35,7 @@ import { cloudProviderStatus } from '../lib/services/cloudProvidersService';
 import { useAppStore } from './appStore';
 
 // Section to scroll to when settings page opens
-type SettingsScrollTarget = 'speech-to-text' | 'ai' | 'privacy' | 'privacy-checkup' | 'health' | 'notifications' | 'sync' | null;
+type SettingsScrollTarget = 'speech-to-text' | 'ai' | 'privacy' | 'privacy-checkup' | 'health' | 'notifications' | 'sync' | 'export' | null;
 
 interface SettingsState {
   settings: AppSettings;


### PR DESCRIPTION
## What

Closes the P2 **PWA storage-persistence guard** from `active-plans/post-1.8.0-roadmap.md` §4. The browser/PWA build stores the journal in IndexedDB, which the browser may **evict under storage pressure** — silently losing data. This requests durable storage and nudges a backup if the browser refuses.

## How

- **`storagePersistence.ts`** — `ensurePersistentStorage()` returns `persisted | denied | unsupported`. Idempotent (short-circuits via `storage.persisted()` so it never re-prompts), and tolerant of the Storage Manager API being absent or throwing.
- **`useStoragePersistence.ts`** — fires **once per session** (sessionStorage guard), gated on `usePlatform().isBrowser` so it is completely inert in the desktop and native mobile builds (real filesystem, no eviction risk). Exposes `showBackupNudge` + `dismissBackupNudge`.
- **`App.tsx`** — renders a dismissible amber nudge when storage was denied; "Back up now" navigates to Settings (where encrypted export lives).

## Scope notes

- Web-target only — zero behavior change on desktop/Android/iOS.
- No new dependencies; uses the standard `navigator.storage` API.
- No backend/Rust changes; does not touch peer sync or any mobile code.

## Tests

12 new unit tests (all green):
- `storagePersistence.test.ts` (6): already-persisted (no re-prompt), granted, denied, missing API, non-function API, throwing API.
- `useStoragePersistence.test.ts` (6): inert when disabled, no nudge on persisted/unsupported, nudge on denied, once-per-session, dismiss.

Health: `vitest run` (new files) ✅ · `tsc --noEmit` ✅ · `lint:ci` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)