### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
## Nightly advisory scan — 2026-07-07

Automated scan via `cargo audit` + `cargo deny check` in `src-tauri/`.

### Closed

| Advisory | Crate | Old → New | Severity | URL |
|---|---|---|---|---|
| RUSTSEC-2026-0190 | `anyhow` | 1.0.102 → 1.0.103 | unsound | https://rustsec.org/advisories/RUSTSEC-2026-0190 |

Semver-compatible patch bump within the existing `anyhow = "1"` manifest range. Applied via `cargo update -p anyhow`.

### Needs manual review

These require manifest bumps in upstream Tauri crates (transitive, semver-incompatible for `cargo update`):

| Advisory | Crate | Current | Fixed in | Chain | URL |
|---|---|---|---|---|---|
| RUSTSEC-2026-0194 | `quick-xml` | 0.37.5 | ≥ 0.41.0 | `tauri-winrt-notification` → `notify-rust` → `tauri-plugin-notification` | https://rustsec.org/advisories/RUSTSEC-2026-0194 |
| RUSTSEC-2026-0195 | `quick-xml` | 0.37.5 | ≥ 0.41.0 | (same) | https://rustsec.org/advisories/RUSTSEC-2026-0195 |
| RUSTSEC-2026-0194 | `quick-xml` | 0.38.4 | ≥ 0.41.0 | `plist` → `tauri` | https://rustsec.org/advisories/RUSTSEC-2026-0194 |
| RUSTSEC-2026-0195 | `quick-xml` | 0.38.4 | ≥ 0.41.0 | (same) | https://rustsec.org/advisories/RUSTSEC-2026-0195 |
| RUSTSEC-2024-0429 | `glib` | 0.18.5 | (unmaintained GTK3 tree) | Tauri Linux WebView | https://rustsec.org/advisories/RUSTSEC-2024-0429 |

Waiting on upstream Tauri to bump `notify-rust` and `plist` for the `quick-xml` findings. The `glib` unsound advisory is in the unmaintained GTK3 tree already tracked in `deny.toml`; consider adding to the ignore list if it should be silenced pending Tauri v3.

### Verification

- ✅ `npm run typecheck`
- ✅ `npm run lint:ci`
- ✅ `npm run test` — 1617 tests / 118 files passed
- ⚠️ `cargo check` — not run (requires `sidecar/whisper-*` binary, CI-only)
- ⚠️ `cargo audit` / `cargo deny check` — still exit non-zero due to the 4 pre-existing `quick-xml` findings above (unchanged by this PR)


---
_Generated by [Claude Code](https://claude.ai/code/session_017vYudDYB8b3cJYVQbUc5Su)_