### PR TITLE
chore(retro): weekly engineering retro 2026-06-26

### DIFF
--- a/docs/retros/2026-06-26.md
+++ b/docs/retros/2026-06-26.md
@@ -1,0 +1,71 @@
+# Weekly Retro — 2026-06-26
+
+## What shipped
+
+### v1.9.0 release + post-release cleanup
+- **v1.9.0 tag cut** (`5e5a4f0`) with automated README/changelog sync via `release-sync` workflow
+- **fix(release):** repaired v1.9.0 version consistency — `package-lock.json` and `VERSION` file were left at 1.8.2, breaking `npm ci` lockfile checks on every PR built off main (#200)
+
+### Android
+- **feat(android): export share sheet** — `save()` flows (recovery PDF, `.moodhaven` backup, 2FA codes) now write to app-private storage and hand off to the OS share sheet on Android, since no save dialog is available (#205); includes `usePlatform.test.ts` and mobile export tests
+
+### Blog & marketing site
+- **feat(blog):** fixed broken hero images on 4 posts (no `heroImage` frontmatter, fallback path was `.jpg` but file was `.png`); added scheduled drip-publish + newsletter/social auto-announce automation ported from `kennethlacroix-site` (#206)
+- **feat(website): SEO deep-dive** — sitewide `Person` JSON-LD (Ken LaCroix) node with `sameAs` backlinks, `rel="me author"` anchors, `/blog/rss.xml` route (was advertised but returned 404), `BreadcrumbList` JSON-LD on blog posts, OG images for `/features`, `/faq`, `/platforms`, `/contribute` (#232)
+- **docs:** added `kennethlacroix.me` backlink + author credit to README footer; linked author name in About tab (#230)
+
+### Security
+- **fix(deps): quinn-proto 0.11.14 → 0.11.15** — patched RUSTSEC-2026-0185 (high-severity 7.5, remote memory-exhaustion via unbounded out-of-order stream reassembly); pulled transitively via reqwest → quinn; lockfile-only change (#233)
+- **chore(security):** suppressed Semgrep false positives on TOTP test fixtures in `two_factor.rs` (`#[cfg(test)]` values re-flagged weekly via issues #75, #95) (#199)
+
+### Repo hygiene
+- **chore(repo): added MIT LICENSE file** — the README badge and JSON-LD both declared MIT but no `LICENSE` file existed; GitHub detected no license (#234)
+- **chore(repo): tidy root** — archived 6 `HANDOFF-*.md` files, stale `SECURITY-AUDIT`, `WEBSITE-POLISH`, `TODOS.md`, and dead `staging/` WIP duplicates into gitignored `docs/internal/archive/` (#203)
+
+### CI
+- **ci: release-sync now opens an auto-merging PR** instead of pushing directly to `main`, removing the branch-protection bypass (#198)
+- **chore(ci):** bumped GitHub Actions to current major versions: `actions/checkout` 4→7, `actions/setup-node` 4→6, `actions/setup-java` 5.2.0→5.3.0 (#207, #208, #209)
+
+---
+
+## In progress
+
+- **test: IPC service coverage buildout** (#110, draft) — +209 tests across 10 new files in `src/lib/services/`; still in draft, not yet merged
+- **a11y: accessibility & UX-correctness pass** (#100) — closed without merge; status unclear, may need a rebase or split into smaller PRs
+- **Cloud provider OAuth** — Dropbox/Google Drive commands are implemented but ship with placeholder credentials (`*_PLACEHOLDER`); auth will fail until real credentials are registered and compiled in (tracked in architecture docs as a Phase 1 gap)
+
+---
+
+## Wins
+
+- **Security advisory patched same day** — RUSTSEC-2026-0185 was identified and fixed within the same CI run that surfaced it; `cargo audit` is clean again
+- **v1.9.0 shipped cleanly** despite the post-release version-file hiccup being caught and fixed within hours
+- **CI branch-protection hygiene** — `release-sync` no longer bypasses required status checks via direct `main` push; the repo is now properly gated
+- **MIT license formalized** — resolves a repo credibility gap; GitHub now correctly detects the license
+- **Android export flows are functional** — users on Android can now share backups/recovery PDFs, closing a silent gap where file saves were dropped
+- **Blog automation pipeline up** — drip-publish + newsletter + LinkedIn announce pipeline is wired; just needs secrets to go live
+
+---
+
+## Concerns / blockers
+
+- **Cloud OAuth credentials are still placeholders** — `DROPBOX_APP_KEY_PLACEHOLDER` / `GOOGLE_CLIENT_ID_PLACEHOLDER` are compile-time constants; cloud sync to Dropbox/GDrive cannot ship until real credentials are registered and build-injected. This is the last hard blocker for cloud sync Phase 1.
+- **a11y PR (#100) stalled** — opened 2026-06-05, closed without merge on 2026-06-21. If the work is still needed, it should be rebased on main and re-opened or landed as smaller PRs to avoid another rebase spiral.
+- **Test coverage buildout (#110) has been in draft for 3 weeks** — opened 2026-06-06, still draft. Either land it or close it; long-lived draft branches accumulate rebase debt.
+- **Blog secrets not yet wired** — drip-publish, newsletter (Resend/EmailOctopus), and social (Buffer) automation shipped but all 7 required secrets (`CF_DEPLOY_HOOK`, `RESEND_API_KEY`, etc.) are unset; the workflows no-op until added in repo settings.
+- **`db_state.json` salt not transferred on full-DB restore** — known gap documented in `docs/peer-sync-security.md`; a restored device may fail to derive the DB key on first unlock until addressed.
+- **Retro destination:** `kenlacroix/gstack-artifacts-ken` is not in scope for this session token. This retro was pushed to `docs/retros/` in `moodhaven-journal` as a fallback (same pattern as #202 last week). Consider adding the artifacts repo to the session scope or creating a permanent `retros/` home in this repo.
+
+---
+
+## Next week
+
+- Wire blog automation secrets (`CF_DEPLOY_HOOK`, `RESEND_API_KEY`, `EMAILOCTOPUS_*`, `BUFFER_*`) so the drip-publish pipeline goes live
+- Resolve cloud OAuth placeholder credentials for Dropbox/Google Drive to unblock cloud sync Phase 1 shipping
+- Land or close test coverage buildout (#110) — 3 weeks in draft is long enough to decide
+- Revisit the a11y PR (#100) — assess whether to rebase and re-open or break into targeted fixes
+- Investigate the `db_state.json` gap in the peer-sync full-DB restore path
+
+---
+
+*Auto-generated by weekly retro agent — 2026-06-26*


### PR DESCRIPTION
Weekly engineering retrospective for the week ending 2026-06-26.

**Note:** The intended destination was `kenlacroix/gstack-artifacts-ken` but that repo is not in scope for this session token. Falling back to `docs/retros/` in this repo, matching the pattern from last week's retro (#202).

## Summary of the week
- v1.9.0 shipped + version-consistency fixes
- Android export share sheet landed
- RUSTSEC-2026-0185 (quinn-proto) patched same-day
- MIT LICENSE file added (was missing despite badge + JSON-LD claiming MIT)
- SEO deep-dive on the marketing site
- Blog drip-publish automation wired (needs secrets)
- CI Actions major version bumps (checkout→7, setup-node→6, setup-java→5.3.0)
- `release-sync` now goes through a PR instead of direct push to main

*Auto-generated by weekly retro agent*

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKCAtGazGvqtVtwrACsvNe)_