### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1470,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3995,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4437,7 +4437,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5607,10 +5607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Resolves the `cargo audit (CVE check)` failure on `Rust (ubuntu-latest)`.

The real failure was a **new high-severity vulnerability**, not the unmaintained-crate warnings (those are "allowed warnings" that don't fail the gate):

- **RUSTSEC-2026-0185** — `quinn-proto 0.11.14`: *remote memory exhaustion from unbounded out-of-order stream reassembly* (CVSS 7.5 high). Fixed in `0.11.15`.

Pulled transitively: `quinn-proto` → `quinn 0.11.9` → `reqwest 0.12.28` → (`tauri-plugin-http` + direct).

## Change
`cargo update -p quinn-proto --precise 0.11.15` — **lockfile-only**, semver-compatible patch. `Cargo.toml` unchanged.

## Verification
- `cargo audit` → **exit 0** (no vulnerabilities; the 19 unmaintained/unsound GTK3/unic warnings remain "allowed" and don't gate, as before).
- `cargo check` → passes.

Independent of the SEO PR (#232).

🤖 Generated with [Claude Code](https://claude.com/claude-code)