### PR TITLE
chore(repo): add MIT LICENSE + kennethlacroix.me backlink

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ken LaCroix and MoodHaven Journal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -448,10 +448,14 @@ Full history: [CHANGELOG.md](CHANGELOG.md)
 
 ## License
 
-[MIT](LICENSE) — © MoodHaven Journal contributors
+[MIT](LICENSE) — © 2025 Ken LaCroix and MoodHaven Journal contributors
 
 ---
 
 <div align="center">
+
+Built by <a href="https://www.kennethlacroix.me">Ken LaCroix</a> · <a href="https://www.moodhaven.app">moodhaven.app</a>
+
 <sub>Built with care for people who write to understand themselves.</sub>
+
 </div>


### PR DESCRIPTION
Repo-hygiene polish.

## Added LICENSE file
There was **no `LICENSE` file** in the repo, even though the README badge links to `LICENSE`, the README claims MIT, and the site's JSON-LD declares the MIT license. GitHub consequently detected **no license** (`/license` → 404) and the badge link was broken. This adds the standard MIT text (© 2025 Ken LaCroix and MoodHaven Journal contributors), which fixes the badge link and lets GitHub show the license in the sidebar.

## Backlink to kennethlacroix.me
README footer now credits the author with a link to kennethlacroix.me (mirroring the website footer) plus a moodhaven.app link, and the copyright line is aligned with the LICENSE holder.

## Also (live repo-settings changes already applied, not in this diff)
- Cleaned a stray run of whitespace in the repo description.
- Homepage URL → `https://www.moodhaven.app` (canonical host; apex now 301s to www).
- Added topics: `rust`, `mood-tracking`, `wear-os`, `local-first`, `journaling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)