### PR TITLE
ci(sonar): measure Rust coverage + enforce quality gate

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -35,10 +35,65 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Tests with coverage
+      - name: Frontend tests with coverage
         run: npm run test:coverage
+
+      # ── Rust coverage ──────────────────────────────────────────────────────
+      # The Rust backend is the largest, most security-sensitive code in the repo.
+      # Without this it reports 0% coverage to Sonar, dragging the metric down and
+      # hiding the real cargo test suite.
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (2026-04-04)
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          workspaces: src-tauri
+
+      - name: Create stub whisper sidecar
+        shell: bash
+        run: |
+          # tauri-build validates sidecar existence at compile time.
+          # Create a stub binary for the host triple so the build compiles
+          # without shipping a real whisper binary in CI.
+          mkdir -p src-tauri/binaries
+          TRIPLE=$(rustc -vV | sed -n 's/host: //p')
+          STUB="src-tauri/binaries/whisper-${TRIPLE}"
+          if [[ ! -f "$STUB" ]]; then
+            printf '\x4D\x5A' > "$STUB" 2>/dev/null || touch "$STUB"
+            echo "Created stub: $STUB"
+          fi
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Rust tests with coverage (lcov)
+        working-directory: src-tauri
+        run: cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info
 
       - name: SonarQube Cloud scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e  # v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # ── Quality gate enforcement ───────────────────────────────────────────
+      # Fails the check if Sonar's quality gate on this branch/PR fails, so the
+      # gate is visible and blocking rather than advisory.
+      - name: SonarQube Quality Gate check
+        uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b  # v1.2.0
+        timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,6 +15,9 @@ sonar.test.inclusions=src/**/*.test.ts,src/**/*.test.tsx
 # Coverage (vitest v8 -> lcov)
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
+# Rust coverage (cargo-llvm-cov -> lcov)
+sonar.rust.lcov.reportPaths=coverage/rust-lcov.info
+
 # Exclude generated, vendored, and build output from analysis
 sonar.exclusions=src-tauri/gen/**,src-tauri/target/**,dist/**,dist-web/**,coverage/**,node_modules/**,**/*.test.ts,**/*.test.tsx,scripts/**,website/**
 


### PR DESCRIPTION
Follow-up to the Sonar duplication work (#185). Two improvements to the existing SonarQube Cloud setup.

## A — Measure Rust backend coverage

`sonar.sources` already includes `src-tauri/src`, but only JS/TS lcov was wired, so the **entire Rust backend** (db, commands, peer-sync engine — the most security-sensitive code, with ~210 `cargo test`s) reported **0% coverage** to Sonar. That dragged the overall number down and hid real test work.

This adds a `cargo-llvm-cov` step to the Sonar job, mirroring the proven `test.yml` Rust recipe (apt deps, stable toolchain + `llvm-tools-preview`, stub whisper sidecar so `tauri-build` compiles), and points Sonar at the output via `sonar.rust.lcov.reportPaths` ([Sonar's documented Rust LCOV property](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/rust)).

## B — Enforce the quality gate

The scan ran but nothing acted on the gate result, so a failing gate never surfaced. Adds `SonarSource/sonarqube-quality-gate-action` so the gate is a visible, blocking check on PRs rather than advisory.

## Notes

- New third-party action pinned to a commit SHA per repo convention (`quality-gate-action` v1.2.0 = `cf038b0`, verified against the GitHub API).
- **CI is the real validation** for the `cargo llvm-cov` compile — the step reuses the same `cargo test` invocation that already passes in `test.yml`, just under instrumentation, so risk is low. Watch the first run.
- The gate evaluates **new code**; this PR adds no measurable new source, so it should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)