### PR TITLE
fix(stt): portable whisper build + graceful unsupported-CPU error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,25 +61,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # cmake_extra carries a baseline-ISA flag set on every x86-64 target so the
+          # whisper-cli sidecar runs on processors without AVX2/FMA/BMI2 (older CPUs,
+          # Pentium/Celeron, many virtualised CPUs). Without it ggml defaults to AVX2
+          # on x86-64 and the sidecar dies with an illegal-instruction fault. SSE4.2 is
+          # kept (universal since ~2010). arm64 uses NEON and is unaffected.
           - platform: Linux (x86_64)
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             whisper_binary: whisper-x86_64-unknown-linux-gnu
-            cmake_extra: ""
+            cmake_extra: "-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF"
             cross: false
 
           - platform: Windows (x86_64)
             os: windows-latest
             target: x86_64-pc-windows-msvc
             whisper_binary: whisper-x86_64-pc-windows-msvc.exe
-            cmake_extra: ""
+            cmake_extra: "-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF"
             cross: false
 
           - platform: macOS (x86_64)
             os: macos-latest
             target: x86_64-apple-darwin
             whisper_binary: whisper-x86_64-apple-darwin
-            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF"
             cross: false
 
           - platform: macOS (Apple Silicon)
@@ -132,7 +137,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: src-tauri/binaries/${{ matrix.whisper_binary }}
-          key: whisper-${{ matrix.whisper_binary }}-v1.7.4
+          key: whisper-${{ matrix.whisper_binary }}-v1.7.4-baseline-isa
 
       - name: Build whisper-cli sidecar
         if: steps.whisper_cache.outputs.cache-hit != 'true'

--- a/active-plans/stt-multi-isa-runtime-dispatch.md
+++ b/active-plans/stt-multi-isa-runtime-dispatch.md
@@ -1,0 +1,100 @@
+# STT multi-ISA whisper via ggml runtime CPU dispatch
+
+> **Status:** Planned (future enhancement). Follow-up to the "STT CPU portability" PR
+> (`fix/stt-cpu-portability`), which made the shipped sidecar a single **SSE4.2 baseline**
+> binary + a graceful "unsupported CPU" message.
+> **Decision gate:** only build this if baseline SSE4.2 transcription proves too slow in
+> practice. Voice-memo transcription is async/background and not latency-critical, so the
+> baseline is likely good enough — this recovers AVX2/AVX-512 speed *without* losing the
+> run-everywhere guarantee, at the cost of a multi-file sidecar bundle.
+
+---
+
+## Problem this solves
+
+The baseline build trades speed for reach: one binary compiled to SSE4.2 runs on every
+x86-64 CPU but leaves AVX2/FMA/AVX-512 performance on the table for modern machines (often
+2–4× slower matmul on long clips / larger models). We want **both**: fast on capable CPUs,
+still working on old ones.
+
+## Approach: ggml runtime backend dispatch
+
+ggml (whisper.cpp's tensor lib) can build **multiple CPU variants** and pick the best one at
+runtime by probing CPU features. Two cmake flags:
+
+- `-DGGML_BACKEND_DL=ON` — build the CPU backend as a **dynamically loaded** module rather
+  than statically linked into `whisper-cli`.
+- `-DGGML_CPU_ALL_VARIANTS=ON` — emit one module per micro-arch tier:
+  `sse42`, `sandybridge` (AVX), `haswell` (AVX2+FMA+BMI2), `skylakex`/`icelake` (AVX-512), …
+  At startup ggml loads the highest variant the running CPU supports and falls back down to
+  `sse42`.
+
+`GGML_BACKEND_DL` requires shared libs, so this also flips `-DBUILD_SHARED_LIBS=ON`. The
+sidecar stops being a single static `.exe`/ELF and becomes `whisper-cli` **plus** a set of
+loadable libraries (`libggml-base`, `libggml-cpu-haswell`, `libggml-cpu-sse42`, …) that must
+travel with it.
+
+Scope: **x86-64 only.** macOS arm64 (and any aarch64 target) is a single NEON variant — keep
+it static, no change. So the matrix forks: arm64 stays as-is, the three x86-64 targets get the
+multi-variant treatment.
+
+---
+
+## Work breakdown
+
+### 1. CI build (`.github/workflows/build.yml`)
+- For the three x86-64 whisper builds, replace the baseline-ISA `cmake_extra` with:
+  `-DBUILD_SHARED_LIBS=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON`.
+  (Drop the explicit `-DGGML_AVX*=OFF` flags — variants now cover the full range.)
+- After build, collect **all** produced artifacts, not just `whisper-cli`:
+  `whisper-cli(.exe)` + `ggml*`/`libggml*` core libs + every `*ggml-cpu-*` variant lib
+  (`.dll` on Windows, `.so` on Linux, `.dylib` on macOS). Stage them into a per-target
+  sidecar resource dir.
+- arm64 macOS keeps the current single-binary path.
+- Bump the whisper cache key again (artifact set changed).
+
+### 2. Tauri bundling (`src-tauri/tauri.conf.json`)
+- `externalBin` still points at `whisper-cli` (the launchable sidecar).
+- Add the variant/core libs to `bundle.resources` (per-platform) so they ship next to the
+  sidecar. Confirm the resource layout that lands them in a directory the loader can find on
+  each OS (NSIS/MSI on Windows, AppImage/.deb on Linux, .app on macOS).
+
+### 3. Runtime library resolution (`src-tauri/src/commands/speech_to_text.rs`, `voice_memos.rs`)
+- ggml-DL finds backend modules via its search path; the cleanest cross-platform knob is the
+  `GGML_BACKEND_PATH` env var (or running the sidecar with its CWD set to the resource dir).
+- When spawning the sidecar (`shell.sidecar("whisper")`), resolve the bundled resource dir via
+  Tauri's path API and set the env/CWD so the loader sees the variant libs. Centralise this in
+  one helper used by all three spawn sites.
+- Keep `cpu_unsupported_message` as the final safety net (a machine lacking even SSE4.2, or a
+  missing-libs misconfiguration, still degrades to a clear message).
+
+### 4. Verification (owner, on real hardware)
+- **AVX2 machine** (laptop): run a transcribe; confirm ggml's stderr log reports it loaded the
+  `haswell` (or higher) variant, and measure speed vs the baseline build on the same clip.
+- **No-AVX2 VM** (Pentium G4560): confirm it loads `sse42` and transcribes without
+  `STATUS_ILLEGAL_INSTRUCTION` — i.e. the fallback path still works.
+- Confirm the bundled installer actually carries the variant libs (inspect the installed dir).
+
+---
+
+## Risks / open questions
+- **Bundle size & file count.** Several extra MB of variant libs per platform; more files for
+  AV/code-signing to flag. Windows SmartScreen / macOS notarization must cover every `.dll`/
+  `.dylib`, not just the exe.
+- **Loader path fragility.** Getting `GGML_BACKEND_PATH`/CWD right across NSIS, AppImage, and
+  .app layouts is the main integration risk; a wrong path silently loses dispatch (or fails to
+  load any backend). Needs explicit on-device checks per OS.
+- **`GGML_BACKEND_DL` maturity.** Pin the whisper.cpp tag and verify the variant set it emits;
+  the tier names/flags have shifted across ggml releases.
+- **Marginal benefit for our default model.** If users mostly run `tiny.en`/`base.en` on short
+  voice memos, the baseline may already be fast enough — measure (step 4) before committing to
+  the added complexity.
+
+## Out of scope
+- Any change to the privacy model (still 100% local, no cloud STT).
+- arm64 / Android / iOS paths (NEON single-variant; iOS has no sidecar at all).
+
+## Process
+- New worktree off `main`; conventional commits (`feat(stt):` / `chore(ci):`).
+- Land only after the baseline PR (`fix/stt-cpu-portability`) merges — this builds on top of it.
+- Owner verifies on AVX2 + non-AVX2 hardware before merge (CI can't prove runtime dispatch).

--- a/docs/speech-to-text.md
+++ b/docs/speech-to-text.md
@@ -232,6 +232,26 @@ Platform suffixes follow Tauri's sidecar naming convention:
 
 In CI, this step runs during the build matrix before `npm run tauri build`.
 
+### Processor compatibility (baseline ISA)
+
+The shipped `whisper-cli` sidecar is built with a **baseline instruction set** on every
+x86-64 target: `-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF`
+(SSE4.2 is kept — universal since ~2010). Without this, ggml defaults to AVX2 on x86-64 and
+the sidecar dies with an illegal-instruction fault (`STATUS_ILLEGAL_INSTRUCTION` 0xC000001D on
+Windows, `SIGILL` on Unix) on older CPUs, low-end Pentium/Celeron parts, and many virtualised
+CPUs — with no output, so the failure was previously silent. The trade-off is a modest speed
+reduction on modern AVX2 machines, which is acceptable for the model sizes used here.
+
+As a safety net, `transcribe_voice_memo` / `stt_transcribe` detect that specific crash
+(`cpu_unsupported_message` in `speech_to_text.rs`) and return *"Speech-to-text isn't supported
+on this device's processor…"* instead of a generic error, so any future SIMD mismatch degrades
+gracefully rather than failing silently.
+
+> A future enhancement could ship multiple CPU variants and use ggml's runtime dispatch
+> (`GGML_CPU_ALL_VARIANTS` + `GGML_BACKEND_DL`) to recover AVX2 speed while keeping the baseline
+> fallback — at the cost of bundling the variant libraries alongside the single sidecar binary.
+> Planned in [`active-plans/stt-multi-isa-runtime-dispatch.md`](../active-plans/stt-multi-isa-runtime-dispatch.md).
+
 ---
 
 ## Privacy Guarantees

--- a/src-tauri/src/commands/speech_to_text.rs
+++ b/src-tauri/src/commands/speech_to_text.rs
@@ -470,6 +470,37 @@ pub async fn stt_delete_model(app: AppHandle, filename: String) -> Result<(), St
     Ok(())
 }
 
+/// Detect the failure that occurs when the whisper.cpp sidecar runs on a CPU
+/// lacking the SIMD instructions it was compiled for: the process dies with an
+/// illegal-instruction fault before producing any output. Surfacing a clear
+/// message lets the UI explain that transcription isn't supported on this
+/// processor instead of a generic "Whisper failed: exit code …".
+///
+/// - Windows reports `STATUS_ILLEGAL_INSTRUCTION` (0xC000001D) or
+///   `STATUS_PRIVILEGED_INSTRUCTION` (0xC0000096) as the process exit code.
+/// - Unix kills the process with `SIGILL`; tauri-plugin-shell surfaces signal
+///   death as `code == None`. A genuine SIMD fault crashes before whisper writes
+///   its init banner, so we additionally require empty output to avoid
+///   misclassifying ordinary non-zero exits.
+pub(crate) fn cpu_unsupported_message(
+    code: Option<i32>,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Option<String> {
+    const STATUS_ILLEGAL_INSTRUCTION: i32 = -1_073_741_795; // 0xC000001D
+    const STATUS_PRIVILEGED_INSTRUCTION: i32 = -1_073_741_674; // 0xC0000096
+    let illegal = matches!(
+        code,
+        Some(STATUS_ILLEGAL_INSTRUCTION) | Some(STATUS_PRIVILEGED_INSTRUCTION)
+    ) || (cfg!(unix) && code.is_none() && stdout.is_empty() && stderr.is_empty());
+
+    illegal.then(|| {
+        "Speech-to-text isn't supported on this device's processor. It requires a \
+         CPU with SSE4.2 (most processors from 2010 onward). Transcription was skipped."
+            .to_string()
+    })
+}
+
 /// Transcribe audio using whisper.cpp sidecar
 #[command]
 pub async fn stt_transcribe(
@@ -534,6 +565,11 @@ pub async fn stt_transcribe(
     let _ = fs::remove_file(&audio_path);
 
     if !output.status.success() {
+        if let Some(msg) =
+            cpu_unsupported_message(output.status.code(), &output.stdout, &output.stderr)
+        {
+            return Err(msg);
+        }
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         let detail = if !stderr.trim().is_empty() {
@@ -635,6 +671,11 @@ pub async fn stt_transcribe_timestamped(
 
     if !output.status.success() {
         let _ = fs::remove_file(&json_path);
+        if let Some(msg) =
+            cpu_unsupported_message(output.status.code(), &output.stdout, &output.stderr)
+        {
+            return Err(msg);
+        }
         let stderr = String::from_utf8_lossy(&output.stderr);
         // Fall back gracefully: return plain text from stdout if available
         let plain_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -815,5 +856,29 @@ mod tests {
         assert!(model_url("evil.sh").is_err());
         assert!(model_url("../../moodhaven.db").is_err());
         assert!(model_url("ggml-base.en.bin.malicious").is_err());
+    }
+
+    #[test]
+    fn cpu_unsupported_detects_windows_illegal_instruction() {
+        // STATUS_ILLEGAL_INSTRUCTION / STATUS_PRIVILEGED_INSTRUCTION, empty output.
+        assert!(cpu_unsupported_message(Some(-1_073_741_795), b"", b"").is_some());
+        assert!(cpu_unsupported_message(Some(-1_073_741_674), b"", b"").is_some());
+    }
+
+    #[test]
+    fn cpu_unsupported_ignores_normal_failures() {
+        // An ordinary non-zero exit with a diagnostic is a real error, not a CPU fault.
+        assert!(cpu_unsupported_message(Some(1), b"", b"error: bad model").is_none());
+        // Success with output is never flagged.
+        assert!(cpu_unsupported_message(Some(0), b"hello", b"").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cpu_unsupported_detects_unix_signal_death() {
+        // SIGILL with no output (crash before whisper logs its banner).
+        assert!(cpu_unsupported_message(None, b"", b"").is_some());
+        // But a process that logged before dying is treated as an ordinary failure.
+        assert!(cpu_unsupported_message(None, b"", b"loading model").is_none());
     }
 }

--- a/src-tauri/src/commands/voice_memos.rs
+++ b/src-tauri/src/commands/voice_memos.rs
@@ -254,6 +254,13 @@ pub async fn transcribe_voice_memo(
         .map_err(|e| format!("transcribe_voice_memo: whisper exec failed: {}", e))?;
 
     if !output.status.success() {
+        if let Some(msg) = crate::commands::speech_to_text::cpu_unsupported_message(
+            output.status.code(),
+            &output.stdout,
+            &output.stderr,
+        ) {
+            return Err(msg);
+        }
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("transcribe_voice_memo: whisper error: {}", stderr));
     }


### PR DESCRIPTION
## Problem

The shipped `whisper-cli` sidecar is compiled with ggml's x86-64 default ISA (AVX2/FMA/BMI2). On CPUs lacking those instructions — older Pentium/Celeron parts and **many virtualised CPUs** — the sidecar dies with an illegal-instruction fault (`STATUS_ILLEGAL_INSTRUCTION` 0xC000001D on Windows, `SIGILL` on Unix) **before producing any output**, so STT/voice-memo transcription failed *silently*.

Found while validating the Android→desktop voice-memo sync round-trip (#164): the synced memo never transcribed on a Pentium G4560 Windows VM because the bundled `whisper.exe` crashed on every spawn.

## Fix (two parts)

**A. Portable CI build (`.github/workflows/build.yml`)** — build `whisper-cli` with a **baseline ISA** on every x86-64 target: `-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF` (SSE4.2 retained → universal since ~2010). One static binary that runs on every x86-64 CPU; modest speed cost on modern machines, acceptable for the model sizes used here. arm64 (NEON) untouched. Whisper cache key bumped so it rebuilds.

**B. Graceful error (`speech_to_text.rs`, `voice_memos.rs`)** — `cpu_unsupported_message()` detects the illegal-instruction crash at all three whisper spawn sites (`stt_transcribe`, `stt_transcribe_timestamped`, `transcribe_voice_memo`) and returns *"Speech-to-text isn't supported on this device's processor…"* instead of a silent/opaque failure. Defense-in-depth safety net for any future SIMD mismatch. 3 unit tests.

## Verification

- **Live proof of the baseline approach:** built an SSE4.2-only `whisper-cli` and ran it on the no-AVX2 Pentium G4560 VM against a real synced memo — it loaded the model and transcribed (exit 0), where the AVX2 build crashed instantly with `STATUS_ILLEGAL_INSTRUCTION`.
- `cargo check` clean; `cargo fmt --check` clean; 3 new unit tests pass.

## Follow-up (planned, not in this PR)

`active-plans/stt-multi-isa-runtime-dispatch.md` — ship multiple CPU variants with ggml runtime dispatch (`GGML_CPU_ALL_VARIANTS` + `GGML_BACKEND_DL`) to recover AVX2/AVX-512 speed while keeping the baseline fallback, at the cost of a multi-file sidecar bundle. Gated on whether baseline speed proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)