### PR TITLE
chore: clippy fixes — 3 new lints from Rust stable

### DIFF
--- a/src-tauri/src/commands/speech_to_text.rs
+++ b/src-tauri/src/commands/speech_to_text.rs
@@ -202,7 +202,7 @@ pub async fn stt_download_model(
     let url = model_url(&filename)?;
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     // Remove any leftover partial file from a previous attempt
     let _ = fs::remove_file(&partial_path);
@@ -442,7 +442,7 @@ pub async fn stt_cancel_download(
 #[command]
 pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if partial_path.exists() {
         fs::remove_file(&partial_path)
@@ -457,7 +457,7 @@ pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(),
 pub async fn stt_delete_model(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if model_path.exists() {
         fs::remove_file(&model_path).map_err(|e| format!("Failed to delete model: {}", e))?;


### PR DESCRIPTION
## Summary

The weekly Rust-stable clippy watch triggered [Tests run #856](https://github.com/kenlacroix/moodhaven-journal/actions/runs/29225647173) on `main` and it failed the `Clippy (deny warnings)` step. `cargo check` passed cleanly on Ubuntu, macOS, and Windows; `cargo test` was skipped only because clippy is a hard gate. This PR applies clippy's own `try` suggestion for the three findings — no other changes.

All three findings are the same lint (`clippy::useless_borrows_in_formatting`), stabilised in Rust 1.97.0, on the same idiom (`format!("{}.partial", &filename)`) in `src-tauri/src/commands/speech_to_text.rs`. `filename: String` already implements `Display`, so the `&` in front of the argument is redundant. Fix: drop the `&`.

| File:line | Lint | Fix |
| :--- | :--- | :--- |
| `src-tauri/src/commands/speech_to_text.rs:205` | `clippy::useless_borrows_in_formatting` | `&format!("{}.partial", &filename)` → `&format!("{}.partial", filename)` |
| `src-tauri/src/commands/speech_to_text.rs:445` | `clippy::useless_borrows_in_formatting` | `&format!("{}.partial", &filename)` → `&format!("{}.partial", filename)` |
| `src-tauri/src/commands/speech_to_text.rs:460` | `clippy::useless_borrows_in_formatting` | `&format!("{}.partial", &filename)` → `&format!("{}.partial", filename)` |

Reference: <https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting>

## Test plan

- [ ] Human review of the three-line diff before merge (clippy's `try` suggestions are usually right but not always — this is a draft on purpose).
- [ ] Green CI on this branch: `cargo check`, `cargo clippy -- -D warnings`, `cargo test`, `cargo fmt --check`.
- [ ] No behaviour change intended — `format!` with `Display` on a `String` value works identically to the same call with `&String` (auto-deref).

## Provenance

Auto-generated by the weekly Rust-stable clippy watch routine. Failing run: <https://github.com/kenlacroix/moodhaven-journal/actions/runs/29225647173>. Left as **draft** so a human confirms clippy's autofixes before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013eRBnQKLrAd6e5TKSKCK5o)_