### PR TITLE
fix(recovery): re-verify derived key against stored hash on recovery-key promote

### DIFF
--- a/src/pages/LockScreen.test.tsx
+++ b/src/pages/LockScreen.test.tsx
@@ -327,6 +327,47 @@ describe('LockScreen — PIN lockout: countdown expiry re-enables input', () => 
   }, 15000);
 });
 
+describe('LockScreen — recovery key: corrupted escrow guard', () => {
+  it('rejects a recovered password that does not match the stored hash (with 2FA enabled)', async () => {
+    const { recoverPassword, isRecoveryKeyEnabled } = await import(
+      '../lib/services/recoveryKeyService'
+    );
+    vi.mocked(isRecoveryKeyEnabled).mockResolvedValueOnce(true);
+    vi.mocked(recoverPassword).mockResolvedValueOnce('wrong-decrypted-password');
+
+    const { verifyUserPassword } = await import('../lib/services/journalService');
+    // Escrow decrypts cleanly but yields a password that fails hash verification.
+    vi.mocked(verifyUserPassword).mockResolvedValueOnce(false);
+
+    // 2FA enabled — without the guard this path would promote via finalizeUnlock (no verify).
+    const { get2FAStatus } = await import('../lib/services/twoFactorService');
+    vi.mocked(get2FAStatus).mockResolvedValue({
+      enabled: true,
+      method: 'totp',
+      has_backup_codes: true,
+    });
+
+    render(<LockScreen />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /use recovery key/i })).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByRole('button', { name: /use recovery key/i }));
+    await userEvent.type(
+      screen.getByLabelText(/recovery key/i),
+      'AAAA-BBBB-CCCC-DDDD-EEEE-FFFF'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /unlock/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/escrow corrupted/i)).toBeInTheDocument();
+    });
+    // Must NOT advance to the 2FA step or promote the session.
+    expect(screen.queryByText(/enter recovery key/i)).toBeInTheDocument();
+    expect(mockFinalizeUnlock).not.toHaveBeenCalled();
+    expect(mockUnlock).not.toHaveBeenCalled();
+  });
+});
+
 describe('LockScreen — PIN submit: stale password', () => {
   it('shows stale-password error when PIN decrypts but verifyUserPassword fails', async () => {
     const { verifyUserPassword } = await import('../lib/services/journalService');

--- a/src/pages/LockScreen.tsx
+++ b/src/pages/LockScreen.tsx
@@ -452,6 +452,19 @@ export function LockScreen() {
           return;
         }
 
+        // Re-verify the recovered password against the stored hash before promoting it.
+        // The recovery key only decrypts an escrowed copy of the password; a corrupted
+        // escrow blob could decrypt cleanly yet yield the wrong password. Without this
+        // check the 2FA branch promotes it via finalizeUnlock (which skips verify_password),
+        // silently unlocking with a key that cannot decrypt entries.
+        const recoveredValid = await verifyUserPassword(recoveredPassword);
+        if (!recoveredValid) {
+          setRecoveryKeyInput('');
+          setIsLoading(false);
+          setError('Recovery key valid but escrow corrupted — derived password does not match.');
+          return;
+        }
+
         // Check if 2FA is enabled
         if (twoFactorStatus?.enabled) {
           // Store the recovered password for use after 2FA verification


### PR DESCRIPTION
## What

Closes the P2/LOW roadmap item from `active-plans/post-1.8.0-roadmap.md` §4: "the recovery-key promote path does not yet re-verify the derived key against the stored hash."

The optional recovery key (key escrow) decrypts a stored copy of the master password. That recovered password is then promoted to unlock the session. The two promote branches were inconsistent:

- **No-2FA path** → `unlock()` → `unlockJournal` → `verify_password` (re-verified ✓)
- **2FA path** → stashes the recovered password and, after 2FA, calls `finalizeUnlock`, which **deliberately skips** `verify_password` (to avoid resetting `TwoFactorPendingState`).

So with 2FA enabled, a corrupted escrow blob that decrypts cleanly to the *wrong* password would silently promote it — unlocking a session that cannot decrypt any entries, with no clear signal to the user.

## How

In `handleRecoveryKeySubmit` (`src/pages/LockScreen.tsx`), immediately after `recoverPassword` succeeds and before either branch, re-verify the recovered password against the stored hash via the existing `verifyUserPassword` (`verify_password`). On mismatch, fail with `"Recovery key valid but escrow corrupted — derived password does not match."` instead of proceeding. This is the single authoritative re-verify point and covers both the 2FA and no-2FA branches.

Minimal change, reuses existing patterns (mirrors the PIN-unlock stale-password guard). No backward-compat shims.

## Tests

Added one focused vitest case in `src/pages/LockScreen.test.tsx`: recovery key with 2FA enabled, escrow decrypts to a password that fails hash verification → asserts the "escrow corrupted" error shows, the flow does not advance to 2FA, and neither `unlock` nor `finalizeUnlock` is called.

- `npx vitest run src/pages/LockScreen.test.tsx` → 13 passed (was 12)
- `npm run typecheck` → clean

Note: machine was heavily CPU-contended (concurrent compiles), so `clippy`/full suite were left to CI. This change is TS-only — no Rust touched.