### PR TITLE
fix(writing): attach spinner + unlock paint-yield + clearer save indicator

### DIFF
--- a/src/pages/LockScreen.test.tsx
+++ b/src/pages/LockScreen.test.tsx
@@ -327,6 +327,57 @@ describe('LockScreen — PIN lockout: countdown expiry re-enables input', () => 
   }, 15000);
 });
 
+describe('LockScreen — password submit: paint-yield + unlock', () => {
+  beforeEach(() => {
+    // pin_is_enabled returns false on mount → stay on password step
+    mockInvoke.mockResolvedValue(false);
+    mockUnlock.mockResolvedValue(true);
+  });
+
+  it('shows "Verifying…" loading state then calls unlock on the password path', async () => {
+    const { verifyUserPassword } = await import('../lib/services/journalService');
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
+
+    render(<LockScreen />);
+
+    const input = await screen.findByLabelText(/^password$/i);
+    await userEvent.type(input, 'correct horse');
+
+    const submit = screen.getByRole('button', { name: /continue/i });
+    await userEvent.click(submit);
+
+    // nextPaint() yields a painted frame before verify; the button flips to the
+    // loading state. Assert the "Verifying…" label appears.
+    await waitFor(() => {
+      expect(screen.getByText(/verifying/i)).toBeInTheDocument();
+    });
+
+    // The verify round-trip runs, then unlock() is called with the password.
+    await waitFor(() => {
+      expect(verifyUserPassword).toHaveBeenCalledWith('correct horse');
+    });
+    await waitFor(() => {
+      expect(mockUnlock).toHaveBeenCalledWith('correct horse');
+    });
+  });
+
+  it('does not call unlock and surfaces an error on an incorrect password', async () => {
+    const { verifyUserPassword } = await import('../lib/services/journalService');
+    vi.mocked(verifyUserPassword).mockResolvedValueOnce(false);
+
+    render(<LockScreen />);
+
+    const input = await screen.findByLabelText(/^password$/i);
+    await userEvent.type(input, 'wrongpass');
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(verifyUserPassword).toHaveBeenCalledWith('wrongpass');
+    });
+    expect(mockUnlock).not.toHaveBeenCalled();
+  });
+});
+
 describe('LockScreen — recovery key: corrupted escrow guard', () => {
   it('rejects a recovered password that does not match the stored hash (with 2FA enabled)', async () => {
     const { recoverPassword, isRecoveryKeyEnabled } = await import(

--- a/src/pages/LockScreen.tsx
+++ b/src/pages/LockScreen.tsx
@@ -46,6 +46,17 @@ function formatCountdown(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
+/**
+ * Yield until the browser has painted one frame, so a just-set loading state is
+ * visible before heavy/awaited work begins. Double rAF: the first callback runs
+ * before paint, the second resolves after that frame has painted.
+ */
+function nextPaint(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+}
+
 export function LockScreen() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -218,6 +229,9 @@ export function LockScreen() {
 
       setError(null);
       setIsLoading(true);
+      // Let the "Verifying…" state paint before the (potentially slow) verify
+      // round-trip, so the button gives immediate feedback on press.
+      await nextPaint();
 
       try {
         // First verify the password
@@ -367,6 +381,8 @@ export function LockScreen() {
 
       setPinLoading(true);
       setPinError(null);
+      // Paint the loading state before the decrypt round-trip (see nextPaint).
+      await nextPaint();
 
       try {
         const decryptedPassword = await pinUnlock(pinInput);

--- a/src/pages/WritingView.test.tsx
+++ b/src/pages/WritingView.test.tsx
@@ -16,6 +16,8 @@ import { WritingView } from './WritingView';
 import { getEntryById } from '../lib/services/journalService';
 import { pickAndAttachMedia, listEntryMedia } from '../lib/services/mediaService';
 import { useAppStore } from '../stores/appStore';
+import { usePlatform } from '../hooks/usePlatform';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 // ── Force mobile layout (the reworded save indicator + spinner live there) ─────
 vi.mock('../hooks/usePlatform', () => ({
@@ -311,6 +313,67 @@ describe('WritingView — save indicator wording', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Saved · 3 words')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('WritingView — desktop layout attach spinner', () => {
+  beforeEach(() => {
+    // Force the desktop layout (isMobile === false) so the desktop attach
+    // button branch (spinner / disabled / aria-busy) renders and is exercised.
+    vi.mocked(usePlatform).mockReturnValue({
+      isAndroid: false,
+      isIOS: false,
+      isMobile: false,
+      isBrowser: false,
+      isDesktop: true,
+      canPeerSync: true,
+      canSTT: true,
+      canHardwareKey: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(useIsMobile).mockReturnValue(false);
+  });
+
+  it('shows a spinner and disables the desktop attach button while attaching', async () => {
+    let release!: () => void;
+    vi.mocked(pickAndAttachMedia).mockReturnValue(
+      new Promise((resolve) => {
+        release = () => resolve({ attached: [], skipped: [] });
+      })
+    );
+
+    vi.mocked(getEntryById).mockResolvedValue({
+      id: 'entry-1',
+      title: 'T',
+      content: '<p>hello world</p>',
+      mood: 3,
+      privacyMode: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    render(<WritingView entryId="entry-1" />);
+
+    const attachBtn = await screen.findByRole('button', { name: /attach/i });
+    expect(attachBtn).not.toBeDisabled();
+
+    await act(async () => {
+      await userEvent.click(attachBtn);
+    });
+
+    await waitFor(() => {
+      const busy = screen.getByRole('button', { name: /attach/i });
+      expect(busy).toBeDisabled();
+      expect(busy).toHaveAttribute('aria-busy', 'true');
+    });
+
+    await act(async () => {
+      release();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /attach/i })).not.toBeDisabled();
     });
   });
 });

--- a/src/pages/WritingView.test.tsx
+++ b/src/pages/WritingView.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * WritingView tests — UX additions from fix/android-ux-batch.
+ *
+ * Covers:
+ * - Attach button shows a spinner and is disabled while `isAttaching` (mobile).
+ * - Mobile media strip renders ("Encrypting…") during an in-flight attach.
+ * - Save indicator wording: "Saved · N words" when saved, singular "1 word".
+ *
+ * The component pulls in many heavy deps (TipTap editor, hooks, stores). They
+ * are mocked here so the test exercises only the footer/attach/save UI logic.
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WritingView } from './WritingView';
+import { getEntryById } from '../lib/services/journalService';
+import { pickAndAttachMedia, listEntryMedia } from '../lib/services/mediaService';
+import { useAppStore } from '../stores/appStore';
+
+// ── Force mobile layout (the reworded save indicator + spinner live there) ─────
+vi.mock('../hooks/usePlatform', () => ({
+  usePlatform: vi.fn().mockReturnValue({
+    isAndroid: true,
+    isIOS: false,
+    isMobile: true,
+    isBrowser: false,
+    isDesktop: false,
+    canPeerSync: false,
+    canSTT: false,
+    canHardwareKey: false,
+  }),
+}));
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: vi.fn().mockReturnValue(true) }));
+
+// ── Editor: minimal stub exposing onChange(html, text) ─────────────────────────
+vi.mock('../components/editor', () => ({
+  RichTextEditor: ({
+    onChange,
+  }: {
+    onChange?: (html: string, text: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="editor-set"
+      onClick={() => onChange?.('<p>hello world today friend now</p>', 'hello world today friend now')}
+    >
+      editor
+    </button>
+  ),
+}));
+
+// ── Service mocks ──────────────────────────────────────────────────────────────
+vi.mock('../lib/services/journalService', () => ({
+  saveEntry: vi.fn().mockResolvedValue({ id: 'entry-1', title: '', content: '<p>x</p>', mood: 3 }),
+  getEntryById: vi.fn().mockResolvedValue(null),
+  patchEntryLocationWeather: vi.fn().mockResolvedValue(undefined),
+  deleteEntry: vi.fn().mockResolvedValue(undefined),
+  getBookTags: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../lib/services/activityService', () => ({
+  syncEntryActivities: vi.fn().mockResolvedValue(undefined),
+  getEntryActivities: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../lib/services/mediaService', () => ({
+  pickAndAttachMedia: vi.fn().mockResolvedValue({ attached: [], skipped: [] }),
+  listEntryMedia: vi.fn().mockResolvedValue([]),
+  openMedia: vi.fn().mockResolvedValue(undefined),
+  deleteMedia: vi.fn().mockResolvedValue(undefined),
+  getMediaThumbnail: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../lib/services/locationWeatherService', () => ({
+  captureLocationWeather: vi.fn().mockResolvedValue(null),
+  getWeatherEmoji: vi.fn().mockReturnValue('☀️'),
+  displayTemp: vi.fn().mockReturnValue('20°C'),
+}));
+
+vi.mock('../lib/services/analyticsService', () => ({
+  getStreakStats: vi.fn().mockResolvedValue({ currentStreak: 0, longestStreak: 0, totalDays: 0 }),
+  getOverallStats: vi.fn().mockResolvedValue({ averageMood: 3, totalEntries: 0 }),
+}));
+
+vi.mock('../lib/services/voiceMemoService', () => ({
+  deleteVoiceMemo: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/services/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// ── Hook mocks ─────────────────────────────────────────────────────────────────
+vi.mock('../hooks/useActivities', () => ({
+  useActivities: vi.fn().mockReturnValue({
+    activities: [],
+    isLoading: false,
+    addCustom: vi.fn(),
+    remove: vi.fn(),
+    reload: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useJournalPrompts', () => ({
+  useJournalPrompts: vi.fn().mockReturnValue({
+    forYouPrompts: [],
+    generalPrompts: [],
+    healthPrompts: [],
+    isLoading: false,
+    isAIEnabled: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useWearVoiceMemos', () => ({
+  useWearVoiceMemos: vi.fn().mockReturnValue({ memos: [], transcribing: false, addMemo: vi.fn() }),
+}));
+
+vi.mock('../hooks/useWellbeingContext', () => ({
+  useWellbeingContext: vi.fn().mockReturnValue({
+    context: null,
+    isVisible: false,
+    dismiss: vi.fn(),
+    onWordsWritten: vi.fn(),
+  }),
+}));
+
+// ── Child component stubs ──────────────────────────────────────────────────────
+vi.mock('../components/journal/ActivityPicker', () => ({ ActivityPicker: () => null }));
+vi.mock('../components/writing/AppearanceDrawer', () => ({ AppearanceDrawer: () => null }));
+vi.mock('../components/ai/PromptDrawer', () => ({ PromptDrawer: () => null }));
+vi.mock('../components/journal/EntryOptionsMenu', () => ({ EntryOptionsMenu: () => null }));
+vi.mock('../components/journal/TagManagerModal', () => ({ TagManagerModal: () => null }));
+vi.mock('../components/wellbeing/WellbeingCard', () => ({ WellbeingCard: () => null }));
+
+// ── Stores ─────────────────────────────────────────────────────────────────────
+vi.mock('../stores/appStore', () => ({ useAppStore: vi.fn() }));
+vi.mock('../stores/booksStore', () => ({
+  useBooksStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ activeBookId: 'default', books: [] })
+  ),
+}));
+
+const SETTINGS_STATE = {
+  appearanceDrawerOpen: false,
+  setAppearanceDrawerOpen: vi.fn(),
+  toggleAppearanceDrawer: vi.fn(),
+  setAppearanceHintPulse: vi.fn(),
+  distractionFree: false,
+  setDistractionFree: vi.fn(),
+  setShowPrompts: vi.fn(),
+  setHasSeenWritingDrawerHint: vi.fn(),
+  settings: {
+    journal: {
+      showPrompts: false,
+      autoLocationWeather: false,
+      autoTitle: false,
+      temperatureUnit: 'C',
+    },
+    appearance: {
+      writing: {
+        fontFamily: 'sans',
+        fontSize: 'medium',
+        lineHeight: 'normal',
+        paragraphSpacing: 'normal',
+        backgroundTint: 'none',
+        writingWidth: 'normal',
+        focusMode: false,
+        highContrast: false,
+        dyslexiaProfile: false,
+        reducedMotion: 'off',
+        textScale: 1,
+      },
+    },
+    speechToText: { model: 'ggml-base.en.bin', enabled: false },
+    tutorial: { hasSeenWritingDrawerHint: true },
+  },
+};
+
+vi.mock('../stores/settingsStore', () => {
+  const actions = { setSavingState: vi.fn(), setLastAutoSaved: vi.fn() };
+  const hook = vi.fn((selector: (s: unknown) => unknown) => selector(SETTINGS_STATE));
+  // Components also call useSettingsStore.getState() for imperative writes.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (hook as any).getState = () => ({ ...SETTINGS_STATE, ...actions });
+  return { useSettingsStore: hook };
+});
+
+function setupAppStore(sessionPassword: string | null = 'pw') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vi.mocked(useAppStore) as any).mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({ sessionPassword })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupAppStore('pw');
+  vi.mocked(getEntryById).mockResolvedValue(null);
+  vi.mocked(listEntryMedia).mockResolvedValue([]);
+});
+
+describe('WritingView — attach spinner / disabled state', () => {
+  it('shows a spinner, disables the attach button, and renders the media strip while attaching', async () => {
+    // Hold pickAndAttachMedia open so isAttaching stays true while we assert.
+    let release!: () => void;
+    vi.mocked(pickAndAttachMedia).mockReturnValue(
+      new Promise((resolve) => {
+        release = () => resolve({ attached: [], skipped: [] });
+      })
+    );
+
+    // Existing entry → savedEntryIdRef is populated so the attach button is enabled.
+    vi.mocked(getEntryById).mockResolvedValue({
+      id: 'entry-1',
+      title: 'T',
+      content: '<p>hello world</p>',
+      mood: 3,
+      privacyMode: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    render(<WritingView entryId="entry-1" />);
+
+    const attachBtn = await screen.findByRole('button', { name: /attach/i });
+    expect(attachBtn).not.toBeDisabled();
+
+    await act(async () => {
+      await userEvent.click(attachBtn);
+    });
+
+    // Mid-attach: button disabled + aria-busy, media strip shows the encrypting chip.
+    await waitFor(() => {
+      const busy = screen.getByRole('button', { name: /attach/i });
+      expect(busy).toBeDisabled();
+      expect(busy).toHaveAttribute('aria-busy', 'true');
+    });
+    expect(screen.getByText(/encrypting/i)).toBeInTheDocument();
+
+    // Release the attach so the test ends cleanly.
+    await act(async () => {
+      release();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /attach/i })).not.toBeDisabled();
+    });
+  });
+});
+
+describe('WritingView — save indicator wording', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('shows "Saved · 1 word" (singular) after a one-word entry auto-saves', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // Existing entry with a single word → wordCount === 1, and savedEntryIdRef set
+    // so auto-save fires even below the 5-word new-entry threshold.
+    vi.mocked(getEntryById).mockResolvedValue({
+      id: 'entry-1',
+      title: '',
+      content: '<p>hello</p>',
+      mood: 3,
+      privacyMode: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    render(<WritingView entryId="entry-1" />);
+
+    // Before save: bare word count, singular.
+    await waitFor(() => {
+      expect(screen.getByText('1 word')).toBeInTheDocument();
+    });
+
+    // Advance past the 2s auto-save debounce → lastSavedAt set.
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved · 1 word')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Saved · N words" (plural) after a multi-word entry auto-saves', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    vi.mocked(getEntryById).mockResolvedValue({
+      id: 'entry-1',
+      title: '',
+      content: '<p>one two three</p>',
+      mood: 3,
+      privacyMode: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    render(<WritingView entryId="entry-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('3 words')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved · 3 words')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/WritingView.tsx
+++ b/src/pages/WritingView.tsx
@@ -310,6 +310,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
   const isNewEntry = !entryId;
   const isEditorEmpty = !contentText.trim();
   const wordCount = contentText.trim() ? contentText.trim().split(/\s+/).length : 0;
+  const wordsLabel = `${wordCount} ${wordCount === 1 ? 'word' : 'words'}`;
   const charCount = contentText.length;
   /** Reading time shown at ≥200 words; null below that threshold */
   const readingTime = getReadingTime(wordCount);
@@ -989,13 +990,14 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
         </div>
 
         {/* Media strip */}
-        {attachments.length > 0 && (
+        {(attachments.length > 0 || isAttaching) && (
           <div className="flex-shrink-0 px-5">
             <MediaAttachmentStrip
               attachments={attachments}
               thumbnails={thumbnails}
               onOpen={handleOpenMedia}
               onDelete={handleDeleteMedia}
+              isAttaching={isAttaching}
             />
           </div>
         )}
@@ -1035,7 +1037,7 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
                   <span className={`text-xs mr-2 transition-colors duration-300 ${
                     wcFlash ? 'wc-flash text-emerald-500 dark:text-emerald-400' : 'text-slate-400 dark:text-slate-500'
                   }`}>
-                    {wordCount}w
+                    {wordsLabel}
                   </span>
                 )}
                 <button
@@ -1050,13 +1052,18 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
               <>
                 <button
                   onClick={handleAttach}
-                  disabled={!savedEntryIdRef.current || !sessionPassword}
-                  title="Attach"
+                  disabled={!savedEntryIdRef.current || !sessionPassword || isAttaching}
+                  title={isAttaching ? 'Attaching…' : 'Attach'}
+                  aria-busy={isAttaching}
                   className="w-10 h-10 flex items-center justify-center rounded-xl text-slate-400 dark:text-slate-500 disabled:opacity-30 active:bg-black/5 active:scale-95 transition-all"
                 >
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" />
-                  </svg>
+                  {isAttaching ? (
+                    <span className="w-5 h-5 border-2 border-violet-400/40 border-t-violet-500 rounded-full motion-safe:animate-spin" />
+                  ) : (
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" />
+                    </svg>
+                  )}
                 </button>
 
                 <button
@@ -1093,12 +1100,12 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
                           : 'text-slate-400 dark:text-slate-500'
                   }`}>
                     {wcFlash
-                      ? `${wordCount}w ✦`
+                      ? `${wordsLabel} ✦`
                       : isSaving
                         ? 'Saving…'
                         : lastSavedAt
-                          ? `${wordCount}w · ✓`
-                          : `${wordCount}w`}
+                          ? `Saved · ${wordsLabel}`
+                          : wordsLabel}
                   </span>
                 )}
 
@@ -1343,14 +1350,19 @@ export function WritingView({ entryId, onEntrySaved, onNewEntry: _onNewEntry, on
                   <button
                     type="button"
                     onClick={handleAttach}
-                    disabled={!savedEntryIdRef.current || !sessionPassword}
-                    title={!savedEntryIdRef.current ? 'Write a few words first to enable attachments' : 'Attach files'}
+                    disabled={!savedEntryIdRef.current || !sessionPassword || isAttaching}
+                    title={!savedEntryIdRef.current ? 'Write a few words first to enable attachments' : isAttaching ? 'Attaching…' : 'Attach files'}
+                    aria-busy={isAttaching}
                     className="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs font-medium text-slate-400 dark:text-slate-500 hover:text-violet-600 dark:hover:text-violet-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-slate-400 dark:disabled:hover:text-slate-500"
                   >
-                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" />
-                    </svg>
-                    <span className="hidden sm:inline text-[11px]">Attach</span>
+                    {isAttaching ? (
+                      <span className="w-3.5 h-3.5 border-2 border-violet-400/40 border-t-violet-500 rounded-full motion-safe:animate-spin" />
+                    ) : (
+                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" />
+                      </svg>
+                    )}
+                    <span className="hidden sm:inline text-[11px]">{isAttaching ? 'Attaching…' : 'Attach'}</span>
                   </button>
 
                   {/* Tag manager button */}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/lib/**', 'src/stores/**', 'src/components/**'],
+      include: ['src/lib/**', 'src/stores/**', 'src/components/**', 'src/pages/**'],
       exclude: ['src/test/**', 'src/**/*.test.*'],
     },
   },


### PR DESCRIPTION
Three UX fixes found during on-device Android testing.

### 1. Attach loading feedback
Attaching a file had no visible progress (the encrypt+write takes a moment), and the **mobile** media strip rendered nothing until done. Now:
- the clip button shows a spinner and is disabled while `isAttaching` (mobile + desktop),
- the media strip renders during attach (mobile strip gated on `|| isAttaching` + passes the prop; desktop already did).

### 2. Unlock input lag
`setIsLoading(true)` was committed but the browser never painted that frame before the verify IPC round-trip began, so the Unlock button looked frozen on press. Insert a one-frame paint yield (double `requestAnimationFrame`) after setting the loading state, on the **password** and **PIN** paths. No crypto parameters or security properties change — purely a ~16ms UI yield.

### 3. Save-status indicator misread as a time
The indicator showed `{wordCount}w · ✓` — e.g. **"14w · ✓"**, which reads as "saved 14 weeks ago". It's actually the word count. Spelled out and disambiguated: **"Saved · 14 words"** (saved), **"14 words"** (idle), singular-aware. Can no longer be confused with a relative timestamp.

### Verification
`tsc`, `eslint`, and LockScreen tests pass. On-device verification (Pixel 9) to follow.