### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
## Summary

Automated nightly advisory scan. Closed 1 in-range advisory via `cargo update`; 4 remain manual (transitive via Tauri).

## Closed advisories

| ID | Crate | Version | Advisory |
|---|---|---|---|
| RUSTSEC-2026-0190 | `anyhow` | 1.0.102 → 1.0.103 | https://rustsec.org/advisories/RUSTSEC-2026-0190 (unsoundness in `Error::downcast_mut()`) |

## Needs manual review

All four remaining vulnerabilities are the same underlying `quick-xml` DoS pair (RUSTSEC-2026-0194 quadratic attribute check, RUSTSEC-2026-0195 unbounded NsReader allocations), which require `quick-xml >= 0.41.0`. Both copies are transitive via Tauri and pinned by their parents' semver ranges — an in-range `cargo update` cannot reach them, so this needs an upstream Tauri bump:

| ID | Crate | Version | Blocking parent | Advisory |
|---|---|---|---|---|
| RUSTSEC-2026-0194 | `quick-xml` | 0.37.5 | `tauri-winrt-notification 0.7.2` (^0.37) | https://rustsec.org/advisories/RUSTSEC-2026-0194 |
| RUSTSEC-2026-0195 | `quick-xml` | 0.37.5 | `tauri-winrt-notification 0.7.2` (^0.37) | https://rustsec.org/advisories/RUSTSEC-2026-0195 |
| RUSTSEC-2026-0194 | `quick-xml` | 0.38.4 | `plist 1.8.0` → `tauri 2.11.0` (^0.38) | https://rustsec.org/advisories/RUSTSEC-2026-0194 |
| RUSTSEC-2026-0195 | `quick-xml` | 0.38.4 | `plist 1.8.0` → `tauri 2.11.0` (^0.38) | https://rustsec.org/advisories/RUSTSEC-2026-0195 |

Impact assessment: both are input-driven DoS on untrusted XML — MoodHaven never feeds untrusted XML through these paths (they're used for plist parsing during build and Windows notification metadata). Severity in practice is lower than the CVSS 7.5 rating, but they still show up as CI blockers.

## Verification note

`npm run check:all` was already failing on `main` due to the four quick-xml advisories described above; the exit status is unchanged by this patch. Rust-only crate bump, no code changes.

## Test plan

- [x] `cargo audit` — anyhow advisory no longer reported
- [x] `cargo deny check` — same exit status as `main` (still fails on pre-existing quick-xml)
- [ ] Reviewer confirms plan for the manual quick-xml manifest bump (waiting on `tauri` 2.12+ / `plist` 1.9+)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWvin2gbmTtDMXC7RvVRMj)_