### PR TITLE
fix(peer-sync): persist peer identity on Android (stable device ID)

### DIFF
--- a/src-tauri/src/commands/peer_identity.rs
+++ b/src-tauri/src/commands/peer_identity.rs
@@ -42,7 +42,11 @@ struct PersistedIdentity {
 }
 
 fn detect_device_type() -> &'static str {
-    "desktop"
+    if cfg!(any(target_os = "android", target_os = "ios")) {
+        "phone"
+    } else {
+        "desktop"
+    }
 }
 
 fn default_device_name() -> String {
@@ -59,6 +63,14 @@ fn default_device_name() -> String {
 
 /// Try to load the Ed25519 seed from the OS keyring.
 /// Returns Some(seed) on success, None if not found or keyring unavailable.
+#[cfg(target_os = "android")]
+fn try_load_from_keyring() -> Option<[u8; 32]> {
+    // The `keyring` crate has no working Android backend; the peer key is
+    // persisted in peer_key.bin instead (see try_store_in_keyring).
+    None
+}
+
+#[cfg(not(target_os = "android"))]
 fn try_load_from_keyring() -> Option<[u8; 32]> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT).ok()?;
     let hex_str = entry.get_password().ok()?;
@@ -68,6 +80,14 @@ fn try_load_from_keyring() -> Option<[u8; 32]> {
 
 /// Try to store the Ed25519 seed in the OS keyring.
 /// Returns true on success, false if the keyring is unavailable.
+#[cfg(target_os = "android")]
+fn try_store_in_keyring(_seed: &[u8; 32]) -> bool {
+    // No working Android keyring backend — force the peer_key.bin file fallback
+    // so the device identity is stable across launches.
+    false
+}
+
+#[cfg(not(target_os = "android"))]
 fn try_store_in_keyring(seed: &[u8; 32]) -> bool {
     let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT) else {
         return false;


### PR DESCRIPTION
## Problem
On Android the peer device identity **regenerated on every access**, so the device ID was never stable — which breaks all peer pairing and sync (a peer trusts one ephemeral ID, then the device immediately becomes a different one).

Root cause: `get_or_create_device_identity` stores the Ed25519 seed via the `keyring` crate, which has **no working Android backend** — `set_password` reports success (so the `peer_key.bin` file fallback is skipped) but `get_password` returns nothing. The "reuse existing identity" check then fails every time and a new keypair is minted.

## Fix
- `try_store_in_keyring` / `try_load_from_keyring` are no-ops on Android → the peer key always uses the durable `peer_key.bin` (0600) file fallback. Desktop paths are byte-identical (non-Android `#[cfg]`).
- `detect_device_type()` returns `"phone"` on android/ios (was hardcoded `"desktop"`).

Same class of issue #167 fixed for the cloud-token key (AndroidKeyStore).

## Verification (Pixel 9, on device)
- `peer_get_identity` now returns the **same** device ID across repeated calls and across `adb install -r`; `peer_key.bin` (32 B) persists on disk; `deviceType = "phone"`.
- With a stable identity, pairing persists on both sides and peer sync connects + authenticates (previously impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)