### PR TITLE
docs: add kennethlacroix.me backlink to README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,4 +454,6 @@ Full history: [CHANGELOG.md](CHANGELOG.md)
 
 <div align="center">
 <sub>Built with care for people who write to understand themselves.</sub>
+<br>
+<sub>Built by <a href="https://kennethlacroix.me">Kenneth Lacroix</a></sub>
 </div>

--- a/README.md
+++ b/README.md
@@ -455,5 +455,5 @@ Full history: [CHANGELOG.md](CHANGELOG.md)
 <div align="center">
 <sub>Built with care for people who write to understand themselves.</sub>
 <br>
-<sub>Built by <a href="https://kennethlacroix.me">Kenneth Lacroix</a></sub>
+<sub>Built by <a href="https://kennethlacroix.me">Kenneth LaCroix</a></sub>
 </div>

--- a/src/components/settings/tabs/AboutTab.tsx
+++ b/src/components/settings/tabs/AboutTab.tsx
@@ -179,7 +179,7 @@ export function AboutTab({
                 rel="author noopener noreferrer"
                 className="underline text-violet-600 dark:text-violet-400"
               >
-                Kenneth Lacroix
+                Kenneth LaCroix
               </a>
               , a solo indie developer. The security
               model relies on established cryptographic primitives — AES-256-GCM, PBKDF2,

--- a/src/components/settings/tabs/AboutTab.tsx
+++ b/src/components/settings/tabs/AboutTab.tsx
@@ -172,7 +172,16 @@ export function AboutTab({
 
           <div className="pt-4">
             <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
-              MoodHaven Journal is built and maintained by a solo indie developer. The security
+              MoodHaven Journal is built and maintained by{' '}
+              <a
+                href="https://kennethlacroix.me"
+                target="_blank"
+                rel="author noopener noreferrer"
+                className="underline text-violet-600 dark:text-violet-400"
+              >
+                Kenneth Lacroix
+              </a>
+              , a solo indie developer. The security
               model relies on established cryptographic primitives — AES-256-GCM, PBKDF2,
               Ed25519 — not proprietary systems. The codebase has not been independently
               audited; you're welcome to{' '}


### PR DESCRIPTION
Two tasteful backlinks to [kennethlacroix.me](https://kennethlacroix.me) for author attribution + SEO/visibility:

- **README footer** — `Built by Kenneth LaCroix` credit line (Palisade pattern).
- **In-app About tab** — links the author name in the existing "built and maintained by …" credits line (rel=author).

No functional changes.