### PR TITLE
fix: resolve Sonar-flagged correctness bugs (sort + reduce)

### DIFF
--- a/src/components/analytics/DayOfWeekPattern.tsx
+++ b/src/components/analytics/DayOfWeekPattern.tsx
@@ -98,8 +98,8 @@ export function DayOfWeekPattern({ data, isLoading = false }: DayOfWeekPatternPr
       {hasData && (() => {
         const active = data.filter((d) => d.entryCount > 0);
         if (active.length < 3) return null;
-        const best = active.reduce((a, b) => a.averageMood >= b.averageMood ? a : b);
-        const worst = active.reduce((a, b) => a.averageMood <= b.averageMood ? a : b);
+        const best = active.reduce((a, b) => a.averageMood >= b.averageMood ? a : b, active[0]);
+        const worst = active.reduce((a, b) => a.averageMood <= b.averageMood ? a : b, active[0]);
         if (best.dayOfWeek === worst.dayOfWeek) return null;
         if (best.averageMood - worst.averageMood < 0.2) return null;
         return (

--- a/src/hooks/useWearVoiceMemos.ts
+++ b/src/hooks/useWearVoiceMemos.ts
@@ -156,10 +156,11 @@ export function useWearVoiceMemos({
 
     const pending = memos.filter((m) => !m.transcription);
     // Sequential — one at a time to avoid hammering the sidecar
-    pending.reduce(
-      (chain, memo) => chain.then(() => transcribeMemo(memo.id)),
-      Promise.resolve()
-    );
+    void (async () => {
+      for (const memo of pending) {
+        await transcribeMemo(memo.id);
+      }
+    })();
   }, [memos, enabled, model, transcribeMemo]);
 
   // ── Called by useWearSignals.onVoiceMemo for newly-arrived memos ─────────

--- a/src/lib/backend/browser.ts
+++ b/src/lib/backend/browser.ts
@@ -264,7 +264,7 @@ export async function dbGetStreakStats(): Promise<{
   totalDays: number;
 }> {
   const entries = await dbGetAllEntries();
-  const days = [...new Set(entries.map((e) => e.created_at.slice(0, 10)))].sort();
+  const days = [...new Set(entries.map((e) => e.created_at.slice(0, 10)))].sort((a, b) => a.localeCompare(b));
   if (days.length === 0) return { currentStreak: 0, longestStreak: 0, totalDays: 0 };
 
   let longest = 1;

--- a/src/lib/services/cloudSyncService.ts
+++ b/src/lib/services/cloudSyncService.ts
@@ -116,7 +116,7 @@ export async function downloadBackup(
           return { success: false, error: 'No backups found on server' };
         }
         // Sort by name (date-based names sort chronologically) — take latest
-        targetFile = listResult.files.sort().reverse()[0];
+        targetFile = listResult.files.sort((a, b) => a.localeCompare(b)).reverse()[0];
       }
     }
 
@@ -152,5 +152,5 @@ export async function listBackups(webdavConfig: WebDAVConfig): Promise<string[]>
   if (!result.success || !result.files) {
     return [];
   }
-  return result.files.sort().reverse();
+  return result.files.sort((a, b) => a.localeCompare(b)).reverse();
 }

--- a/src/lib/utils/metadataExtractor.ts
+++ b/src/lib/utils/metadataExtractor.ts
@@ -543,7 +543,7 @@ function calculateStreaks(metadataList: EntryMetadata[]): {
   currentStreak: number;
   longestStreak: number;
 } {
-  const dates = [...new Set(metadataList.map((m) => m.date))].sort().reverse();
+  const dates = [...new Set(metadataList.map((m) => m.date))].sort((a, b) => a.localeCompare(b)).reverse();
   return calculateStreaksFromDates(dates);
 }
 
@@ -565,7 +565,7 @@ export function calculateGratitudeStreak(entries: JournalEntry[]): {
         .map((e) => new Date(e.created_at).toISOString().split('T')[0])
     ),
   ]
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .reverse();
 
   return calculateStreaksFromDates(gratitudeDates);


### PR DESCRIPTION
Fixes the 8 high-confidence bugs SonarQube Cloud flagged on `main` (all 5 CRITICAL + 3 MAJOR). The 18 MINOR a11y findings are intentionally deferred — see note below.

## Fixed
| Rule | Sev | Count | Fix |
|---|---|---|---|
| S2871 | CRITICAL | 5 | `Array.sort()` on string arrays (filenames, ISO dates) → explicit `localeCompare`. Behavior-preserving for the ASCII/ISO data, removes the locale-dependent ordering footgun. |
| S6959 | MAJOR | 2 | `reduce()` without initial value in `DayOfWeekPattern` → seed with `active[0]` (was guarded by `length>=3`, now explicit). |
| S2201 | MAJOR | 1 | Discarded `reduce()` promise chain in `useWearVoiceMemos` → explicit `for await` loop; same sequential behavior, return value no longer dropped. |

Files: `browser.ts`, `cloudSyncService.ts`, `metadataExtractor.ts`, `DayOfWeekPattern.tsx`, `useWearVoiceMemos.ts`.

## Verification
- `npm run typecheck` ✅
- `npm run lint:ci` ✅
- Targeted tests (metadataExtractor, useWearVoiceMemos, DayOfWeekPattern, cloudSyncService): 124 passed ✅

## Deferred: 18 a11y findings (S1082, MINOR)
Most are modal **backdrops** (`onClick={onClose}`) that already have document-level Escape handling, plus a couple of `stopPropagation` wrapper divs. The naive fix (`role="button"` + `tabIndex` on a full-screen overlay) makes a giant focusable element announced as a button — that's *worse* a11y, not better. These need per-case treatment (focus-trap aware, or marked won't-fix for pure backdrops) in a dedicated pass.

## Related false positives (UI triage, not code)
The 2 Sonar "vulnerabilities" are both false positives, to be marked Safe in the Sonar UI:
- `appStore.ts:58` — `sessionPassword: 'dev-bypass'`, a dev-only literal gated behind `import.meta.env.DEV` with a PROD throw.
- `recoveryKeyService.ts:29` — `'recovery_key_encrypted_password'` is a settings-**key name**, not a password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)