### PR TITLE
feat(privacy): enforce auto-lock timeout + clear-clipboard-on-lock

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const SyncDetailsModal = lazy(() => import('./components/sync/SyncDetailsModal')
 import { useAppStore } from './stores/appStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { useReminderScheduler } from './hooks/useReminderScheduler';
+import { useAutoLock } from './hooks/useAutoLock';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
 import { useWearSignals } from './hooks/useWearSignals';
 import { usePeerSync } from './hooks/usePeerSync';
@@ -92,6 +93,10 @@ function MainApp() {
 
   // Schedule reminder notifications (hook checks enabled state internally)
   useReminderScheduler();
+
+  // Enforce auto-lock timeout + clear-clipboard-on-lock privacy settings.
+  // Hook is inert unless unlocked AND autoLockTimeout > 0.
+  useAutoLock();
 
   // Update check — runs once per session after settings are loaded, respects 24h gate
   const updateHook = useUpdateCheck();

--- a/src/hooks/useAutoLock.test.ts
+++ b/src/hooks/useAutoLock.test.ts
@@ -1,0 +1,99 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../lib/services/journalService', () => ({
+  hasPassword: vi.fn(),
+  setupPassword: vi.fn(),
+  unlockJournal: vi.fn(),
+  finalizeUnlock: vi.fn(),
+  lockJournal: vi.fn(),
+  devBypassUnlock: vi.fn(),
+}));
+
+import { useAutoLock } from './useAutoLock';
+import { useAppStore } from '../stores/appStore';
+import { useSettingsStore } from '../stores/settingsStore';
+import { createDefaultSettings } from '../types/settings';
+
+function setPrivacy(autoLockTimeout: number, clearClipboardOnLock: boolean) {
+  const settings = createDefaultSettings();
+  settings.privacy.autoLockTimeout = autoLockTimeout;
+  settings.privacy.clearClipboardOnLock = clearClipboardOnLock;
+  useSettingsStore.setState({ settings });
+}
+
+describe('useAutoLock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAppStore.setState({ isUnlocked: true });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not lock when timeout is 0 (disabled)', () => {
+    setPrivacy(0, false);
+    renderHook(() => useAutoLock());
+    act(() => vi.advanceTimersByTime(60 * 60 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(true);
+  });
+
+  it('does not arm when locked', () => {
+    useAppStore.setState({ isUnlocked: false });
+    setPrivacy(5, false);
+    renderHook(() => useAutoLock());
+    act(() => vi.advanceTimersByTime(10 * 60 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(false);
+  });
+
+  it('locks after the configured inactivity timeout', () => {
+    setPrivacy(1, false);
+    renderHook(() => useAutoLock());
+    expect(useAppStore.getState().isUnlocked).toBe(true);
+    act(() => vi.advanceTimersByTime(60 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(false);
+  });
+
+  it('resets the timer on user interaction', () => {
+    setPrivacy(1, false);
+    renderHook(() => useAutoLock());
+    act(() => vi.advanceTimersByTime(50 * 1000));
+    act(() => window.dispatchEvent(new Event('keydown')));
+    act(() => vi.advanceTimersByTime(50 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(true);
+    act(() => vi.advanceTimersByTime(10 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(false);
+  });
+
+  it('clears the clipboard on lock when clearClipboardOnLock is set', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    setPrivacy(1, true);
+    renderHook(() => useAutoLock());
+    act(() => vi.advanceTimersByTime(60 * 1000));
+    expect(writeText).toHaveBeenCalledWith('');
+    expect(useAppStore.getState().isUnlocked).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('does not touch the clipboard when clearClipboardOnLock is off', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    setPrivacy(1, false);
+    renderHook(() => useAutoLock());
+    act(() => vi.advanceTimersByTime(60 * 1000));
+    expect(writeText).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('cleans up listeners on unmount (no lock after unmount)', () => {
+    setPrivacy(1, false);
+    const { unmount } = renderHook(() => useAutoLock());
+    unmount();
+    act(() => vi.advanceTimersByTime(60 * 1000));
+    expect(useAppStore.getState().isUnlocked).toBe(true);
+  });
+});

--- a/src/hooks/useAutoLock.ts
+++ b/src/hooks/useAutoLock.ts
@@ -1,0 +1,73 @@
+/**
+ * useAutoLock - Enforces the auto-lock and clear-clipboard privacy settings.
+ *
+ * Active only while the journal is unlocked and `autoLockTimeout > 0`:
+ * - An inactivity timer (reset on pointer/key/touch/scroll) locks the app after
+ *   `autoLockTimeout` minutes.
+ * - When the app is backgrounded (tab hidden / window blur), the countdown
+ *   restarts rather than firing instantly, so backgrounding locks after the
+ *   timeout — matching the inactivity semantics the setting implies.
+ * - On lock, the system clipboard is cleared when `clearClipboardOnLock` is set.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '../stores/appStore';
+import { useSettingsStore } from '../stores/settingsStore';
+
+const ACTIVITY_EVENTS = ['pointerdown', 'keydown', 'touchstart', 'scroll', 'mousemove'] as const;
+
+export function useAutoLock() {
+  const isUnlocked = useAppStore((s) => s.isUnlocked);
+  const lock = useAppStore((s) => s.lock);
+  const autoLockTimeout = useSettingsStore((s) => s.settings.privacy?.autoLockTimeout ?? 0);
+  const clearClipboardOnLock = useSettingsStore((s) => s.settings.privacy?.clearClipboardOnLock ?? false);
+
+  // Keep clipboard preference in a ref so the lock callback need not be a dependency.
+  const clearClipboardRef = useRef(clearClipboardOnLock);
+  clearClipboardRef.current = clearClipboardOnLock;
+
+  useEffect(() => {
+    if (!isUnlocked || autoLockTimeout <= 0) return;
+
+    const timeoutMs = autoLockTimeout * 60_000;
+    let timer: number | null = null;
+
+    const doLock = () => {
+      if (clearClipboardRef.current) {
+        try {
+          void navigator.clipboard?.writeText('').catch(() => {/* permission denied — ignore */});
+        } catch {
+          // clipboard API unavailable — ignore
+        }
+      }
+      lock();
+    };
+
+    const resetTimer = () => {
+      if (timer !== null) clearTimeout(timer);
+      timer = window.setTimeout(doLock, timeoutMs);
+    };
+
+    // Backgrounding (tab hidden) restarts the countdown so it locks after the timeout.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') resetTimer();
+    };
+
+    resetTimer();
+
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, resetTimer, { passive: true });
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('blur', resetTimer);
+
+    return () => {
+      if (timer !== null) clearTimeout(timer);
+      for (const evt of ACTIVITY_EVENTS) {
+        window.removeEventListener(evt, resetTimer);
+      }
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('blur', resetTimer);
+    };
+  }, [isUnlocked, autoLockTimeout, lock]);
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -114,10 +114,14 @@ export const useAppStore = create<AppState>((set) => ({
     }
   },
 
-  // Lock the journal
+  // Lock the journal.
+  // SECURITY: null the store copy of the password FIRST, so that even if
+  // lockJournal() later throws, the broadly-readable Zustand reference is
+  // already cleared. lockJournal() then nulls the narrower journalService
+  // module variable and wipes the derived-key cache (clearKeyCache).
   lock: () => {
-    lockJournal();
     set({ isUnlocked: false, sessionPassword: null });
+    lockJournal();
   },
 
   // Set theme


### PR DESCRIPTION
## What

Fixes the substantive finding from the rooted-device security test: **auto-lock was unwired.** `autoLockTimeout` and `clearClipboardOnLock` persisted and the UI honored them, but no idle timer or lifecycle listener ever invoked `lock()`. Verified on a rooted Pixel 4a — set to 1 min, idle 2 min, app stayed unlocked. (frida confirmed the encryption key stays resident in memory the whole time it's not locked, which is what made the unwired auto-lock matter.)

## Changes
- **`src/hooks/useAutoLock.ts`** (new) — inactivity timer (reset on pointer/key/touch/scroll) → existing `lock()` after `autoLockTimeout` minutes; `visibilitychange`/blur restart the countdown so backgrounding locks after the timeout; clears the clipboard on the auto-lock path when `clearClipboardOnLock` is on. Inert unless unlocked AND `autoLockTimeout > 0`; cleans up all listeners/timers on unmount and lock.
- **`src/App.tsx`** — wires `useAutoLock()` into `MainApp`.
- **`src/stores/appStore.ts`** — `lock()` nulls the broadly-readable Zustand `sessionPassword` before `lockJournal()` (minor hardening; the password lingering in the JS heap can't be fully scrubbed in JS, so the real mitigation is reliable locking — this PR).
- **`src/hooks/useAutoLock.test.ts`** (new) — 7 tests.

## Validation
- `tsc --noEmit` ✅ · `lint:ci` ✅ · 7 new tests ✅
- Adversarially reviewed: safe-to-apply; does not touch the unlock flow or crypto.

## Follow-ups (not in this PR)
- Honor `clearClipboardOnLock` on the **manual** lock path too (today only the auto-lock path clears it). Needs a circular-import-safe way for `lock()` to read the setting — `settingsStore` already imports `appStore`.
- Wire `useAutoLock` into the breakout writer window (desktop-only).
- SEC-017: collapse the duplicate session-password storage (`appStore` + `journalService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)