### PR TITLE
chore(security): suppress Semgrep FPs on TOTP test fixtures (closes #75, #95)

### DIFF
--- a/src-tauri/src/commands/two_factor.rs
+++ b/src-tauri/src/commands/two_factor.rs
@@ -796,8 +796,8 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt_round_trip() {
-        let secret = "JBSWY3DPEHPK3PXP";
-        let password = "correct-horse-battery-staple";
+        let secret = "JBSWY3DPEHPK3PXP"; // nosemgrep: rust-hardcoded-secret (test fixture — TOTP encrypt/decrypt round-trip)
+        let password = "correct-horse-battery-staple"; // nosemgrep: rust-hardcoded-secret (test fixture — TOTP round-trip)
         let blob = encrypt_totp_secret(secret, password).expect("encrypt failed");
         let recovered = decrypt_totp_secret(&blob, password).expect("decrypt failed");
         assert_eq!(recovered, secret);
@@ -805,7 +805,7 @@ mod tests {
 
     #[test]
     fn wrong_password_fails_decryption() {
-        let secret = "JBSWY3DPEHPK3PXP";
+        let secret = "JBSWY3DPEHPK3PXP"; // nosemgrep: rust-hardcoded-secret (test fixture — wrong-password decryption)
         let blob = encrypt_totp_secret(secret, "password-a").expect("encrypt failed");
         let result = decrypt_totp_secret(&blob, "password-b");
         assert!(result.is_err());
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn legacy_plaintext_returned_as_is() {
-        let legacy = "JBSWY3DPEHPK3PXP";
+        let legacy = "JBSWY3DPEHPK3PXP"; // nosemgrep: rust-hardcoded-secret (test fixture — legacy plaintext passthrough)
         let result = decrypt_totp_secret(legacy, "anypassword").expect("should succeed");
         assert_eq!(result, legacy);
     }


### PR DESCRIPTION
## Summary

Triage of the recurring weekly Semgrep auto-reports (#75, #95). **Every finding across both issues is a confirmed false positive** — test fixtures and non-secret UI flags. This PR silences the only un-suppressed ERROR-severity ones so the scan stops re-reporting them.

### Changes
- `two_factor.rs` — add `// nosemgrep: rust-hardcoded-secret` to the 3 `#[cfg(test)]` TOTP round-trip fixtures (`JBSWY3DPEHPK3PXP` + `correct-horse-battery-staple`), matching the existing `journal.rs` convention.

### Triage of remaining findings (no code change needed)
- **`time_capsule.rs` rust-sql-injection** — constant SQL string inside a `#[test]` fn, no interpolation. FP.
- **`TimeCapsuleRevealModal.tsx` dangerouslySetInnerHTML** — renders the user's *own* DOMPurify-sanitized decrypted journal HTML; already suppressed. FP.
- **`secureStorage.test.ts` / localStorage findings** — test values + non-secret UI flags / tombstone UUIDs. FP.
- `booksStore.ts:81` nosemgrep rule-ID fix flagged in #75 — already corrected to `no-localstorage-secrets`.

### Meta
The weekly scan has run **local-rules-only for 8+ weeks** because semgrep.dev cloud rulesets return HTTP 403 (`p/security-audit`, `p/typescript`, `p/owasp-top-ten`). Worth restoring cloud-ruleset auth so coverage isn't degraded — tracked separately.

Closes #75
Closes #95

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>