### PR TITLE
fix(ci): longer kill-window for change_master_password crash-replay boundaries

### DIFF
--- a/scripts/crash-replay.sh
+++ b/scripts/crash-replay.sh
@@ -76,6 +76,12 @@ replay_boundary() {
   # Run parked at this boundary; kill once it signals readiness. The brace group's stderr is
   # dropped so the shell's async "Killed" job notice (expected) doesn't pollute the exhibit.
   local killed="TIMEOUT" pid status
+  # change_master_password re-derives keys (600k-iter PBKDF2) and re-encrypts media before it
+  # can park at a boundary, so it needs a far longer readiness budget than the migrate path.
+  # On a loaded CI runner the old fixed ~10s window expired before the real kill -9 landed,
+  # scoring the boundary as TIMEOUT (a false failure) even though recovery rolled back cleanly.
+  local budget=200                    # ~10s — migrate boundaries park almost immediately
+  [ "$kind" = "cp" ] && budget=1200   # ~60s — cp does heavy crypto before reaching its park point
   {
     if [ "$kind" = "cp" ]; then
       MH_CRASH_POINT="$b" MH_CRASH_READY="$ready" "$BIN" cp-change "$dir" "$PW" "$NEWPW" >/dev/null 2>&1 &
@@ -83,7 +89,7 @@ replay_boundary() {
       MH_CRASH_POINT="$b" MH_CRASH_READY="$ready" "$BIN" migrate "$dir" "$PW" >/dev/null 2>&1 &
     fi
     pid=$!
-    for _ in $(seq 1 200); do      # ~10s
+    for _ in $(seq 1 "$budget"); do   # budget set above: migrate ~10s, cp ~60s
       if [ -f "$ready" ]; then
         kill -9 "$pid" 2>/dev/null
         wait "$pid"; status=$?


### PR DESCRIPTION
## Why

`main`'s Tests run (and every open PR) fails on one ubuntu-only step: **Crash-replay SIGKILL harness (Layer B)** — "3 failure(s) across 8 boundaries". The table shows all 8 boundaries actually recovered correctly; the 3 `cmp.*` (change_master_password) boundaries were killed by **TIMEOUT instead of SIGKILL**:

```
encrypt.after_salt      SIGKILL  old  intact  PASS
encrypt.* (×5)          SIGKILL  …    intact  PASS
cmp.tmp_built           TIMEOUT  old  ?       PASS
cmp.after_db_flip       TIMEOUT  old  ?       PASS
cmp.after_promote       TIMEOUT  old  ?       PASS
```

`replay_boundary` polled ~10s (`seq 1 200` × `sleep 0.05`) for the parked op to signal readiness, then `kill -9`. The `cmp` path re-derives keys (600k-iter PBKDF2) and re-encrypts media **before** it can park, so on a loaded ubuntu runner it exceeded 10s → no `ready` file → `killed="TIMEOUT"` → counted as a failure by `[ "$killed" = "SIGKILL" ] || FAILS++`, despite recovery rolling back to "old" every time.

## Fix

Make the readiness budget kind-aware: keep ~10s for the fast `migrate` boundaries, give the `cp` path ~60s so it reaches its park point and gets a genuine `kill -9`. The early-break means the larger ceiling costs nothing in the normal fast-park case, and the **SIGKILL-required assertion is unchanged** — a genuine timeout still fails (we didn't relax the safety check, just gave the slow path time to be tested properly).

Not a crash-safety regression — this was harness-timeout flakiness, pre-existing on main and identical across all open PRs.

`bash -n` clean. Verifying on this PR's ubuntu Rust job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)