### PR TITLE
perf(crypto): enable sha2 'asm' feature for hardware SHA on ARM

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4818,6 +4818,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1"
 base64 = "0.22"
 totp-rs = { version = "5", features = ["qr", "gen_secret"] }
 data-encoding = "2"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["asm"] }
 rand = "0.8"
 hex = "0.4"
 aes-gcm = "0.10"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1"
 base64 = "0.22"
 totp-rs = { version = "5", features = ["qr", "gen_secret"] }
 data-encoding = "2"
-sha2 = { version = "0.10", features = ["asm"] }
+sha2 = "0.10"
 rand = "0.8"
 hex = "0.4"
 aes-gcm = "0.10"
@@ -73,6 +73,14 @@ tauri-plugin-shell = "2"
 # The same version is already pulled transitively by Tauri — no network download needed.
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "2.0", features = [] }
+
+# Hardware SHA for PBKDF2 (verify_password) on ARM. sha2's `asm` feature enables
+# the aarch64 ARMv8 SHA backend, which uses core::arch intrinsics (NOT the external
+# sha2-asm crate) gated behind a runtime cpufeatures check — fast on phones with
+# the crypto extensions, soft fallback otherwise. Scoped to aarch64 so x86_64
+# (esp. Windows MSVC) does NOT pull sha2-asm, whose x86 assembly fails to build there.
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+sha2 = { version = "0.10", features = ["asm"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Finding

After eliminating the redundant double-verify (#195), unlock was still ~3.4s — entirely one `verify_password` 600k-iteration PBKDF2-HMAC-SHA256.

`sha2` 0.10's backend selection (`src/sha256.rs`) only uses the **aarch64 hardware** SHA path when the **`asm` feature** is enabled:
```rust
} else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
    mod aarch64;  use aarch64::compress;   // hardware (ARMv8 SHA2)
} else {
    mod soft;     use soft::compress;      // software — what we were getting
}
```
Without `asm`, aarch64 fell through to the **software** path (~3.5s on a Pixel 9, even at opt-level 3).

## Fix

`sha2 = { version = "0.10", features = ["asm"] }`.

**Safe on every device:** the aarch64 backend (`sha256/aarch64.rs`) guards the hardware instructions behind a runtime `cpufeatures` check (`sha2_hwcap::get()`) with a `soft::compress` fallback — so CPUs with the ARMv8 crypto extensions (essentially all arm64 Android phones of the last several years) use hardware SHA, and any without them transparently use software. No `-C target-feature` flag, no SIGILL risk.

Unlike the debug-only `[profile.dev]` opt tweak, this benefits **release** builds too — production users get the fast unlock.

## Result (Pixel 9)

`verify_password`: ~3.4s → sub-second. Combined with #195 (double-verify), unlock went from ~7s to **near-instant**.

## Verification

`cargo check` clean (host build compiles with the asm feature). On-device confirmed near-instant unlock.