### PR TITLE
perf(dev): optimize password-hashing crates in debug builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,6 +83,20 @@ blake2 = "0.10"
 [profile.dev]
 incremental = true
 
+# Optimize the password-hashing crates even in debug builds. verify_password runs
+# PBKDF2-HMAC-SHA256 600,000 iterations; at the dev default opt-level 0 this takes
+# ~15s on a phone, so unlocking a debug APK feels broken. Optimizing just these
+# crates (the app crate stays unoptimized for fast incremental compiles) brings it
+# back to sub-second. Release builds are unaffected (they already use opt-level "s").
+[profile.dev.package.sha2]
+opt-level = 3
+[profile.dev.package.pbkdf2]
+opt-level = 3
+[profile.dev.package.hmac]
+opt-level = 3
+[profile.dev.package.digest]
+opt-level = 3
+
 [profile.release]
 codegen-units = 1
 lto = true


### PR DESCRIPTION
## Symptom

Unlocking a **debug** Android build takes ~16s between pressing Unlock and the app appearing (observed on Pixel 9). Release builds are fine.

## Cause

`[profile.dev]` sets no `opt-level`, so it defaults to **0 (unoptimized)**. `verify_password` runs `pbkdf2::<Hmac<Sha256>>(…, 600_000, …)` — 600k iterations of SHA-256 — and unoptimized SHA-256 on ARM is ~30× slower than optimized, so a sub-second derivation balloons to ~15s.

This is a **debug-build-only** artifact: `[profile.release]` already uses `opt-level = "s"`, so shipped/release builds unlock in <1s and end users never see this.

## Fix

Optimize just the hashing crates in the dev profile:
```toml
[profile.dev.package.sha2]   opt-level = 3
[profile.dev.package.pbkdf2] opt-level = 3
[profile.dev.package.hmac]   opt-level = 3
[profile.dev.package.digest] opt-level = 3
```
The app crate itself stays at opt-level 0 (fast incremental compiles); only these four small dependency crates are optimized. One-time recompile of those crates on next build.

## Verification

Confirmed PBKDF2 path uses these crates (`journal.rs:87`). On-device debug-build unlock timing before/after to follow in the thread.