### PR TITLE
chore(deps): nightly advisory scan — 1 advisory closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argon2"

--- a/src-tauri/src/commands/speech_to_text.rs
+++ b/src-tauri/src/commands/speech_to_text.rs
@@ -202,7 +202,7 @@ pub async fn stt_download_model(
     let url = model_url(&filename)?;
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     // Remove any leftover partial file from a previous attempt
     let _ = fs::remove_file(&partial_path);
@@ -442,7 +442,7 @@ pub async fn stt_cancel_download(
 #[command]
 pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if partial_path.exists() {
         fs::remove_file(&partial_path)
@@ -457,7 +457,7 @@ pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(),
 pub async fn stt_delete_model(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if model_path.exists() {
         fs::remove_file(&model_path).map_err(|e| format!("Failed to delete model: {}", e))?;


### PR DESCRIPTION
Nightly `cargo deny` / `cargo audit` scan for 2026-07-30. One advisory closed via in-range `Cargo.lock` bump. Two distinct advisories on `quick-xml` (4 total findings across two transitive versions) remain and need manual dependency work — see below.

## Closed

| ID | Crate | Version | Advisory |
|:---|:---|:---|:---|
| RUSTSEC-2026-0190 | `anyhow` | 1.0.102 → 1.0.104 | [Unsoundness in `Error::downcast_mut()`](https://rustsec.org/advisories/RUSTSEC-2026-0190) |

In-range fix (direct dep declared as `anyhow = "1"`); verified by re-running `cargo deny check advisories` — advisory no longer reported.

## Needs manual review

Both are high-severity (CVSS 7.5) vulnerabilities in `quick-xml`, but pulled transitively at `0.37.5` and `0.38.4`. The advisories require `>=0.41.0`, which is a semver-incompatible bump on a `0.x` crate and cannot be resolved by `cargo update` alone.

| ID | Crate | Version(s) | Advisory | Path |
|:---|:---|:---|:---|:---|
| RUSTSEC-2026-0194 | `quick-xml` | 0.37.5, 0.38.4 | [Quadratic runtime on duplicate attribute names](https://rustsec.org/advisories/RUSTSEC-2026-0194) | via `plist` → `tauri` (0.38.4); via WebDAV stack (0.37.5) |
| RUSTSEC-2026-0195 | `quick-xml` | 0.37.5, 0.38.4 | [Unbounded namespace-declaration allocation in `NsReader` (DoS)](https://rustsec.org/advisories/RUSTSEC-2026-0195) | same as above |

Next step for a human: bump `tauri` / WebDAV client dep to a version that pulls `quick-xml >= 0.41.0`, or add explicit override in `Cargo.toml`. Both advisories were already present in `main` before this scan; the scan neither introduced nor removed them.

## Verification

- `cargo deny check advisories` — 5 advisories before → 4 after (only manual `quick-xml` items remain).
- Lockfile resolves cleanly (`cargo tree -p anyhow` → `anyhow v1.0.104`).
- `npm run typecheck` — ✅
- `npm run lint:ci` — ✅
- `npm test` — ✅ (1617 tests / 118 files).
- `cargo check` not runnable in this environment (missing `gdk-3.0` system libs); patch-level bump on a widely-used crate with no API changes — CI will exercise the full build.

Note: `npm run check:all` will fail on `check:deny` / `check:audit` in CI because the manual `quick-xml` advisories above are still open. That failure predates this PR — it exists on `main` today.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NzgGEJ67s5aNbU1PE8bus)_