### PR TITLE
fix: remove redundant & in format! args (clippy::useless_borrows_in_formatting)

### DIFF
--- a/src-tauri/src/commands/speech_to_text.rs
+++ b/src-tauri/src/commands/speech_to_text.rs
@@ -202,7 +202,7 @@ pub async fn stt_download_model(
     let url = model_url(&filename)?;
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     // Remove any leftover partial file from a previous attempt
     let _ = fs::remove_file(&partial_path);
@@ -442,7 +442,7 @@ pub async fn stt_cancel_download(
 #[command]
 pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if partial_path.exists() {
         fs::remove_file(&partial_path)
@@ -457,7 +457,7 @@ pub async fn stt_cleanup_partial(app: AppHandle, filename: String) -> Result<(),
 pub async fn stt_delete_model(app: AppHandle, filename: String) -> Result<(), String> {
     let models_dir = get_models_dir(&app).map_err(|e| e.to_string())?;
     let model_path = validate_model_path(&models_dir, &filename)?;
-    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", &filename))?;
+    let partial_path = validate_model_path(&models_dir, &format!("{}.partial", filename))?;
 
     if model_path.exists() {
         fs::remove_file(&model_path).map_err(|e| format!("Failed to delete model: {}", e))?;


### PR DESCRIPTION
## Summary

Rust 1.98.0 introduced the [`useless_borrows_in_formatting`](https://doc.rust-lang.org/clippy/lints/useless_borrows_in_formatting.html) lint, which flags redundant `&` references inside `format!()` arguments. This was breaking the Rust (macos-latest) CI check across all open PRs.

## Changes

Three identical occurrences in `src-tauri/src/commands/speech_to_text.rs`:

| Line | Function | Before | After |
|------|----------|--------|-------|
| 205 | `stt_download_model` | `&format!("{}.partial", &filename)` | `&format!("{}.partial", filename)` |
| 445 | `stt_cleanup_partial` | `&format!("{}.partial", &filename)` | `&format!("{}.partial", filename)` |
| 460 | `stt_delete_model` | `&format!("{}.partial", &filename)` | `&format!("{}.partial", filename)` |

`filename` is a `String` which implements `Display` directly — the `&` inside `format!()` is redundant and the new lint correctly flags it.

## Testing

- `cargo check` and `cargo clippy` pass with this fix
- No behaviour change — the generated string is identical

---
_Generated by [Claude Code](https://claude.ai/code/session_018Fs2aPMveMWbFi9kube1iG)_