### PR TITLE
chore(retro): weekly engineering retro 2026-06-19

### DIFF
--- a/retros/2026-06-19.md
+++ b/retros/2026-06-19.md
@@ -1,0 +1,92 @@
+# Weekly Retro — 2026-06-19
+
+## What shipped
+
+**v1.9.0 released**
+- `chore(release): v1.9.0` — tagged and shipped with auto-generated changelog and download-link sync
+- `fix(release): repair v1.9.0 version consistency (VERSION + package-lock)` (#200) — quick follow-up to align VERSION file and package-lock after the tag
+
+**Android voice memo pipeline (new)**
+- `feat(android): on-device voice memo capture — transcribe on synced desktop (voice Slice 1)` (#163) — records audio on Android, transfers to desktop via peer sync
+- `feat(sync): voice-memo peer-sync phase — transcription round-trip (voice Slice 2)` (#164) — whisper.cpp transcription result synced back to the originating Android device
+
+**Android Phase 2 expansion**
+- `feat(android): cloud-token key via AndroidKeyStore (Phase 2)` (#167) — OAuth tokens for cloud providers now stored in Android hardware-backed keystore
+- `feat(android): open media attachments via ACTION_VIEW intent (Phase 2)` (#166) — media files open in native Android apps
+- `feat(android): hold a MulticastLock so mDNS peer discovery works` (#165) — fixes peer visibility dropping when screen is on
+- `feat(android): attach media via content-URI bytes` (#191) — photo/file picker via content-URI instead of path copies
+- `fix(android): register PluginManager activity-result launcher (file picker)` (#190) — crash fix for the new media attach flow
+- `chore(android): declare bundle.android minSdkVersion in tauri.conf` (#169)
+
+**Android Phase 3**
+- `feat(sync): honest mobile sync clarity (Phase 3)` (#170) — UI now accurately communicates what syncs vs. what remains desktop-only
+
+**Crypto & unlock performance**
+- `perf(crypto): single per-account encryption salt + background migration` (#194) — replaces per-entry PBKDF2 derivation with a cached account-level key; silent migration on unlock
+- `perf(unlock): skip redundant second verify_password (halves unlock time)` (#195) — eliminates a double password-verify that was running on every unlock
+- `perf(crypto): enable sha2 'asm' feature for hardware SHA on ARM` (#196) — native ARM SHA instructions now used on M-series Macs and ARM Linux
+- `perf(dev): optimize password-hashing crates in debug builds` (#193) — dramatically faster dev/test iteration
+
+**Peer sync fixes**
+- `fix(peer-sync): set SO_REUSEADDR on the sync listener` (#189) — prevents "address already in use" on rapid restart
+- `fix(peer-sync): accept SQLite naive timestamps in parse_peer_timestamp` (#183) — fixes sync rejection of entries written by older SQLite schema
+- `fix(peer-sync): persist peer identity on Android` (#182) — Android had no keyring backend; device ID was regenerating every launch, breaking trust
+
+**Security & privacy**
+- `feat(privacy): enforce auto-lock timeout + clear-clipboard-on-lock` (#187) — auto-lock was advisory only; now actually fires + clipboard wipe on lock
+- `fix(recovery): re-verify derived key against stored hash on recovery-key promote` (#176) — closes a gap where the promote path skipped hash verification
+- `feat(security): implement crash-safe change_master_password (Approach A)` (#155) — atomic encrypt-in-place with crash-replay harness
+- `chore(security): suppress Semgrep FPs on TOTP test fixtures` (#199) — closes issues #75 and #95
+
+**Other features & fixes**
+- `feat(media): compress images before encryption` (#173) — reduces storage and sync payload
+- `feat(web): durable-storage guard + backup nudge (PWA)` (#175) — requests persistent storage and prompts for backup if refused
+- `feat(recovery): printable recovery-key PDF export` (#168)
+- `feat(sync): BYO-Cloud folder sync (desktop)` (#149) — custom folder as a cloud sync destination
+- `fix(writing): attach spinner + unlock paint-yield + clearer save indicator` (#192)
+- `refactor(stillhaven): dedupe environment overlays, 2D chrome, DeviceIcon` (#185) — Sonar-driven dedup
+- `fix: resolve Sonar-flagged correctness bugs (sort + reduce)` (#181)
+- `ci(android): gate PRs on Android app Kotlin compilation` (#188) — Android build failures now block merge
+- `ci(sonar): measure Rust coverage + enforce quality gate` (#186) — SonarQube now covers Rust, not just TypeScript
+- `docs(website): add Android pentest blog post` (#177)
+- `fix(website): bind "VirusTotal scanned" badge to the actual report` (#172)
+
+---
+
+## In progress
+
+- **#198** `ci: release-sync opens an auto-merging PR instead of pushing to main` — open PR to stop the release bot from force-pushing to main; switches to an auto-merging PR flow
+
+---
+
+## Wins
+
+- **v1.9.0 shipped** — a substantial release encompassing Android expansion, security hardening, and a crypto overhaul
+- **Android voice memo end-to-end** — record on watch/phone → sync → desktop transcription → sync back is now a working loop
+- **Unlock time roughly halved** — double verify eliminated + cached account key means password derivation runs once per session instead of once per entry operation
+- **Zero-knowledge model tightened** — auto-lock now actually enforces (was advisory), clipboard cleared on lock, recovery-key promote now re-verifies the derived key
+- **SonarQube quality gate live** — Rust + TypeScript coverage both measured; gate now enforcing on PRs
+- **Android Kotlin CI gate** — compile failures surface in PRs rather than post-merge
+
+---
+
+## Concerns / blockers
+
+- **v1.9.0 needed an immediate patch** (#200) — VERSION file and package-lock.json were out of sync at tag time; the release process has a manual step that can be forgotten. Automating this (or adding a pre-tag check) would prevent repeat patches.
+- **PR #154 closed without merge** (`perf: bundle audit — lazy loading, vendor chunks, crypto & render hotfixes`) — this work was dropped or superseded without a clear note in the issue tracker. Worth confirming the perf concerns are addressed elsewhere or reopening if still relevant.
+- **Release bot pushing directly to main** — PR #198 is open to fix this but not yet merged; until it lands, the release-sync job can bypass branch protection.
+- **db_state.json salt not yet transferred on full-DB restore** — flagged in `peer-sync-security.md` as a known gap; a restored device may fail to derive the DB key on first unlock. Still unresolved.
+
+---
+
+## Next week
+
+- Merge #198 to move release-sync off direct-to-main pushes
+- Investigate or re-open #154 (bundle perf audit) — confirm whether lazy-loading work is still needed
+- Resolve the db_state.json salt transfer gap in the peer full-DB restore path
+- Android Phase 3+ / deeper mobile integration (watch sync status, phase 4 entry preview)
+- Continue burning down Sonar findings now that the quality gate is live
+
+---
+
+*Auto-generated by weekly retro agent — 2026-06-19*


### PR DESCRIPTION
Weekly engineering retrospective for the week ending 2026-06-19.

**Note:** The intended destination was `kenlacroix/gstack-artifacts-ken` but that repo is not yet created or the session token lacks access (404/403). Filed here in `retros/` as a fallback so the record isn't lost. Once the artifacts repo is set up, future retros can land there instead.

Covers: v1.9.0 release, Android voice memo pipeline (Slices 1 & 2), Android Phase 2–3 expansion, crypto/unlock performance overhaul, peer sync reliability fixes, SonarQube quality gate, and security hardening.

Auto-generated by weekly retro routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYh8mvh8fB7akuXVnm1Xj2)_