### PR TITLE
fix(test): assert unlock(password, true) on LockScreen password path

### DIFF
--- a/src/pages/LockScreen.test.tsx
+++ b/src/pages/LockScreen.test.tsx
@@ -353,11 +353,13 @@ describe('LockScreen — password submit: paint-yield + unlock', () => {
     });
 
     // The verify round-trip runs, then unlock() is called with the password.
+    // The password path passes alreadyVerified=true so unlock() skips the
+    // redundant second verify_password PBKDF2 (see LockScreen.tsx:260).
     await waitFor(() => {
       expect(verifyUserPassword).toHaveBeenCalledWith('correct horse');
     });
     await waitFor(() => {
-      expect(mockUnlock).toHaveBeenCalledWith('correct horse');
+      expect(mockUnlock).toHaveBeenCalledWith('correct horse', true);
     });
   });
 


### PR DESCRIPTION
Unbreaks main: merge interaction between #192 and #195 left LockScreen.test.tsx asserting a one-arg `unlock()` while `LockScreen.tsx:260` now passes `alreadyVerified=true`. One-line assertion fix; all 15 LockScreen tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)