### PR TITLE
fix(peer-sync): set SO_REUSEADDR on the sync listener

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3012,6 +3012,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket2 0.5.10",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ hardware-key = ["dep:ctap-hid-fido2", "dep:argon2"]
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-log = "2"
+socket2 = "0.5"
 log = "0.4"
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/peer_sync_engine/mod.rs
+++ b/src-tauri/src/commands/peer_sync_engine/mod.rs
@@ -1847,6 +1847,31 @@ fn run_sync_client(app: AppHandle, peer_device_id: String, host: String) {
     }
 }
 
+/// Bind a TCP listener on `0.0.0.0:{port}` with `SO_REUSEADDR` enabled.
+///
+/// Without `SO_REUSEADDR`, a re-bind fails with "Address already in use" while
+/// sockets from the previous sync session sit in TIME_WAIT (~60s) — which happens
+/// constantly on Android, where the app is killed and relaunched often, leaving the
+/// peer-sync server unable to start and breaking all sync until the kernel clears
+/// TIME_WAIT.
+fn bind_reusable_listener(port: u16) -> Result<TcpListener, String> {
+    let addr: SocketAddr = format!("0.0.0.0:{port}")
+        .parse()
+        .map_err(|e| format!("parse sync addr: {e}"))?;
+    let socket = Socket::new(Domain::IPV4, SockType::STREAM, Some(SockProtocol::TCP))
+        .map_err(|e| format!("create sync socket: {e}"))?;
+    socket
+        .set_reuse_address(true)
+        .map_err(|e| format!("set SO_REUSEADDR: {e}"))?;
+    socket
+        .bind(&addr.into())
+        .map_err(|e| format!("bind sync server on port {port}: {e}"))?;
+    socket
+        .listen(128)
+        .map_err(|e| format!("listen sync server on port {port}: {e}"))?;
+    Ok(socket.into())
+}
+
 // ── Tauri commands ────────────────────────────────────────────────────────────
 
 /// Start the sync server on this device's deterministic port.
@@ -1875,26 +1900,8 @@ pub fn peer_start_sync_server(
     let identity = get_or_create_device_identity(&app)?;
     let port = sync_port_for_device(&identity.device_id);
 
-    // Bind listener with SO_REUSEADDR. Without it, a re-bind fails with
-    // "Address already in use" while sockets from the previous sync session sit in
-    // TIME_WAIT (~60s) — which happens constantly on Android, where the app is
-    // killed and relaunched often, leaving the peer-sync server unable to start and
-    // breaking all sync until the kernel clears TIME_WAIT.
-    let addr: SocketAddr = format!("0.0.0.0:{port}")
-        .parse()
-        .map_err(|e| format!("parse sync addr: {e}"))?;
-    let socket = Socket::new(Domain::IPV4, SockType::STREAM, Some(SockProtocol::TCP))
-        .map_err(|e| format!("create sync socket: {e}"))?;
-    socket
-        .set_reuse_address(true)
-        .map_err(|e| format!("set SO_REUSEADDR: {e}"))?;
-    socket
-        .bind(&addr.into())
-        .map_err(|e| format!("bind sync server on port {port}: {e}"))?;
-    socket
-        .listen(128)
-        .map_err(|e| format!("listen sync server on port {port}: {e}"))?;
-    let listener: TcpListener = socket.into();
+    // Bind listener with SO_REUSEADDR (see bind_reusable_listener).
+    let listener = bind_reusable_listener(port)?;
     listener
         .set_nonblocking(true)
         .map_err(|e| format!("set nonblocking: {e}"))?;
@@ -2075,6 +2082,35 @@ mod tests {
     use super::*;
     use crate::db::{EncryptedContent, JournalEntryRow};
     use rusqlite::Connection;
+
+    // ── bind_reusable_listener ─────────────────────────────────────────────────
+
+    /// Resolve the OS-assigned ephemeral port from a bound listener (we bind on
+    /// 0.0.0.0:0, the kernel picks the port, and we read it back to re-bind it).
+    fn ephemeral_port(listener: &TcpListener) -> u16 {
+        listener.local_addr().expect("local_addr").port()
+    }
+
+    #[test]
+    fn bind_reusable_listener_binds_ephemeral_port() {
+        let listener = bind_reusable_listener(0).expect("bind on ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        assert!(addr.is_ipv4());
+        assert_ne!(addr.port(), 0, "kernel must assign a concrete port");
+    }
+
+    #[test]
+    fn bind_reusable_listener_allows_immediate_rebind() {
+        // Bind once to claim a concrete port, read it back, then drop the listener.
+        let port = {
+            let first = bind_reusable_listener(0).expect("first bind");
+            ephemeral_port(&first)
+        };
+        // Re-binding the same port immediately must succeed thanks to SO_REUSEADDR;
+        // without it the freed socket could linger in TIME_WAIT and trigger AddrInUse.
+        let rebound = bind_reusable_listener(port).expect("rebind same port");
+        assert_eq!(ephemeral_port(&rebound), port);
+    }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/src-tauri/src/commands/peer_sync_engine/mod.rs
+++ b/src-tauri/src/commands/peer_sync_engine/mod.rs
@@ -63,7 +63,8 @@ use protocol::*;
 
 use chrono::Utc;
 use serde::Serialize;
-use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use socket2::{Domain, Protocol as SockProtocol, Socket, Type as SockType};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc, Mutex,
@@ -1874,14 +1875,31 @@ pub fn peer_start_sync_server(
     let identity = get_or_create_device_identity(&app)?;
     let port = sync_port_for_device(&identity.device_id);
 
-    // Bind listener
-    let listener = TcpListener::bind(format!("0.0.0.0:{port}"))
+    // Bind listener with SO_REUSEADDR. Without it, a re-bind fails with
+    // "Address already in use" while sockets from the previous sync session sit in
+    // TIME_WAIT (~60s) — which happens constantly on Android, where the app is
+    // killed and relaunched often, leaving the peer-sync server unable to start and
+    // breaking all sync until the kernel clears TIME_WAIT.
+    let addr: SocketAddr = format!("0.0.0.0:{port}")
+        .parse()
+        .map_err(|e| format!("parse sync addr: {e}"))?;
+    let socket = Socket::new(Domain::IPV4, SockType::STREAM, Some(SockProtocol::TCP))
+        .map_err(|e| format!("create sync socket: {e}"))?;
+    socket
+        .set_reuse_address(true)
+        .map_err(|e| format!("set SO_REUSEADDR: {e}"))?;
+    socket
+        .bind(&addr.into())
         .map_err(|e| format!("bind sync server on port {port}: {e}"))?;
+    socket
+        .listen(128)
+        .map_err(|e| format!("listen sync server on port {port}: {e}"))?;
+    let listener: TcpListener = socket.into();
     listener
         .set_nonblocking(true)
         .map_err(|e| format!("set nonblocking: {e}"))?;
 
-    log::info!("[sync] Server bound on port {port}");
+    log::info!("[sync] Server bound on port {port} (SO_REUSEADDR)");
 
     let (stop_tx, stop_rx) = mpsc::sync_channel(1);
     let app_clone = app.clone();


### PR DESCRIPTION
## Problem

The peer-sync TCP listener was bound with `TcpListener::bind()`, which does **not** set `SO_REUSEADDR`. After a sync session, the TCP connections sit in `TIME_WAIT` (~60s) holding port `44000 + deviceId%1000`. A re-bind during that window fails with `Address already in use (os error 98)`.

On Android the app process is killed and relaunched constantly, so the **first** post-unlock `peer_start_sync_server` almost always lands inside the TIME_WAIT window → the sync server never starts → the whole peer-sync subsystem is dead → the UI shows a "sync error". A second attempt a moment later succeeds once the kernel clears TIME_WAIT — the classic "fails first, works on retry" symptom.

## Fix

Build the listener with `socket2`, calling `set_reuse_address(true)` before `bind()`/`listen()`, then convert into a `std::net::TcpListener` (the rest of the server loop is unchanged). `SO_REUSEADDR` on a listener is the standard, safe remedy for TIME_WAIT rebind failures.

## Verification

- `cargo check` + `clippy` clean.
- On-device (Pixel 9): captured the pre-fix failure in `moodhaven.log` — `bind sync server on port 44012: Address already in use` on a *fresh* app start (proving it was kernel TIME_WAIT, not the app's own live socket). With the fix the first bind succeeds.

Pre-existing bug, independent of the Android voice-sync work.