### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
Nightly `cargo audit` + `cargo deny` scan for 2026-07-03.

## Closed advisories

| ID | Crate | Version | Advisory |
|:---|:---|:---|:---|
| RUSTSEC-2026-0190 | anyhow | 1.0.102 → 1.0.103 | https://rustsec.org/advisories/RUSTSEC-2026-0190 |

Closed via `cargo update -p anyhow` — an in-range patch bump. This was the `Error::downcast_mut()` unsoundness advisory published 2026-06-25.

## Needs manual review

The following advisories were surfaced but cannot be closed by an in-range `cargo update`; they require a manifest bump upstream (Tauri / plist) or a new manual `ignore` entry. They are listed here so a human can decide.

| ID | Crate | Version | Required | Notes |
|:---|:---|:---|:---|:---|
| [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | quick-xml | 0.37.5 | >= 0.41.0 | Quadratic run-time on duplicate-attribute check (high). Transitive via Tauri codegen. Requires Tauri to bump `quick-xml`. |
| [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | quick-xml | 0.38.4 | >= 0.41.0 | Same advisory, second path: `plist v1.8.0 → tauri v2.11.0`. Requires `plist` to bump `quick-xml`, or a Tauri drop of `plist`. |
| [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | quick-xml | 0.37.5 | >= 0.41.0 | Unbounded `NsReader` namespace allocation (high). Same upstream path. |
| [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | quick-xml | 0.38.4 | >= 0.41.0 | Same, via `plist → tauri`. |
| [RUSTSEC-2024-0429](https://rustsec.org/advisories/RUSTSEC-2024-0429) | glib | 0.18.5 | (no fix) | Unsound `VariantStrIter` iterators. Already ignored in `src-tauri/audit.toml` (GTK3 stack). `cargo deny` still surfaces it because `src-tauri/deny.toml` does not carry the same ignore — consider aligning the two ignore lists. |

## Verification

`cargo audit` and `cargo deny check` were re-run after the update. RUSTSEC-2026-0190 no longer appears; the quick-xml findings above persist as expected (out of in-range scope). `npm run check:all` was NOT run to completion in the scan environment because the sandbox lacks GTK3 dev libs and full `node_modules` — CI will run it here.

_Generated by the nightly advisory-scan routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLip68WtkAchQ9HmVqawnk)_