### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"


### PR DESCRIPTION
## Summary

Nightly advisory scan for 2026-07-18. One advisory auto-closed via `cargo update`; two require a manual manifest bump.

## Closed

| Advisory | Crate | Old → New | Details |
|:---|:---|:---|:---|
| [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) | `anyhow` | 1.0.102 → 1.0.103 | Unsoundness in `Error::downcast_mut()` |

Verified locally after the bump: `cargo audit` no longer reports RUSTSEC-2026-0190, `cargo deny check advisories` no longer errors on `anyhow`, `npm run typecheck` / `npm run lint:ci` / `npm test` (1617 tests, 118 files) all pass.

## Needs manual review

Both of these require a manifest bump — the transitive parents pin `quick-xml` below the fixed `0.41.0`, so `cargo update` alone can't move them.

| Advisory | Crate | Version | Pinned by | Suggested action |
|:---|:---|:---|:---|:---|
| [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | `quick-xml` | 0.37.5 | `tauri-winrt-notification@0.7.2` (via `notify-rust` → `tauri-plugin-notification`) | Wait for / bump `tauri-plugin-notification` past a `quick-xml ^0.41` release |
| [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | `quick-xml` | 0.37.5 | same as above | same |
| [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | `quick-xml` | 0.38.4 | `plist@1.8.0` (via `tauri@2.11.0`) | Bump `tauri` past a `plist` release that uses `quick-xml ^0.41` |
| [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | `quick-xml` | 0.38.4 | same as above | same |

Both `quick-xml` advisories are DoS-class (severity 7.5). MoodHaven's use of `quick-xml` is transitive (via `plist` for Tauri asset parsing and via `notify-rust` for Windows notifications) and does not parse user-controlled XML at runtime, so exposure is limited to build-time and OS-supplied inputs.

## Test plan

- [x] `cargo audit` and `cargo deny check advisories` no longer report RUSTSEC-2026-0190
- [x] `npm run typecheck` passes
- [x] `npm run lint:ci` passes
- [x] `npm test` passes (1617 tests)
- [ ] CI green on this branch

---
_Generated by [Claude Code](https://claude.ai/code/session_017znbX5kJGm9uLc7UcixhXh)_