### PR TITLE
feat(website): SEO deep-dive — entity backlinks, RSS, OG images, breadcrumbs

### DIFF
--- a/website/app/about/page.tsx
+++ b/website/app/about/page.tsx
@@ -226,7 +226,7 @@ export default function AboutPage() {
                   <a
                     href="https://www.kennethlacroix.me"
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="me author noopener noreferrer"
                     className="text-xs font-medium text-primary-700 hover:underline"
                   >
                     Website ↗

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -122,7 +122,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     "author": {
       "@type": "Person",
       "name": "Ken LaCroix",
-      "url": "https://www.moodhaven.app/about"
+      "url": "https://www.kennethlacroix.me",
+      "sameAs": [
+        "https://www.kennethlacroix.me",
+        "https://github.com/kenlacroix"
+      ]
     },
     "publisher": {
       "@type": "Organization",
@@ -133,11 +137,40 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     ...(post.heroImage ? { "image": `https://www.moodhaven.app${post.heroImage}` } : {}),
   };
 
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://www.moodhaven.app",
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Blog",
+        "item": "https://www.moodhaven.app/blog",
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": post.title,
+        "item": `https://www.moodhaven.app/blog/${slug}`,
+      },
+    ],
+  };
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
       <BlogPostClient
         title={post.title}

--- a/website/app/blog/rss.xml/route.ts
+++ b/website/app/blog/rss.xml/route.ts
@@ -1,0 +1,65 @@
+// app/blog/rss.xml/route.ts
+import { getAllPosts, type PostMeta } from "@/lib/posts";
+
+export const dynamic = "force-static";
+
+const BASE = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.moodhaven.app"
+).replace(/\/$/, "");
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const todayISO = new Date().toISOString().slice(0, 10);
+
+  const posts = getAllPosts()
+    .filter((p: PostMeta) => {
+      if (p.draft === true) return false;
+      if (p.published === false) return false;
+      if (!p.publishDate) return false;
+      if (p.publishDate.slice(0, 10) > todayISO) return false;
+      return true;
+    })
+    .sort((a, b) => (a.publishDate! < b.publishDate! ? 1 : -1));
+
+  const items = posts
+    .map((p) => {
+      const url = `${BASE}/blog/${p.slug}`;
+      const pubDate = new Date(p.publishDate!).toUTCString();
+      return `    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXml(p.excerpt ?? "")}</description>
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>MoodHaven Journal Blog</title>
+    <link>${BASE}/blog</link>
+    <atom:link href="${BASE}/blog/rss.xml" rel="self" type="application/rss+xml" />
+    <description>Privacy-first software, local-first design, and what we're building.</description>
+    <language>en-US</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/website/app/contribute/opengraph-image.tsx
+++ b/website/app/contribute/opengraph-image.tsx
@@ -1,0 +1,9 @@
+export const runtime = "edge";
+
+import { renderOgImage, ogSize as size, ogContentType as contentType } from "@/lib/ogImage";
+
+export { size, contentType };
+
+export default function Image() {
+  return renderOgImage("Contribute", "Help build a privacy-first, open-source journal — code, testing, writing, advocacy");
+}

--- a/website/app/faq/opengraph-image.tsx
+++ b/website/app/faq/opengraph-image.tsx
@@ -1,0 +1,9 @@
+export const runtime = "edge";
+
+import { renderOgImage, ogSize as size, ogContentType as contentType } from "@/lib/ogImage";
+
+export { size, contentType };
+
+export default function Image() {
+  return renderOgImage("Frequently Asked Questions", "How MoodHaven keeps your journal private, encrypted, and yours");
+}

--- a/website/app/features/opengraph-image.tsx
+++ b/website/app/features/opengraph-image.tsx
@@ -1,0 +1,9 @@
+export const runtime = "edge";
+
+import { renderOgImage, ogSize as size, ogContentType as contentType } from "@/lib/ogImage";
+
+export { size, contentType };
+
+export default function Image() {
+  return renderOgImage("Features", "Mood tracking, AI insights, encryption, sync — everything MoodHaven does");
+}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -96,14 +96,29 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             "@context": "https://schema.org",
             "@graph": [
               {
+                "@type": "Person",
+                "@id": "https://www.moodhaven.app/#ken",
+                "name": "Ken LaCroix",
+                "url": "https://www.kennethlacroix.me",
+                "jobTitle": "Creator & Maintainer",
+                "sameAs": [
+                  "https://www.kennethlacroix.me",
+                  "https://github.com/kenlacroix"
+                ]
+              },
+              {
                 "@type": "Organization",
                 "@id": "https://www.moodhaven.app/#org",
                 "name": "MoodHaven Journal",
                 "url": "https://www.moodhaven.app",
                 "logo": "https://www.moodhaven.app/icons/opengraph-image.png",
+                "founder": { "@id": "https://www.moodhaven.app/#ken" },
                 "sameAs": [
                   "https://github.com/kenlacroix/moodhaven-journal",
-                  "https://moodhaven.substack.com"
+                  "https://moodhaven.substack.com",
+                  "https://x.com/moodhavenapp",
+                  "https://bsky.app/profile/moodhavenapp.bsky.social",
+                  "https://www.linkedin.com/company/moodhavenapp/"
                 ]
               },
               {

--- a/website/app/platforms/opengraph-image.tsx
+++ b/website/app/platforms/opengraph-image.tsx
@@ -1,0 +1,9 @@
+export const runtime = "edge";
+
+import { renderOgImage, ogSize as size, ogContentType as contentType } from "@/lib/ogImage";
+
+export { size, contentType };
+
+export default function Image() {
+  return renderOgImage("Platform Availability", "Windows · macOS · Linux · Browser · Wear OS companion");
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -26,6 +26,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "",
     "/getting-started",
     "/download",
+    "/features",
+    "/platforms",
     "/about",
     "/blog",
     "/changelog",

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -71,7 +71,7 @@ export default function Footer() {
             <Link
               href="https://www.kennethlacroix.me"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="me author noopener noreferrer"
               className="underline hover:text-neutral-600"
             >
               Ken LaCroix

--- a/website/lib/ogImage.tsx
+++ b/website/lib/ogImage.tsx
@@ -1,0 +1,146 @@
+import { ImageResponse } from "next/og";
+
+export const ogSize = { width: 1200, height: 630 };
+export const ogContentType = "image/png";
+
+/**
+ * Shared OpenGraph image in the warm MoodHaven brand style.
+ * Pass a page title and a one-line subtitle.
+ */
+export function renderOgImage(title: string, subtitle: string) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 1200,
+          height: 630,
+          background:
+            "linear-gradient(160deg, #faf9f7 0%, #f3ede8 50%, #ede6df 100%)",
+          display: "flex",
+          flexDirection: "column",
+          padding: "72px 80px",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: -100,
+            right: -100,
+            width: 480,
+            height: 480,
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(139,92,246,0.08) 0%, transparent 70%)",
+            pointerEvents: "none",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: -80,
+            left: -60,
+            width: 320,
+            height: 320,
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(167,139,250,0.06) 0%, transparent 70%)",
+            pointerEvents: "none",
+          }}
+        />
+
+        {/* Brand label */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 52,
+          }}
+        >
+          <div
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: "#8b5cf6",
+            }}
+          />
+          <div
+            style={{
+              fontSize: 15,
+              fontWeight: 700,
+              color: "#7c3aed",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+            }}
+          >
+            MoodHaven Journal
+          </div>
+        </div>
+
+        {/* Title — large display */}
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 900,
+            color: "#1c1917",
+            lineHeight: 1.08,
+            letterSpacing: "-0.02em",
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            maxWidth: 980,
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: 24,
+            color: "#78716c",
+            lineHeight: 1.5,
+            maxWidth: 880,
+            marginBottom: 44,
+          }}
+        >
+          {subtitle}
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgba(120,113,108,0.2)",
+            paddingTop: 24,
+          }}
+        >
+          <div style={{ fontSize: 17, color: "#8b5cf6", fontWeight: 600 }}>
+            moodhaven.app
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              color: "#7c3aed",
+              background: "rgba(139,92,246,0.08)",
+              border: "1px solid rgba(139,92,246,0.2)",
+              padding: "6px 18px",
+              borderRadius: 999,
+              fontWeight: 600,
+              letterSpacing: "0.05em",
+            }}
+          >
+            Privacy-First · Open Source
+          </div>
+        </div>
+      </div>
+    ),
+    { ...ogSize }
+  );
+}


### PR DESCRIPTION
Deep-dive SEO pass on the marketing site, focused on backlinking to kennethlacroix.me and structured data.

## Backlinking to kennethlacroix.me
- New sitewide `Person` (Ken LaCroix) JSON-LD node with `url`/`sameAs` → kennethlacroix.me + GitHub; referenced as Organization `founder`.
- Blog `Article` author now points to kennethlacroix.me with `sameAs`.
- `rel="me author"` on visible kennethlacroix.me anchors (Footer, About) for identity association.

## Fixes
- **`/blog/rss.xml`** — added the route. It was advertised in `<head>` `alternates` but returned **404**.
- **Sitemap** — added `/features` and `/platforms` (real indexable pages that were missing).

## Additions
- **BreadcrumbList** JSON-LD (`Home › Blog › <post>`) on blog posts → breadcrumb rich results.
- **OG images** for `/features`, `/faq`, `/platforms`, `/contribute` via a shared `lib/ogImage.tsx` helper (previously fell back to the root OG image).
- Expanded Organization `sameAs` (X, Bluesky, LinkedIn).

## Already good (verified, no change needed)
- Per-page canonicals sitewide.
- Apex `moodhaven.app` → `www` 301 confirmed live (deep paths + query strings preserved, no loop) via a Cloudflare zone Redirect Rule.

Verified with `next build` — 35/35 static pages, clean compile; all four new `opengraph-image` routes present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)