### PR TITLE
fix(peer-sync): accept SQLite naive timestamps in parse_peer_timestamp

### DIFF
--- a/src-tauri/src/commands/peer_sync_engine/conflict.rs
+++ b/src-tauri/src/commands/peer_sync_engine/conflict.rs
@@ -16,6 +16,15 @@ const MAX_FUTURE_SECS: i64 = 10;
 fn parse_peer_timestamp(ts: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
     let dt = chrono::DateTime::parse_from_rfc3339(ts)
         .map(|dt| dt.with_timezone(&chrono::Utc))
+        .or_else(|_| {
+            // SQLite `datetime('now')` / CURRENT_TIMESTAMP schema defaults emit a
+            // naive "YYYY-MM-DD HH:MM:SS" (no 'T', no timezone) — treat as UTC.
+            // Both fallbacks require time components, so date-only strings (e.g.
+            // "9999-12-31") are still rejected.
+            chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%d %H:%M:%S")
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S"))
+                .map(|naive| naive.and_utc())
+        })
         .map_err(|_| format!("invalid timestamp: {ts:?}"))?;
     let limit = chrono::Utc::now() + chrono::TimeDelta::seconds(MAX_FUTURE_SECS);
     if dt > limit {


### PR DESCRIPTION
## Problem
`parse_peer_timestamp` accepted only strict **RFC3339** (`parse_from_rfc3339` — requires `T` + timezone). But several tables default `created_at`/`updated_at` to SQLite's `datetime('now')` / `CURRENT_TIMESTAMP` (`db/schema.sql`, `settings.rs`), which emit a **naive** `YYYY-MM-DD HH:MM:SS` (space, no TZ).

When such a row reached the manifest exchange, the receiving peer rejected the timestamp and **aborted the whole sync connection** (`invalid timestamp: "2026-06-13 12:57:32"`) before any data phase completed. Observed on a real two-device sync (Android phone ↔ Windows desktop) — the connection died before the entries/books/voice-memo phases ran.

## Fix
Add a fallback that parses the naive `%Y-%m-%d %H:%M:%S` (and the `T` variant) as **UTC**. The strict RFC3339 path is tried first and unchanged.

Security properties preserved:
- Both fallbacks require time components, so date-only strings (the far-future `"9999-12-31"` LWW-bypass guard) are still rejected.
- The `> now + MAX_FUTURE_SECS` future-timestamp check is unchanged.

## Verification
On a two-device sync that previously aborted with `invalid timestamp`, after this fix the manifest exchange completes and the data phases run (incl. the voice-memo sync phase carrying a memo across).

🤖 Generated with [Claude Code](https://claude.com/claude-code)