### PR TITLE
fix(android): register PluginManager activity-result launcher (file picker)

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/moodhaven/app/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import app.tauri.plugin.PluginManager
 
 class MainActivity : TauriActivity() {
   // Held for the app's lifetime so mdns-sd can receive multicast peer-discovery
@@ -15,13 +16,22 @@ class MainActivity : TauriActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     installSplashScreen()
+    super.onCreate(savedInstanceState)
+    // The generated TauriActivity for this project omits the codegen's
+    // `PluginManager.onActivityCreate(this)` call, so the Tauri PluginManager's
+    // startActivityForResultLauncher is never registered. Any plugin that opens a
+    // system activity for a result — e.g. tauri-plugin-dialog's file picker —
+    // then throws "lateinit property startActivityForResultLauncher has not been
+    // initialized" and silently fails to launch. Register it here (idempotent: the
+    // manager guards on `activity.isInitialized`). Custom plugins are loaded after
+    // super.onCreate() so the activity/launcher are set up first.
+    PluginManager.onActivityCreate(this)
     getPluginManager().load(null, "biometric", BiometricPlugin(this), "{}")
     getPluginManager().load(null, "wear", WearPlugin(this), "{}")
     getPluginManager().load(null, "opener", OpenerPlugin(this), "{}")
     getPluginManager().load(null, "securekey", SecureKeyPlugin(this), "{}")
     acquireMulticastLock()
     enableEdgeToEdge()
-    super.onCreate(savedInstanceState)
   }
 
   private fun acquireMulticastLock() {


### PR DESCRIPTION
## Symptom

On Android, tapping the media **attach/clip** button did nothing. logcat:
```
V/Tauri/Plugin: pluginId: dialog, command: showFilePicker
E/Tauri: lateinit property startActivityForResultLauncher has not been initialized
```
The plugin command fired but the system picker never opened.

## Root cause

Tauri's `PluginManager.startActivityForResultLauncher` is registered in `PluginManager.onActivityCreate()`, which the **2.11 codegen `TauriActivity.kt`** calls from its `onCreate`:
```kotlin
override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState)
    PluginManager.onActivityCreate(this)
}
```
This project's committed/generated `TauriActivity.kt` predates that template and **has no `onCreate` override** — so `PluginManager.onActivityCreate()` is never called and the launcher stays uninitialized. Any activity-result plugin (file picker, etc.) then throws on `launch()`.

`TauriActivity.kt` is regenerated on every `tauri android build`, so patching it there doesn't stick.

## Fix

Call `PluginManager.onActivityCreate(this)` from `MainActivity.onCreate` (hand-owned, not regenerated), right after `super.onCreate()` so it runs before the activity is STARTED. It's **idempotent** — `onActivityCreate` early-returns when `activity.isInitialized`, so this composes safely if a future codegen adds the override back. Custom plugin loads are moved after `super.onCreate()` so the activity is initialized first.

## Verification

On-device (Pixel 9 / Android 16): the system file picker now opens from the attach button. Kotlin-only change.

> Note: a follow-up is tracked for post-selection attachment feedback on Android (separate from this launcher fix).