### PR TITLE
fix(ci): repair cargo-audit gate and skip Sonar on dependabot PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   sonar:
     name: Analyze
+    # Dependabot-triggered runs use the Dependabot secret store, which has no
+    # SONAR_TOKEN, so the scan can only fail. Skip it — a skipped check still
+    # satisfies branch protection.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,6 +1,11 @@
 # cargo-audit configuration for MoodHaven Journal
 # https://docs.rs/cargo-audit/latest/cargo_audit/config/
 #
+# Must live at src-tauri/.cargo/audit.toml — cargo-audit only reads
+# `.cargo/audit.toml` relative to its working directory (CI runs it
+# from src-tauri/). It was previously at src-tauri/audit.toml, where
+# it was silently never loaded.
+#
 # The advisories below are for unmaintained GTK3/GLib transitive dependencies
 # pulled in by Tauri's Linux WebView stack (webkit2gtk → gtk3 → atk/gdk/glib/…).
 # No fix version exists — these crates are deprecated as the ecosystem moved to
@@ -23,6 +28,8 @@ ignore = [
   "RUSTSEC-2024-0429",  # glib
   # Other unmaintained transitive deps (no fix version available)
   "RUSTSEC-2024-0370",  # proc-macro-error (pulled in by Tauri macros)
+  "RUSTSEC-2024-0384",  # instant (via keyring → secret-service → zbus v3)
+  "RUSTSEC-2024-0388",  # derivative (via keyring → secret-service → zbus v3)
   "RUSTSEC-2025-0057",  # fxhash
   "RUSTSEC-2025-0081",  # unic-char-property
   "RUSTSEC-2025-0075",  # unic-char-range

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -1231,7 +1231,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1470,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2884,14 +2884,16 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -3058,7 +3060,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3124,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.16.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e551a9f0db223eaf3eb156906f99f46897fd951ee66dd1cb0be14db4d36d2fa"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite 2.6.1",
  "log",
@@ -3231,7 +3233,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3709,13 +3711,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3957,18 +3959,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4025,7 +4018,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4424,7 +4417,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4437,7 +4430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4945,7 +4938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5590,11 +5583,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows",
  "windows-version",
@@ -5607,10 +5599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6002,7 +5994,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6031,7 +6023,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/speech_to_text.rs
+++ b/src-tauri/src/commands/speech_to_text.rs
@@ -202,7 +202,7 @@ pub async fn stt_download_model(
     let url = model_url(&filename)?;
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     // Remove any leftover partial file from a previous attempt
     let _ = fs::remove_file(&partial_path);
@@ -442,7 +442,7 @@ pub async fn stt_cancel_download(
 #[command]
 pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if partial_path.exists() {
         fs::remove_file(&partial_path)
@@ -457,7 +457,7 @@ pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(),
 pub async fn stt_delete_model(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if model_path.exists() {
         fs::remove_file(&model_path).map_err(|e| format!("Failed to delete model: {}", e))?;


### PR DESCRIPTION
## Summary

Three repo-wide CI problems were blocking every open PR. This fixes all of them:

**1. cargo-audit failing everywhere (4 vulnerabilities)**
Two quick-xml advisories (RUSTSEC-2026-0194 quadratic attribute check + NsReader memory-exhaustion DoS) hit both locked versions — 0.37.5 (via tauri-winrt-notification) and 0.38.4 (via plist). Fixed with real upgrades, no ignores:
- `plist` 1.8.0 → 1.10.0 (pulls quick-xml **0.41.0**, the fixed version)
- `notify-rust` 4.16 → 4.18 + `tauri-winrt-notification` 0.7.2 → 0.7.3 (removes quick-xml 0.37.5 from the tree)
- `anyhow` 1.0.102 → 1.0.103 (RUSTSEC-2026-0190) — **supersedes the nightly advisory-scan PRs #247, #245, #240**, which are identical 2-line versions of this bump

**2. Audit ignore config was never being read**
The ignore list lived at `src-tauri/audit.toml`, but cargo-audit only loads `.cargo/audit.toml` relative to its working directory — it was silently a no-op the whole time (harmless until now because it only listed non-failing warnings). Moved to `src-tauri/.cargo/audit.toml` and synced the `instant`/`derivative` entries from deny.toml.

**3. Sonar Analyze failing on all dependabot PRs (#244, #239, #238)**
Dependabot-triggered workflows use the Dependabot secret store (`Secret source: Dependabot` in the job logs), which has no `SONAR_TOKEN`, so the scan can only fail. The Analyze job now skips for dependabot; a skipped check still satisfies branch protection.

## Verification
- `cargo audit` exits clean locally: 0 vulnerabilities, 0 warnings (ignore list now actually applies)
- `cargo check --all-targets` passes with the updated lockfile

## After this merges
- Close #247 / #245 / #240 as superseded
- Rerun checks on #238, #239, #244 (dependabot bumps) — they should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)