### PR TITLE
perf(unlock): skip redundant second verify_password (halves unlock time)

### DIFF
--- a/src/lib/services/journalService.ts
+++ b/src/lib/services/journalService.ts
@@ -83,8 +83,15 @@ let sessionPassword: string | null = null;
 /**
  * Unlock the journal with password
  */
-export async function unlockJournal(password: string): Promise<boolean> {
-  const isValid = await verifyUserPassword(password);
+export async function unlockJournal(
+  password: string,
+  alreadyVerified = false,
+): Promise<boolean> {
+  // verify_password runs a 600k-iteration PBKDF2 (~seconds on a phone). When the
+  // caller (the lock screen) has ALREADY verified — and thereby derived + stored
+  // the DB key + 2FA state — re-verifying here just doubles the unlock latency for
+  // no benefit. Skip it in that case.
+  const isValid = alreadyVerified || (await verifyUserPassword(password));
 
   if (isValid) {
     sessionPassword = password;

--- a/src/pages/LockScreen.tsx
+++ b/src/pages/LockScreen.tsx
@@ -240,8 +240,10 @@ export function LockScreen() {
           pendingPasswordRef.current = password;
           setStep('biometric-enroll-offer');
         } else {
-          // No 2FA, no biometric offer — unlock directly
-          const success = await unlock(password);
+          // No 2FA, no biometric offer — unlock directly. The password was already
+          // verified above (verifyUserPassword), which derived + stored the DB key,
+          // so skip the redundant second verify_password PBKDF2 inside unlock().
+          const success = await unlock(password, true);
           if (success) {
             // Reset rate limit only after the session is unlocked (delete_setting requires unlock)
             await resetRateLimit().catch((err) => logger.warn('resetRateLimit failed', { error: String(err) }));

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -35,7 +35,7 @@ interface AppState {
   // Actions
   checkInitialization: () => Promise<void>;
   initialize: (password: string) => Promise<boolean>;
-  unlock: (password: string) => Promise<boolean>;
+  unlock: (password: string, alreadyVerified?: boolean) => Promise<boolean>;
   finalizeUnlock: (password: string) => Promise<boolean>;
   lock: () => void;
   setTheme: (theme: 'light' | 'dark' | 'system') => void;
@@ -84,10 +84,11 @@ export const useAppStore = create<AppState>((set) => ({
     }
   },
 
-  // Unlock with password
-  unlock: async (password: string) => {
+  // Unlock with password. `alreadyVerified` skips a redundant verify_password
+  // PBKDF2 when the caller (lock screen) has already verified this password.
+  unlock: async (password: string, alreadyVerified = false) => {
     try {
-      const success = await unlockJournal(password);
+      const success = await unlockJournal(password, alreadyVerified);
       if (success) {
         set({ isUnlocked: true, sessionPassword: password });
       }


### PR DESCRIPTION
## Finding (measured on-device, Pixel 9)

Instrumented the unlock path:
```
[TIMING] verifyUserPassword  ms=3531
[TIMING] unlock()            ms=3608   ← second identical PBKDF2
```
The password's 600k-iteration PBKDF2 ran **twice** per unlock:
1. `LockScreen.handlePasswordSubmit` → `verifyUserPassword` (needed — it also derives + stores the DB key + 2FA state, and decides 2FA routing).
2. Then `unlock()` → `unlockJournal()` → `verifyUserPassword` **again** — pure redundancy.

## Fix

Thread an `alreadyVerified` flag `LockScreen → appStore.unlock → unlockJournal`. The lock-screen password path (which just verified) passes `true`, so `unlockJournal` skips the second `verify_password`. The DB key + 2FA state were already set by the first verify, so `unlock_app` still works.

Other entry points (PIN unlock, biometric, setup auto-unlock) only verify once and are untouched (default `alreadyVerified=false`).

## Result

```
unlock(): 3608ms → 60ms
total:    7143ms → 3592ms   (2× faster)
```

(The remaining ~3.5s is the single `verify_password` PBKDF2 — tracked separately; likely the `sha2` crate not using ARMv8 hardware SHA.)

## Verification

`tsc`, `eslint`, and appStore/journalService/LockScreen tests all pass.